### PR TITLE
Feature: Add New Songs to Existing Library

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -28,4 +28,5 @@ export type StoreStructure = {
   };
   playlists: Playlist[];
   lastPlayedSong: string; // a key into "library"
+  libraryPath: string;
 };

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -5,6 +5,7 @@ import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 export type Channels =
   | 'ipc-example'
   | 'select-library'
+  | 'add-to-library'
   | 'initialize'
   | 'get-album-art'
   | 'song-imported';

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -403,21 +403,14 @@ function MainDash() {
         return;
       }
 
-      const typedArg = arg as StoreStructure;
+      const typedArg = arg as StoreStructure & { scrollToIndex: number };
 
       // reset the library, the filtered library, the current song, and pause.
       setLibrary(typedArg.library);
       setFilteredLibrary(typedArg.library);
       setShowImportingProgress(false);
-      // set current song to the first song in the library
-      const firstSong = Object.keys(typedArg.library)[0];
-      const firstSongMeta = typedArg.library[firstSong];
-
-      setCurrentSong(firstSong);
-      setCurrentSongMetadata(firstSongMeta);
-      requestAndSetAlbumArtForSong(firstSong);
-      setPaused(true);
-      setInitialScrollIndex(2);
+      // scroll one of the new songs into view
+      setInitialScrollIndex(typedArg.scrollToIndex);
 
       window.setTimeout(() => {
         setSongsImported(0);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,8 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import Typography from '@mui/material/Typography';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import AddIcon from '@mui/icons-material/Add';
+import Tooltip from '@mui/material/Tooltip';
 import {
   styled,
   ThemeProvider,
@@ -25,14 +27,14 @@ import { useResizeDetector } from 'react-resize-detector';
 import LinearProgress from '@mui/material/LinearProgress';
 import LibraryAddOutlined from '@mui/icons-material/LibraryAddOutlined';
 import InputBase from '@mui/material/InputBase';
+import SearchIcon from '@mui/icons-material/Search';
 import ContinuousSlider from './ContinuousSlider';
 import LinearProgressBar from './LinearProgressBar';
 import { StoreStructure, SongSkeletonStructure } from '../common/common';
 import './App.scss';
-import SearchIcon from '@mui/icons-material/Search';
 
 const SearchIconWrapper = styled('div')(({ theme }) => ({
-  padding: theme.spacing(0, 2),
+  padding: theme.spacing(0, 1.5),
   height: '100%',
   position: 'absolute',
   top: 0,
@@ -53,7 +55,7 @@ const Search = styled('div')(({ theme }) => ({
   background: 'black',
 
   marginLeft: 0,
-  width: '80px',
+  width: '104px',
   [theme.breakpoints.up('sm')]: {
     width: 'auto',
   },
@@ -66,7 +68,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   '& .MuiInputBase-input': {
     // vertical padding + font size from searchIcon
     paddingLeft: `calc(1em + ${theme.spacing(0.5)})`,
-    paddingRight: `calc(1em + ${theme.spacing(4)})`,
+    paddingRight: `calc(1em + ${theme.spacing(2.5)})`,
     transition: theme.transitions.create('width'),
     width: '100%',
     [theme.breakpoints.up('sm')]: {
@@ -370,6 +372,63 @@ function MainDash() {
     window.electron.ipcRenderer.sendMessage('select-library');
   };
 
+  /**
+   * @dev allow user to select a directory and import all songs within it
+   */
+  const importNewSongs = async () => {
+    setShowImportingProgress(true);
+
+    // updates the UX with the progress of the import
+    window.electron.ipcRenderer.on('song-imported', (args) => {
+      setSongsImported((args as any).songsImported);
+      setTotalSongs((args as any).totalSongs);
+      // completion time is roughly 5ms per song
+      const estimatedTimeRemaining = Math.floor(
+        ((args as any).totalSongs - (args as any).songsImported) * 5,
+      );
+
+      // convert the estimated time remaining in ms to a human readable format
+      const minutes = Math.floor(estimatedTimeRemaining / 60000);
+      // if it is less than one minute say `less than a minute`
+      const seconds =
+        minutes < 1 ? 'Time Left: < 1min' : `Time Left: ${minutes}mins...`;
+      setEstimatedTimeRemainingString(seconds);
+    });
+
+    // once the import is complete, update the store/data
+    window.electron.ipcRenderer.once('add-to-library', (arg) => {
+      // exit early if the user cancels the import or the args are malformed
+      if (!arg || !(arg as any)?.library) {
+        setShowImportingProgress(false);
+        return;
+      }
+
+      const typedArg = arg as StoreStructure;
+
+      // reset the library, the filtered library, the current song, and pause.
+      setLibrary(typedArg.library);
+      setFilteredLibrary(typedArg.library);
+      setShowImportingProgress(false);
+      // set current song to the first song in the library
+      const firstSong = Object.keys(typedArg.library)[0];
+      const firstSongMeta = typedArg.library[firstSong];
+
+      setCurrentSong(firstSong);
+      setCurrentSongMetadata(firstSongMeta);
+      requestAndSetAlbumArtForSong(firstSong);
+      setPaused(true);
+      setInitialScrollIndex(2);
+
+      window.setTimeout(() => {
+        setSongsImported(0);
+        setTotalSongs(0);
+      }, 1000);
+    });
+
+    // request that the user selects a directory and that main process processes
+    window.electron.ipcRenderer.sendMessage('add-to-library');
+  };
+
   const filterByTitle = () => {
     if (!library) return;
     if (!filteredLibrary) return;
@@ -643,28 +702,54 @@ function MainDash() {
             }}
           />
         )}
-        <button
-          onClick={importSongs}
-          type="button"
-          aria-label="import library"
-          className="nodrag absolute top-[56px] md:top-4 right-4 items-center justify-center
+
+        <Tooltip title="Import Library">
+          <button
+            onClick={importSongs}
+            type="button"
+            aria-label="import library"
+            className="nodrag absolute top-[60px] md:top-4 right-4 items-center justify-center
           rounded-md text-[18px] ring-offset-background transition-colors
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
           focus-visible:ring-offset-2 disabled:pointer-events-none
           disabled:opacity-50 border border-neutral-800 bg-black
           hover:bg-white hover:text-black
           px-4 py-[7px] text-sm"
-        >
-          <LibraryAddOutlined
-            fontSize="inherit"
-            sx={{
-              position: 'relative',
-              bottom: '1px',
-            }}
-          />
-        </button>
+          >
+            <LibraryAddOutlined
+              fontSize="inherit"
+              sx={{
+                position: 'relative',
+                bottom: '1px',
+              }}
+            />
+          </button>
+        </Tooltip>
 
-        <Box className="absolute h-[45px] top-4 md:top-4 md:right-[4.4rem] right-4 w-auto text-white">
+        <Tooltip title="Add Songs To Library">
+          <button
+            onClick={importNewSongs}
+            type="button"
+            aria-label="import new songs"
+            className="nodrag absolute top-[60px] md:top-4 right-[4.5rem] items-center justify-center
+          rounded-md text-[18px] ring-offset-background transition-colors
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+          focus-visible:ring-offset-2 disabled:pointer-events-none
+          disabled:opacity-50 border border-neutral-800 bg-black
+          hover:bg-white hover:text-black
+          px-4 py-[7px] text-sm"
+          >
+            <AddIcon
+              fontSize="inherit"
+              sx={{
+                position: 'relative',
+                bottom: '1px',
+              }}
+            />
+          </button>
+        </Tooltip>
+
+        <Box className="absolute h-[45px] top-4 md:top-4 md:right-[8rem] right-4 w-auto text-white">
           <Search
             sx={{
               borderRadius: '0.375rem',


### PR DESCRIPTION
## This PR

Allows the user to click the `+` icon and add new albums to their existing library. You can select individual songs or just one from a folder.

When you add songs, it copies them into your existing library's folder, that way our references are always valid and you dont have worry about futzing with your nice library folder. 

Also tightened up some CSS around the search plus and plus library icons as well as Tooltips.