### PR TITLE
Factor out components from Main to lighten its LoC

### DIFF
--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import Draggable from 'react-draggable';
+import { TinyText } from './SimpleStyledMaterialUIComponents';
+import AlbumArtRightClickMenu from './AlbumArtRightClickMenu';
+import usePlayerStore from '../store/player';
+
+interface AlbumArtProps {
+  albumArtMaxWidth: number;
+  setShowAlbumArtMenu: (menu: any) => void;
+  showAlbumArtMenu: any;
+  setAlbumArtMaxWidth: (width: number) => void;
+  width: number | null;
+}
+
+export default function AlbumArt({
+  albumArtMaxWidth,
+  setShowAlbumArtMenu,
+  showAlbumArtMenu,
+  setAlbumArtMaxWidth,
+  width,
+}: AlbumArtProps) {
+  const currentSong = usePlayerStore((store) => store.currentSong);
+  const currentSongMetadata = usePlayerStore(
+    (store) => store.currentSongMetadata,
+  );
+  const currentSongDataURL = usePlayerStore(
+    (store) => store.currentSongDataURL,
+  );
+  const filteredLibrary = usePlayerStore((store) => store.filteredLibrary);
+  const setOverrideScrollToIndex = usePlayerStore(
+    (store) => store.setOverrideScrollToIndex,
+  );
+
+  if (!currentSongDataURL) {
+    return (
+      <div
+        className="relative aspect-square w-[40%] bg-gradient-to-r from-neutral-800 via-neutral-700 to-neutral-600 border-2 border-neutral-700 shadow-2xl rounded-lg transition-all duration-500"
+        style={{
+          maxWidth: `${albumArtMaxWidth}px`,
+        }}
+      >
+        <div className="inset-0 h-full w-full flex items-center justify-center rounded-lg">
+          <svg
+            className="text-neutral-300 w-1/5 h-1/5 animate-bounce"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
+          </svg>
+          <TinyText className="absolute bottom-3 left-3">hihat</TinyText>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative aspect-square w-full bg-gradient-to-r from-neutral-800 via-neutral-700 to-neutral-600 border-2 border-neutral-700 shadow-2xl rounded-lg"
+      style={{
+        maxWidth: `${albumArtMaxWidth}px`,
+      }}
+    >
+      <img
+        alt="Album Art"
+        aria-hidden="true"
+        className="album-art h-full w-full rounded-lg hover:cursor-pointer"
+        onClick={() => {
+          const libraryArray = Object.values(filteredLibrary);
+          const index = libraryArray.findIndex(
+            (song) =>
+              song.common.title === currentSongMetadata.common?.title &&
+              song.common.artist === currentSongMetadata.common?.artist &&
+              song.common.album === currentSongMetadata.common?.album,
+          );
+          setOverrideScrollToIndex(index);
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setShowAlbumArtMenu({
+            mouseX: e.clientX - 2,
+            mouseY: e.clientY - 4,
+          });
+        }}
+        src={currentSongDataURL}
+        style={{
+          maxWidth: `${albumArtMaxWidth}px`,
+        }}
+      />
+      {showAlbumArtMenu && currentSong && (
+        <AlbumArtRightClickMenu
+          anchorEl={document.querySelector('.album-art')}
+          mouseX={showAlbumArtMenu.mouseX}
+          mouseY={showAlbumArtMenu.mouseY}
+          onClose={() => {
+            setShowAlbumArtMenu(undefined);
+          }}
+          song={currentSong}
+        />
+      )}
+      <Draggable
+        axis="y"
+        onDrag={(e, data) => {
+          if (!width) return;
+          const newMaxWidth = albumArtMaxWidth + data.deltaY;
+          const clampedMaxWidth = Math.max(
+            120,
+            Math.min(newMaxWidth, width * 0.4),
+          );
+          setAlbumArtMaxWidth(clampedMaxWidth);
+        }}
+        position={{ x: 0, y: 0 }}
+      >
+        <div className="w-full absolute bottom-0 h-[20px] bg-transparent cursor-ns-resize hover:cursor-ns-resize bg-red-400" />
+      </Draggable>
+    </div>
+  );
+}

--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -116,6 +116,12 @@ export default function AlbumArt({
             Math.min(newMaxWidth, width * 0.4),
           );
           setAlbumArtMaxWidth(clampedMaxWidth);
+
+          /**
+           * @important dispatch an event to let all components know the width has changed
+           * @see LibraryList.tsx
+           */
+          window.dispatchEvent(new Event('album-art-width-changed'));
         }}
         position={{ x: 0, y: 0 }}
       >

