### PR TITLE
Feature: see library stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ This project was built with the following technologies:
 - [x] Adjustable album art size
 - [x] Shuffle "history" for hitting previous
 - [x] Mute and max buttons
+- [x] Show stats about your library somewhere, like GB and # of songs
 - [ ] Edit song metadata
-- [ ] Show stats about your library somewhere, like GB and # of songs
-- [ ] Hide and show columns in the explorer
-- [ ] iTunes-1.0-like "browser" for seeing scrollable list of artists or albums
+- [ ] Toggle column visibility in the explorer
+- [ ] iTunes-1.0-like browser with list of artists or albums
 - [ ] Queue next-up song
 
 


### PR DESCRIPTION
## This PR

Add a easter-egg menu item for seeing your library stats (# of songs and GB of space)

<img width="338" alt="Screenshot 2024-10-27 at 12 42 22 AM" src="https://github.com/user-attachments/assets/2c4e9be3-1594-4fce-b256-63b47634cd79">
<img width="1043" alt="Screenshot 2024-10-27 at 12 42 14 AM" src="https://github.com/user-attachments/assets/869befcb-f4ee-4f49-a973-3f3627648a6e">
