### PR TITLE
Feat: When clicking on song or artist, scroll to song in library list

### DIFF
--- a/src/renderer/components/LibraryList.tsx
+++ b/src/renderer/components/LibraryList.tsx
@@ -55,6 +55,15 @@ export default function LibraryList({
   const storeLibrary = useMainStore((store) => store.library);
   const currentSong = usePlayerStore((store) => store.currentSong);
   const filteredLibrary = usePlayerStore((store) => store.filteredLibrary);
+  const overrideScrollToIndex = usePlayerStore(
+    (store) => store.overrideScrollToIndex,
+  );
+
+  const scrollToIndex =
+    overrideScrollToIndex !== undefined
+      ? overrideScrollToIndex
+      : initialScrollIndex;
+
   const setFilteredLibrary = usePlayerStore(
     (store) => store.setFilteredLibrary,
   );
@@ -325,9 +334,7 @@ export default function LibraryList({
           rowCount={Object.keys(filteredLibrary || {}).length}
           rowHeight={ROW_HEIGHT}
           scrollToAlignment="center"
-          scrollToIndex={
-            initialScrollIndex > 0 ? initialScrollIndex : undefined
-          }
+          scrollToIndex={scrollToIndex}
         />
       </div>
     </div>

--- a/src/renderer/components/LinearProgressBar.tsx
+++ b/src/renderer/components/LinearProgressBar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
 import { LessOpaqueTinyText } from './SimpleStyledMaterialUIComponents';
+import usePlayerStore from '../store/player';
 
 export default function LinearProgressBar({
   value,
@@ -17,6 +18,9 @@ export default function LinearProgressBar({
   max: number;
 }) {
   const [position, setPosition] = React.useState(32);
+  const setOverrideScrollToIndex = usePlayerStore(
+    (store) => store.setOverrideScrollToIndex,
+  );
 
   function convertToMMSS(timeInSeconds: number) {
     const minutes = Math.floor(timeInSeconds / 60);
@@ -49,8 +53,21 @@ export default function LinearProgressBar({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
+            cursor: 'pointer',
           }}
           aria-label="current-title"
+          onClick={() => {
+            // find the index of this song in the library
+            // @TODO: this really needs to be extracted into a helper function
+            const library = usePlayerStore.getState().filteredLibrary;
+            const libraryArray = Object.values(library);
+            const index = libraryArray.findIndex(
+              (song) =>
+                song.common.title === title && song.common.artist === artist,
+            );
+
+            setOverrideScrollToIndex(index);
+          }}
         >
           {title}
         </LessOpaqueTinyText>
@@ -101,8 +118,21 @@ export default function LinearProgressBar({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
+            cursor: 'pointer',
           }}
           aria-label="current-artist"
+          onClick={() => {
+            // find the index of this song in the library
+            // @TODO: this really needs to be extracted into a helper function
+            const library = usePlayerStore.getState().filteredLibrary;
+            const libraryArray = Object.values(library);
+            const index = libraryArray.findIndex(
+              (song) =>
+                song.common.title === title && song.common.artist === artist,
+            );
+
+            setOverrideScrollToIndex(index);
+          }}
         >
           {artist}
         </LessOpaqueTinyText>

--- a/src/renderer/store/player.ts
+++ b/src/renderer/store/player.ts
@@ -11,6 +11,7 @@ interface PlayerStore {
   volume: number;
   currentSongTime: number;
   filteredLibrary: { [key: string]: SongSkeletonStructure };
+  overrideScrollToIndex: number | undefined;
 
   deleteEverything: () => void;
   setVolume: (volume: number) => void;
@@ -24,6 +25,7 @@ interface PlayerStore {
   setFilteredLibrary: (filteredLibrary: {
     [key: string]: SongSkeletonStructure;
   }) => void;
+  setOverrideScrollToIndex: (index: number | undefined) => void;
 }
 
 const usePlayerStore = create<PlayerStore>((set) => ({
@@ -36,6 +38,7 @@ const usePlayerStore = create<PlayerStore>((set) => ({
   volume: 100,
   currentSongTime: 0,
   filteredLibrary: {},
+  overrideScrollToIndex: undefined,
 
   deleteEverything: () => set({}, true),
   setVolume: (volume) => set({ volume }),
@@ -47,6 +50,9 @@ const usePlayerStore = create<PlayerStore>((set) => ({
   setCurrentSongMetadata: (currentSongMetadata) => set({ currentSongMetadata }),
   setFilteredLibrary: (filteredLibrary) => set({ filteredLibrary }),
   setCurrentSongTime: (currentSongTime) => set({ currentSongTime }),
+  setOverrideScrollToIndex: (overrideScrollToIndex) => {
+    return set({ overrideScrollToIndex });
+  },
 }));
 
 export default usePlayerStore;


### PR DESCRIPTION
## This PR

Allows the user to click on the title or artist of the song within the player at the bottom in order to scroll back to that song within the library list.