### PR TITLE
Add Backup/Sync Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18.2.0",
         "react-draggable": "^4.4.6",
         "react-router-dom": "^6.16.0",
+        "rsync": "^0.6.1",
         "source-map-support": "^0.5.21",
         "zustand": "^4.4.7"
       },
@@ -42,6 +43,7 @@
         "@types/react-dom": "^18.2.7",
         "@types/react-test-renderer": "^18.0.1",
         "@types/react-virtualized": "^9.21.26",
+        "@types/rsync": "^0.4.36",
         "@types/terser-webpack-plugin": "^5.0.4",
         "@types/webpack-bundle-analyzer": "^4.6.0",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -5218,6 +5220,15 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "node_modules/@types/rsync": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@types/rsync/-/rsync-0.4.36.tgz",
+      "integrity": "sha512-K2Frb12sSRvSkSTBJzzwgOED1Q2rj4+54zweCN3yCRHprdc5fO18qZm1ojNdO2QwVGo0UYIqpyYPCYSK3O7pBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -18532,6 +18543,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/rsync": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/rsync/-/rsync-0.6.1.tgz",
+      "integrity": "sha512-39HcwWuM67CQ9tHloazShXWUOWa2m3SGqX6XQhQMSj0VCQMkSI9PodoxM7/+hKf2p4v2umbhfoarYqd1gwII/w=="
     },
     "node_modules/run-applescript": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.6",
     "react-router-dom": "^6.16.0",
+    "rsync": "^0.6.1",
     "source-map-support": "^0.5.21",
     "zustand": "^4.4.7"
   },
@@ -102,6 +103,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-test-renderer": "^18.0.1",
     "@types/react-virtualized": "^9.21.26",
+    "@types/rsync": "^0.4.36",
     "@types/terser-webpack-plugin": "^5.0.4",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -92,6 +92,12 @@ export default class MenuBuilder {
           },
         },
         {
+          label: 'backup library',
+          click: () => {
+            this.mainWindow.webContents.send('menu-backup-library');
+          },
+        },
+        {
           label: 'reset all hihat data',
           click: () => {
             this.mainWindow.webContents.send('menu-reset-library');

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -92,7 +92,7 @@ export default class MenuBuilder {
           },
         },
         {
-          label: 'backup library',
+          label: 'backup / sync library',
           click: () => {
             this.mainWindow.webContents.send('menu-backup-library');
           },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,6 +15,8 @@ export type Channels =
   | 'show-in-finder'
   | 'menu-select-library'
   | 'menu-rescan-library'
+  | 'menu-backup-library'
+  | 'backup-library-success'
   | 'menu-add-songs'
   | 'menu-reset-library'
   | 'menu-hide-dupes'
@@ -77,6 +79,7 @@ export interface ResponseArgs extends ArgsBase {
     songData: StoreStructure['library'][string];
   };
   'update-store': StoreStructure;
+  'backup-library-success': undefined;
 }
 
 const electronHandler = {

--- a/src/renderer/components/MainDash.tsx
+++ b/src/renderer/components/MainDash.tsx
@@ -625,8 +625,8 @@ export default function MainDash() {
             <div className="flex w-full justify-center px-2">
               <TinyText as="div">
                 This feature creates a copy of your music library in a folder
-                you choose, like on an external hard drive. It's smart enough
-                to:
+                you choose, like on an external hard drive. It&apos;s smart
+                enough to:
                 <ol className="list-decimal pl-6 space-y-2 mt-2">
                   <li>
                     Only copy new or changed files, saving time and space.

--- a/src/renderer/components/MainDash.tsx
+++ b/src/renderer/components/MainDash.tsx
@@ -501,6 +501,14 @@ export default function MainDash() {
     window.electron.ipcRenderer.on('menu-delete-dupes', () => {
       setShowConfirmDedupeAndDeleteDialog(true);
     });
+
+    window.electron.ipcRenderer.on('menu-backup-library', () => {
+      window.electron.ipcRenderer.sendMessage('menu-backup-library');
+
+      window.electron.ipcRenderer.once('backup-library-success', () => {
+        console.log('library backed up');
+      });
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**


### PR DESCRIPTION
Pretty straight forward.

Use `rsync` (common backup utility on linux) to back up the library's folder of music to any given directory.

Useful for backing up to an HD or even syncing your library with something like an iPod using Rockbox (which is what I plan to use this for).

Does not export any hihat data itself, so no playcounts are dates added.

<img width="605" alt="Screenshot 2024-08-29 at 8 07 41 PM" src="https://github.com/user-attachments/assets/7b7bce84-0cce-4abf-8645-8903a9d4e7e4">
<img width="308" alt="Screenshot 2024-08-29 at 8 07 38 PM" src="https://github.com/user-attachments/assets/508b272a-deec-4481-b87c-7e92f2b59bea">