--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -15,6 +15,9 @@ export default function AlbumArt({
   showAlbumArtMenu,
   width,
 }: AlbumArtProps) {
+  /**
+   * @dev global store hooks
+   */
   const currentSong = usePlayerStore((store) => store.currentSong);
   const currentSongMetadata = usePlayerStore(
     (store) => store.currentSongMetadata,
@@ -27,6 +30,9 @@ export default function AlbumArt({
     (store) => store.setOverrideScrollToIndex,
   );
 
+  /**
+   * @dev component state
+   */
   const [albumArtMaxWidth, setAlbumArtMaxWidth] = useState(320);
 
   if (!currentSongDataURL) {

--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -1,22 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Draggable from 'react-draggable';
 import { TinyText } from './SimpleStyledMaterialUIComponents';
 import AlbumArtRightClickMenu from './AlbumArtRightClickMenu';
 import usePlayerStore from '../store/player';
 
 interface AlbumArtProps {
-  albumArtMaxWidth: number;
   setShowAlbumArtMenu: (menu: any) => void;
   showAlbumArtMenu: any;
-  setAlbumArtMaxWidth: (width: number) => void;
   width: number | null;
 }
 
 export default function AlbumArt({
-  albumArtMaxWidth,
   setShowAlbumArtMenu,
   showAlbumArtMenu,
-  setAlbumArtMaxWidth,
   width,
 }: AlbumArtProps) {
   const currentSong = usePlayerStore((store) => store.currentSong);
@@ -30,6 +26,8 @@ export default function AlbumArt({
   const setOverrideScrollToIndex = usePlayerStore(
     (store) => store.setOverrideScrollToIndex,
   );
+
+  const [albumArtMaxWidth, setAlbumArtMaxWidth] = useState(320);
 
   if (!currentSongDataURL) {
     return (

--- a/src/renderer/components/Dialog/BackingUpLibraryDialog.tsx
+++ b/src/renderer/components/Dialog/BackingUpLibraryDialog.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import { TinyText } from '../SimpleStyledMaterialUIComponents';
+
+interface BackingUpLibraryDialogProps {
+  open: boolean;
+}
+
+export default function BackingUpLibraryDialog({
+  open,
+}: BackingUpLibraryDialogProps) {
+  return (
+    <Dialog
+      className="flex flex-col items-center justify-center content-center p-10"
+      open={open}
+    >
+      <div className="flex flex-col items-center pb-4 max-w-[240px]">
+        <DialogTitle>Backing Up</DialogTitle>
+        <DialogContent>
+          <div className="flex w-full justify-center px-2 flex-col gap-6">
+            <TinyText className="text-center">
+              Syncing your library with the chosen folder. This may take a while
+              so go grab some tea!
+            </TinyText>
+            <Box sx={{ width: '100%', marginBottom: '12px' }}>
+              <LinearProgress color="inherit" variant="indeterminate" />
+            </Box>
+          </div>
+        </DialogContent>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/Dialog/ConfirmDedupingDialog.tsx
+++ b/src/renderer/components/Dialog/ConfirmDedupingDialog.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import { TinyText } from '../SimpleStyledMaterialUIComponents';
+
+interface ConfirmDedupingDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function ConfirmDedupingDialog(
+  props: ConfirmDedupingDialogProps,
+) {
+  const { open, onClose, onConfirm } = props;
+
+  return (
+    <Dialog
+      className="flex flex-col items-center justify-center content-center p-10"
+      open={open}
+    >
+      <div className="flex flex-col items-center pb-4 max-w-[400px]">
+        <DialogTitle>Deduplicate Library</DialogTitle>
+        <DialogContent>
+          <div className="flex w-full justify-center px-2">
+            <TinyText>
+              This will find any duplicate song files with identical title,
+              artist, and album and keep only the highest quality version of
+              each song. That way your library will contain only the best
+              quality files.
+            </TinyText>
+          </div>
+        </DialogContent>
+        <div className="flex flex-row">
+          <div className="flex w-full justify-center pt-2 pb-1 px-2">
+            <button
+              className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
+              onClick={onClose}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
+          <div className="flex w-full justify-center pt-2 pb-1 px-2">
+            <button
+              className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
+              onClick={onConfirm}
+              type="button"
+            >
+              Deduplicate
+            </button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/Dialog/DedupingProgressDialog.tsx
+++ b/src/renderer/components/Dialog/DedupingProgressDialog.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import { TinyText } from '../SimpleStyledMaterialUIComponents';
+
+interface DedupingProgressDialogProps {
+  open: boolean;
+}
+
+export default function DedupingProgressDialog({
+  open,
+}: DedupingProgressDialogProps) {
+  return (
+    <Dialog
+      className="flex flex-col items-center justify-center content-center p-10"
+      open={open}
+    >
+      <div className="flex flex-col items-center px-20 pb-6">
+        <DialogTitle>Deduplicating Songs</DialogTitle>
+        <Box sx={{ width: '100%', marginBottom: '12px' }}>
+          <LinearProgress color="inherit" variant="indeterminate" />
+        </Box>
+        <div className="flex w-full justify-center pt-2 pb-1 px-2">
+          <TinyText>This operation will take three to five minutes</TinyText>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/Dialog/ImportProgressDialog.tsx
+++ b/src/renderer/components/Dialog/ImportProgressDialog.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import { TinyText } from '../SimpleStyledMaterialUIComponents';
+
+interface ImportProgressDialogProps {
+  open: boolean;
+  songsImported: number;
+  totalSongs: number;
+  estimatedTimeRemainingString: string;
+}
+
+export default function ImportProgressDialog({
+  open,
+  songsImported,
+  totalSongs,
+  estimatedTimeRemainingString,
+}: ImportProgressDialogProps) {
+  return (
+    <Dialog
+      className="flex flex-col items-center justify-center content-center p-10"
+      open={open}
+    >
+      <div className="flex flex-col items-center px-20 pb-6">
+        <DialogTitle>Importing Songs</DialogTitle>
+        <Box sx={{ width: '100%', marginBottom: '12px' }}>
+          <LinearProgress
+            color="inherit"
+            value={(songsImported / totalSongs) * 100}
+            variant={
+              songsImported === totalSongs ? 'indeterminate' : 'determinate'
+            }
+          />
+        </Box>
+        <div className="flex w-full justify-center mt-1 px-2 ">
+          <h4>{`${songsImported} / ${totalSongs}`}</h4>
+        </div>
+        <div className="flex w-full justify-center pt-2 pb-1 px-2">
+          <TinyText>{`${
+            estimatedTimeRemainingString || 'Calculating...'
+          }`}</TinyText>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/ImportNewSongsButtons.tsx
+++ b/src/renderer/components/ImportNewSongsButtons.tsx
@@ -1,0 +1,93 @@
+import { RefObject } from 'react';
+import Tooltip from '@mui/material/Tooltip';
+import { LibraryAdd } from '@mui/icons-material';
+import usePlayerStore from '../store/player';
+import useMainStore from '../store/main';
+
+interface ImportNewSongsButtonProps {
+  setShowImportingProgress: (show: boolean) => void;
+  setSongsImported: (count: number) => void;
+  setTotalSongs: (count: number) => void;
+  setEstimatedTimeRemainingString: (time: string) => void;
+  setInitialScrollIndex: (index: number | undefined) => void;
+}
+
+export default function ImportNewSongsButton({
+  setShowImportingProgress,
+  setSongsImported,
+  setTotalSongs,
+  setEstimatedTimeRemainingString,
+  setInitialScrollIndex,
+}: ImportNewSongsButtonProps) {
+  const setFilteredLibrary = usePlayerStore(
+    (store) => store.setFilteredLibrary,
+  );
+  const setLibraryInStore = useMainStore((store) => store.setLibrary);
+
+  const importNewSongs = async () => {
+    window.electron.ipcRenderer.on('song-imported', (args) => {
+      setShowImportingProgress(true);
+      setSongsImported(args.songsImported);
+      setTotalSongs(args.totalSongs);
+
+      const estimatedTimeRemaining = Math.floor(
+        (args.totalSongs - args.songsImported) * 5,
+      );
+
+      const minutes = Math.floor(estimatedTimeRemaining / 60000);
+      const seconds = Math.floor(estimatedTimeRemaining / 1000);
+      const timeRemainingString =
+        // eslint-disable-next-line no-nested-ternary
+        minutes < 1
+          ? seconds === 0
+            ? 'Processing Metadata...'
+            : `${seconds}s left`
+          : `${minutes}mins left`;
+      setEstimatedTimeRemainingString(timeRemainingString);
+    });
+
+    window.electron.ipcRenderer.once('add-to-library', (arg) => {
+      if (!arg || !arg.library) {
+        setShowImportingProgress(false);
+        return;
+      }
+
+      setLibraryInStore(arg.library);
+      setFilteredLibrary(arg.library);
+      setInitialScrollIndex(arg.scrollToIndex);
+      setShowImportingProgress(false);
+
+      window.setTimeout(() => {
+        setSongsImported(0);
+        setTotalSongs(0);
+      }, 100);
+    });
+
+    window.electron.ipcRenderer.sendMessage('add-to-library');
+  };
+
+  return (
+    <Tooltip title="Import New Songs">
+      <button
+        aria-label="import to songs"
+        className="nodrag absolute top-[60px] md:top-4 right-4 items-center justify-center
+    rounded-md text-[18px] ring-offset-background transition-colors
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+    focus-visible:ring-offset-2 disabled:pointer-events-none
+    disabled:opacity-50 border border-neutral-800 bg-black
+    hover:bg-white hover:text-black
+    px-4 py-[7px] text-sm"
+        onClick={importNewSongs}
+        type="button"
+      >
+        <LibraryAdd
+          fontSize="inherit"
+          sx={{
+            position: 'relative',
+            bottom: '1px',
+          }}
+        />
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/renderer/components/ImportNewSongsButtons.tsx
+++ b/src/renderer/components/ImportNewSongsButtons.tsx
@@ -1,4 +1,3 @@
-import { RefObject } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import { LibraryAdd } from '@mui/icons-material';
 import usePlayerStore from '../store/player';

--- a/src/renderer/components/ImportNewSongsButtons.tsx
+++ b/src/renderer/components/ImportNewSongsButtons.tsx
@@ -18,6 +18,9 @@ export default function ImportNewSongsButton({
   setEstimatedTimeRemainingString,
   setInitialScrollIndex,
 }: ImportNewSongsButtonProps) {
+  /**
+   * @dev global store hooks
+   */
   const setFilteredLibrary = usePlayerStore(
     (store) => store.setFilteredLibrary,
   );

--- a/src/renderer/components/LibraryList.tsx
+++ b/src/renderer/components/LibraryList.tsx
@@ -42,9 +42,9 @@ type LibraryListProps = {
    */
   width: number;
   /**
-   * @dev the height of the row container
+   * @dev the height of the list container
    */
-  rowContainerHeight: number;
+  height: number | undefined;
   /**
    * @dev the height of the row container
    */
@@ -71,7 +71,7 @@ type SongMenuState =
 
 export default function LibraryList({
   width,
-  rowContainerHeight,
+  height,
   initialScrollIndex,
   playSong,
   onImportLibrary,
@@ -89,6 +89,11 @@ export default function LibraryList({
   const setOverrideScrollToIndex = usePlayerStore(
     (store) => store.setOverrideScrollToIndex,
   );
+
+  /**
+   * @dev state
+   */
+  const [rowContainerHeight, setRowContainerHeight] = useState(0);
   const [staleWidth, setStaleWidth] = useState(width);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -337,6 +342,42 @@ export default function LibraryList({
     setFilteredLibrary(filteredLib);
     setFilterType(filter);
   };
+
+  const updateRowContainerHeight = () => {
+    if (!height || !width) return;
+
+    const artContainerHeight =
+      document.querySelector('.art')?.clientHeight || 0;
+
+    if (width > 640) {
+      setRowContainerHeight(height - artContainerHeight - 110);
+    } else {
+      setRowContainerHeight(height - artContainerHeight - 160);
+    }
+  };
+
+  /**
+   * @dev update the row container height when
+   * the window is resized in any way. that way our virtualized table
+   * always has the right size and right amount of rows visible.
+   */
+  useEffect(() => {
+    updateRowContainerHeight();
+  }, [height, width]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  /**
+   * @dev update the row container height when the album art width changes
+   * using the draggable component to resize the album art.
+   * @see AlbumArt.tsx
+   */
+  useEffect(() => {
+    window.addEventListener(
+      'album-art-width-changed',
+      updateRowContainerHeight,
+    );
+
+    updateRowContainerHeight();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * @dev render the row for the virtualized table, reps a single song

--- a/src/renderer/components/LibraryList.tsx
+++ b/src/renderer/components/LibraryList.tsx
@@ -91,12 +91,11 @@ export default function LibraryList({
   );
 
   /**
-   * @dev state
+   * @dev component state
    */
   const [rowContainerHeight, setRowContainerHeight] = useState(0);
   const [staleWidth, setStaleWidth] = useState(width);
   const [isDragging, setIsDragging] = useState(false);
-
   const [columnUXInfo, setColumnUXInfo] = useState([
     {
       id: 'title',

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -72,7 +72,6 @@ export default function Main() {
   /**
    * @dev component state
    */
-  const [rowContainerHeight, setRowContainerHeight] = useState(0);
   const [showImportingProgress, setShowImportingProgress] = useState(false);
   const [songsImported, setSongsImported] = useState(0);
   const [totalSongs, setTotalSongs] = useState(0);
@@ -333,25 +332,6 @@ export default function Main() {
   };
 
   /**
-   * @dev useEffect to update the row container height when
-   * the window is resized in any way. that way our virtualized table
-   * always has the right size and right amount of rows visible.
-   */
-  useEffect(() => {
-    const artContainerHeight =
-      document.querySelector('.art')?.clientHeight || 0;
-    const playerHeight = document.querySelector('.player')?.clientHeight || 0;
-
-    if (height) {
-      setRowContainerHeight(height - playerHeight - artContainerHeight - 26);
-    }
-
-    if (width && albumArtMaxWidth) {
-      // set
-    }
-  }, [height, width, albumArtMaxWidth]);
-
-  /**
    * @dev useEffect to initialize the app and set up the internal store
    * for the library etc. also sets the current song and album art.
    * also sets the row container height for the library list.
@@ -363,14 +343,6 @@ export default function Main() {
       setInitialized(true);
       setLibraryInStore(arg.library);
       setFilteredLibrary(arg.library);
-
-      const artContainerHeight =
-        document.querySelector('.art')?.clientHeight || 0;
-
-      if (height) {
-        // since the player has no actual height, we use 120 to implicitly set the height
-        setRowContainerHeight(height - 120 - artContainerHeight);
-      }
 
       if (arg.lastPlayedSong) {
         setCurrentSong(arg.lastPlayedSong);
@@ -541,6 +513,7 @@ export default function Main() {
        */}
       {width && (
         <LibraryList
+          height={height}
           initialScrollIndex={initialScrollIndex}
           onImportLibrary={importNewLibrary}
           playSong={async (song, meta) => {
@@ -551,7 +524,6 @@ export default function Main() {
               await playSong(song, meta);
             }
           }}
-          rowContainerHeight={rowContainerHeight}
           width={width}
         />
       )}

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -91,7 +91,6 @@ export default function Main() {
     useState(false);
   const [showBackingUpLibraryDialog, setShowBackingUpLibraryDialog] =
     useState(false);
-  const [albumArtMaxWidth, setAlbumArtMaxWidth] = useState(320);
 
   /**
    * @def functions
@@ -488,8 +487,6 @@ export default function Main() {
        */}
       <div className="flex art drag justify-center p-4 space-x-4 md:flex-row ">
         <AlbumArt
-          albumArtMaxWidth={albumArtMaxWidth}
-          setAlbumArtMaxWidth={setAlbumArtMaxWidth}
           setShowAlbumArtMenu={setShowAlbumArtMenu}
           showAlbumArtMenu={showAlbumArtMenu}
           width={width || null}

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import SearchIcon from '@mui/icons-material/Search';
+import { StoreStructure } from '../../common/common';
+import useMainStore from '../store/main';
+import usePlayerStore from '../store/player';
+import {
+  Search,
+  SearchIconWrapper,
+  StyledInputBase,
+} from './SimpleStyledMaterialUIComponents';
+
+type SearchBarProps = {
+  // eslint-disable-next-line react/require-default-props
+  className?: string;
+};
+
+export default function SearchBar({ className }: SearchBarProps) {
+  const storeLibrary = useMainStore((store) => store.library);
+  const setFilteredLibrary = usePlayerStore(
+    (store) => store.setFilteredLibrary,
+  );
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const query = event.target.value;
+    if (!storeLibrary) return;
+    const filtered = Object.keys(storeLibrary).filter((song) => {
+      const meta = storeLibrary[song];
+      return (
+        meta.common.title?.toLowerCase().includes(query.toLowerCase()) ||
+        meta.common.artist?.toLowerCase().includes(query.toLowerCase()) ||
+        meta.common.album?.toLowerCase().includes(query.toLowerCase())
+      );
+    });
+
+    const filteredLib: StoreStructure['library'] = {};
+    filtered.forEach((song) => {
+      filteredLib[song] = storeLibrary[song];
+    });
+
+    setFilteredLibrary(filteredLib);
+  };
+
+  return (
+    <Box className={className}>
+      <Search
+        sx={{
+          borderRadius: '0.375rem',
+        }}
+      >
+        <StyledInputBase
+          inputProps={{ 'aria-label': 'search' }}
+          onChange={handleSearch}
+          placeholder="Search"
+        />
+        <SearchIconWrapper className="text-[16px]">
+          <SearchIcon fontSize="inherit" />
+        </SearchIconWrapper>
+      </Search>
+    </Box>
+  );
+}

--- a/src/renderer/components/SimpleStyledMaterialUIComponents.tsx
+++ b/src/renderer/components/SimpleStyledMaterialUIComponents.tsx
@@ -56,7 +56,7 @@ export const TinyText = styled(Typography)({
   letterSpacing: 0.2,
 });
 
-export const LessOpaqueTinyText = styled(Typography)({
+export const LessOpaqueTinyText = styled('div')({
   fontSize: '0.75rem',
   textAlign: 'center',
   opacity: 0.5,


### PR DESCRIPTION
## This PR

Factors out the following components to make `Main` less of a monolith

 * BackingUpLibraryDialog
 * BackupConfirmationDialog
 * ConfirmDedupingDialog
 * DedupingProgressDialog
 * ImportProgressDialog 
* AlbumArt
* ImportNewSongsButton
* SearchBar

Also move all logic pertaining to resizing the library list into the library list itself, that way Main isn't doing the heavy lifting on that -- it just passes in the current height and width.