### PR TITLE
Feature: Browser UX

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -229,6 +229,14 @@ export default class MenuBuilder {
             this.mainWindow.webContents.toggleDevTools();
           },
         },
+        { type: 'separator' },
+        {
+          label: 'Toggle Browser View',
+          accelerator: 'Command+B',
+          click: () => {
+            this.mainWindow.webContents.send('menu-toggle-browser');
+          },
+        },
       ],
     };
     const subMenuViewProd: MenuItemConstructorOptions = {
@@ -239,6 +247,14 @@ export default class MenuBuilder {
           accelerator: 'Ctrl+Command+F',
           click: () => {
             this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Toggle Browser View',
+          accelerator: 'Command+B',
+          click: () => {
+            this.mainWindow.webContents.send('menu-toggle-browser');
           },
         },
       ],

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -25,6 +25,7 @@ export type Channels =
   | 'hide-song'
   | 'delete-song'
   | 'delete-album'
+  | 'menu-toggle-browser'
   // TODO: use this way more for replies
   | 'update-store';
 
@@ -35,6 +36,7 @@ export interface SendMessageArgs extends ArgsBase {
     rescan: boolean;
   };
   'add-to-library': undefined;
+  'menu-toggle-browser': undefined;
   'get-album-art': string;
   'set-last-played-song': string;
   'modify-tag-of-file': {

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -39,17 +39,16 @@ button:focus {
   outline: none;
 }
 
-.nodrag {
-  -webkit-app-region: no-drag;
-  overflow: hidden;
-}
-
 .drag {
   -webkit-app-region: drag;
 
   & * {
     -webkit-app-region: no-drag;
   }
+}
+
+.nodrag {
+  -webkit-app-region: no-drag !important;
 }
 
 .ReactVirtualized__List {

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -145,3 +145,18 @@ button:focus {
 ::-webkit-scrollbar-thumb:hover {
   border: 1px solid white;
 }
+
+
+.resize::after {
+  pointer-events: none;
+  content: " ";
+  font-size: 14px;
+  position: absolute;
+  height: 13px;
+  width: 13px;
+  text-align: center;
+  bottom: 0;
+  right: 0;
+  z-index: 2;
+  background-color: #0d0d0d;
+}

--- a/src/renderer/App.scss
+++ b/src/renderer/App.scss
@@ -160,3 +160,13 @@ button:focus {
   z-index: 2;
   background-color: #0d0d0d;
 }
+
+.resize-handle-sw {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 15px;
+  height: 15px;
+  cursor: sw-resize;
+  z-index: 3;
+}

--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -3,20 +3,19 @@ import Draggable from 'react-draggable';
 import { TinyText } from './SimpleStyledMaterialUIComponents';
 import AlbumArtRightClickMenu from './AlbumArtRightClickMenu';
 import usePlayerStore from '../store/player';
+import { useWindowDimensions } from '../hooks/useWindowDimensions';
 
 interface AlbumArtProps {
   setShowAlbumArtMenu: (menu: any) => void;
   showAlbumArtMenu: any;
-  width: number | null;
-  height: number | null;
 }
 
 export default function AlbumArt({
   setShowAlbumArtMenu,
   showAlbumArtMenu,
-  width,
-  height,
 }: AlbumArtProps) {
+  const { width, height } = useWindowDimensions();
+
   /**
    * @dev global store hooks
    */

--- a/src/renderer/components/AlbumArtRightClickMenu.tsx
+++ b/src/renderer/components/AlbumArtRightClickMenu.tsx
@@ -42,6 +42,7 @@ export default function AlbumArtRightClickMenu(
       }}
       anchorPosition={{ top: mouseY, left: mouseX }}
       anchorReference="anchorPosition"
+      className="nodrag"
       id="basic-menu"
       MenuListProps={{
         'aria-labelledby': 'basic-button',

--- a/src/renderer/components/AlbumArtRightClickMenu.tsx
+++ b/src/renderer/components/AlbumArtRightClickMenu.tsx
@@ -28,6 +28,11 @@ export default function AlbumArtRightClickMenu(
     onClose();
   };
 
+  const toggleBrowserView = () => {
+    window.dispatchEvent(new Event('toggle-browser-view'));
+    onClose();
+  };
+
   return (
     <Menu
       anchorEl={anchorEl}
@@ -59,6 +64,14 @@ export default function AlbumArtRightClickMenu(
         }}
       >
         Download Artwork
+      </MenuItem>
+      <MenuItem
+        onClick={toggleBrowserView}
+        sx={{
+          fontSize: '11px',
+        }}
+      >
+        Toggle Browser View
       </MenuItem>
     </Menu>
   );

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -7,10 +7,9 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import usePlayerStore from '../store/player';
 import useMainStore from '../store/main';
 import { LightweightAudioMetadata } from '../../common/common';
+import { useWindowDimensions } from '../hooks/useWindowDimensions';
 
 interface BrowserProps {
-  width: number | null;
-  height: number | null;
   onClose: () => void;
 }
 
@@ -22,7 +21,8 @@ type BrowserSelection = {
 const ROW_HEIGHT = 25.5;
 const BROWSER_WIDTH = 800; // Fixed browser width
 
-export default function Browser({ width, height, onClose }: BrowserProps) {
+export default function Browser({ onClose }: BrowserProps) {
+  const { width, height } = useWindowDimensions();
   const setFilteredLibrary = usePlayerStore(
     (store) => store.setFilteredLibrary,
   );

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -232,7 +232,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
               rowCount={artists.length}
               rowHeight={ROW_HEIGHT}
               rowRenderer={renderRow(artists, selection.artist, (artist) =>
-                setSelection((prev) => ({
+                setSelection((_prev) => ({
                   artist,
                   album: null, // Clear album selection when artist changes
                 })),

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -50,12 +50,11 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
       // eslint-disable-next-line no-restricted-syntax
       for (const entry of entries) {
         const { width: newWidth, height: newHeight } = entry.contentRect;
+
         setBrowserDimensions({
           width: newWidth,
           height: newHeight,
         });
-
-        window.dispatchEvent(new Event('browser-resized'));
       }
     });
 
@@ -65,7 +64,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
     return () => {
       resizeObserver.disconnect();
     };
-  }, []);
+  }, [browserRef]);
 
   // Calculate available artists and albums based on library
   useEffect(() => {
@@ -134,28 +133,33 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
   useEffect(() => {
     if (!width || !height) return;
 
-    const browserHeight = height * 0.4;
-
     let newX = position.x;
-    if (position.x + BROWSER_WIDTH > width) {
-      newX = width - BROWSER_WIDTH - 10;
+    if (position.x + browserDimensions.width > width) {
+      newX = width - browserDimensions.width - 10;
     }
     if (newX < 0) {
-      newX = 10;
+      newX = 0;
     }
 
     let newY = position.y;
-    if (position.y + browserHeight > height) {
-      newY = height - browserHeight - 10;
+    if (position.y + browserDimensions.height > height - 80) {
+      newY = height - browserDimensions.height - 80;
     }
-    if (newY < 0) {
-      newY = 10;
+    if (newY < 60) {
+      newY = 60;
     }
 
     if (newX !== position.x || newY !== position.y) {
       setPosition({ x: newX, y: newY });
     }
-  }, [width, height, position.x, position.y]);
+  }, [
+    width,
+    height,
+    position.x,
+    position.y,
+    browserDimensions.width,
+    browserDimensions.height,
+  ]);
 
   const renderRow = (
     list: string[],
@@ -175,7 +179,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
       return (
         <div
           key={key}
-          className="flex w-full items-center border-b last:border-b-0 border-neutral-800 transition-colors hover:bg-neutral-800/50 data-[state=selected]:bg-neutral-800 py-1"
+          className="flex w-full items-center border-b last:border-b-0 border-neutral-800 transition-colors duration-75 hover:bg-neutral-800/50 data-[state=selected]:bg-neutral-800 py-1"
           data-state={list[index] === selectedItem ? 'selected' : undefined}
           onClick={() => {
             if (list[index] === selectedItem) {
@@ -198,6 +202,8 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
 
   if (!width || !height) return null;
 
+  console.log(browserDimensions.width / 2);
+
   return (
     <Draggable
       bounds="parent"
@@ -207,7 +213,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
     >
       <div
         ref={browserRef}
-        className="absolute bg-[#1d1d1d] border-2 border-neutral-800 rounded-lg shadow-2xl z-[1000000000] drag resize overflow-hidden"
+        className="absolute bg-[#1d1d1d] rounded-lg shadow-2xl z-[1000000000] drag resize overflow-hidden"
         style={{
           width: browserDimensions.width,
           height: browserDimensions.height,
@@ -215,10 +221,10 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
           minWidth: '400px',
           minHeight: '200px',
           maxWidth: width ? width - 20 : '1200px',
-          maxHeight: height ? height - 20 : '800px',
+          maxHeight: height ? height - 60 - 120 : '800px',
         }}
       >
-        <div className="drag-handle flex items-center justify-between px-2 py-0.5 border-b border-neutral-800 cursor-move">
+        <div className="drag-handle flex items-center justify-between px-2 py-0.5 border-b border-neutral-800 cursor-move border-t-2 border-l-2 border-r-2">
           <div className="flex items-center gap-2">
             <DragIndicatorIcon className="text-neutral-400" fontSize="small" />
             <span className="text-xs font-medium text-neutral-400">
@@ -243,7 +249,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
           </IconButton>
         </div>
 
-        <div className="grid grid-cols-2 divide-x divide-neutral-800 h-[calc(100%-32px)]">
+        <div className="grid grid-cols-2 divide-x divide-neutral-800 h-[calc(100%-32px)] border-neutral-800  border-b-2 border-l-2 border-r-2 rounded-b-lg">
           <div>
             <div className="sticky top-0 z-50 bg-[#1d1d1d] outline outline-offset-0 outline-1 mb-[1px] outline-neutral-800">
               <div className="select-none flex flow-row leading-[1em] items-center py-1.5 px-4 text-left align-middle font-medium text-xs text-neutral-500">
@@ -251,7 +257,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
               </div>
             </div>
             <List
-              height={browserDimensions.height - 52}
+              height={browserDimensions.height - 64}
               rowCount={artists.length}
               rowHeight={ROW_HEIGHT}
               rowRenderer={renderRow(artists, selection.artist, (artist) =>
@@ -270,7 +276,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
               </div>
             </div>
             <List
-              height={browserDimensions.height - 52}
+              height={browserDimensions.height - 64}
               rowCount={albums.length}
               rowHeight={ROW_HEIGHT}
               rowRenderer={renderRow(albums, selection.album, (album) =>

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -256,7 +256,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
     >
       <div
         ref={browserRef}
-        className="absolute bg-[#1d1d1d] rounded-lg shadow-2xl z-[1000000000] drag resize overflow-hidden"
+        className="absolute nodrag bg-[#1d1d1d] rounded-lg shadow-2xl resize overflow-hidden"
         style={{
           width: browserDimensions.width,
           height: browserDimensions.height,
@@ -265,6 +265,7 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
           minHeight: '200px',
           maxWidth: width ? width - 20 : '1200px',
           maxHeight: height ? height - 60 - 120 : '800px',
+          zIndex: 1000000000,
         }}
       >
         {/* Add this line right after the opening div */}

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -1,0 +1,232 @@
+import React, { useState, useEffect } from 'react';
+import { List } from 'react-virtualized';
+import Draggable from 'react-draggable';
+import { IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import usePlayerStore from '../store/player';
+import useMainStore from '../store/main';
+import { LightweightAudioMetadata } from '../../common/common';
+
+interface BrowserProps {
+  width: number | null;
+  height: number | null;
+  onClose: () => void;
+}
+
+type BrowserSelection = {
+  artist: string | null;
+  album: string | null;
+};
+
+const ROW_HEIGHT = 25.5;
+
+export default function Browser({ width, height, onClose }: BrowserProps) {
+  const setFilteredLibrary = usePlayerStore(
+    (store) => store.setFilteredLibrary,
+  );
+  const storeLibrary = useMainStore((store) => store.library);
+
+  const [selection, setSelection] = useState<BrowserSelection>({
+    artist: null,
+    album: null,
+  });
+
+  const [artists, setArtists] = useState<string[]>([]);
+  const [albums, setAlbums] = useState<string[]>([]);
+
+  const columnWidth = width
+    ? Math.min(Math.floor((width * 0.6) / 2), 400)
+    : 180;
+
+  // Calculate available artists and albums based on library
+  useEffect(() => {
+    if (!storeLibrary) return;
+
+    const artistSet = new Set<string>();
+    const albumSet = new Set<string>();
+
+    Object.values(storeLibrary).forEach((song: LightweightAudioMetadata) => {
+      if (song.common.artist) {
+        artistSet.add(song.common.artist);
+      }
+      if (song.common.album) {
+        albumSet.add(song.common.album);
+      }
+    });
+
+    setArtists(Array.from(artistSet).sort());
+    setAlbums(Array.from(albumSet).sort());
+  }, [storeLibrary]);
+
+  // Filter the library based on selections
+  useEffect(() => {
+    if (!storeLibrary) return;
+
+    const filteredSongs = { ...storeLibrary };
+    Object.keys(filteredSongs).forEach((key) => {
+      const song = filteredSongs[key];
+      if (
+        (selection.artist && song.common.artist !== selection.artist) ||
+        (selection.album && song.common.album !== selection.album)
+      ) {
+        delete filteredSongs[key];
+      }
+    });
+
+    setFilteredLibrary(filteredSongs);
+  }, [selection, storeLibrary, setFilteredLibrary]);
+
+  // Update available albums when artist is selected
+  useEffect(() => {
+    if (!storeLibrary || !selection.artist) return;
+
+    const albumSet = new Set<string>();
+    Object.values(storeLibrary).forEach((song: LightweightAudioMetadata) => {
+      if (song.common.artist === selection.artist && song.common.album) {
+        albumSet.add(song.common.album);
+      }
+    });
+    setAlbums(Array.from(albumSet).sort());
+    setSelection((prev) => ({ ...prev, album: null }));
+  }, [selection.artist, storeLibrary]);
+
+  const [position, setPosition] = useState({ x: 100, y: 100 });
+
+  // Add this useEffect right after the position state declaration
+  useEffect(() => {
+    if (!width || !height) return;
+
+    const browserWidth = columnWidth * 2 + 8;
+    const browserHeight = height * 0.4;
+
+    // Ensure x position is within visible bounds
+    let newX = position.x;
+    if (position.x + browserWidth > width) {
+      newX = width - browserWidth - 10; // 10px padding from edge
+    }
+    if (newX < 0) {
+      newX = 10; // 10px padding from edge
+    }
+
+    // Ensure y position is within visible bounds
+    let newY = position.y;
+    if (position.y + browserHeight > height) {
+      newY = height - browserHeight - 10;
+    }
+    if (newY < 0) {
+      newY = 10;
+    }
+
+    // Only update if position changed
+    if (newX !== position.x || newY !== position.y) {
+      setPosition({ x: newX, y: newY });
+    }
+  }, [width, height, columnWidth, position.x, position.y]);
+
+  const renderRow = (
+    list: string[],
+    selectedItem: string | null,
+    onClick: (item: string) => void,
+  ) =>
+    // eslint-disable-next-line react/no-unstable-nested-components
+    function ({
+      index,
+      key,
+      style,
+    }: {
+      index: number;
+      key: string;
+      style: React.CSSProperties;
+    }) {
+      return (
+        <div
+          key={key}
+          className="flex w-full items-center border-b last:border-b-0 border-neutral-800 transition-colors hover:bg-neutral-800/50 data-[state=selected]:bg-neutral-800 py-1"
+          data-state={list[index] === selectedItem ? 'selected' : undefined}
+          onClick={() => onClick(list[index])}
+          onKeyDown={() => {}}
+          role="button"
+          style={style}
+          tabIndex={index}
+        >
+          <div className="select-none whitespace-nowrap overflow-hidden py-1 px-4 align-middle text-xs">
+            {list[index]}
+          </div>
+        </div>
+      );
+    };
+
+  if (!width || !height) return null;
+
+  if (width < columnWidth * 2 + 8) {
+    return null;
+  }
+
+  const listHeight = height * 0.4;
+
+  return (
+    <Draggable
+      bounds="parent"
+      handle=".drag-handle"
+      onStop={(e, data) => setPosition({ x: data.x, y: data.y })}
+      position={position}
+    >
+      <div
+        className="absolute bg-[#1d1d1d] border-2 border-neutral-800 rounded-lg shadow-2xl z-[1000000000] drag"
+        style={{ width: columnWidth * 2 + 8 }} // Add 8px for padding
+      >
+        <div className="drag-handle flex items-center justify-between px-2 py-0.5 border-b border-neutral-800 cursor-move">
+          <div className="flex items-center gap-2">
+            <DragIndicatorIcon className="text-neutral-400" fontSize="small" />
+            <span className="text-xs font-medium text-neutral-400">
+              browser
+            </span>
+          </div>
+          <IconButton
+            className="text-neutral-400 hover:text-white"
+            onClick={onClose}
+            size="small"
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </div>
+
+        <div className="flex">
+          <div style={{ width: columnWidth }}>
+            <div className="sticky top-0 z-50 bg-[#1d1d1d] outline outline-offset-0 outline-1 mb-[1px] outline-neutral-800">
+              <div className="select-none flex flow-row leading-[1em] items-center py-1.5 px-4 text-left align-middle font-medium text-xs text-neutral-500">
+                Artist
+              </div>
+            </div>
+            <List
+              height={listHeight - 20}
+              rowCount={artists.length}
+              rowHeight={ROW_HEIGHT}
+              rowRenderer={renderRow(artists, selection.artist, (artist) =>
+                setSelection((prev) => ({ ...prev, artist })),
+              )}
+              width={columnWidth}
+            />
+          </div>
+          <div style={{ width: columnWidth }}>
+            <div className="sticky top-0 z-50 bg-[#1d1d1d] outline outline-offset-0 outline-1 mb-[1px] outline-neutral-800">
+              <div className="select-none flex flow-row leading-[1em] items-center py-1.5 px-4 text-left align-middle font-medium text-xs text-neutral-500">
+                Album
+              </div>
+            </div>
+            <List
+              height={listHeight - 20}
+              rowCount={albums.length}
+              rowHeight={ROW_HEIGHT}
+              rowRenderer={renderRow(albums, selection.album, (album) =>
+                setSelection((prev) => ({ ...prev, album })),
+              )}
+              width={columnWidth}
+            />
+          </div>
+        </div>
+      </div>
+    </Draggable>
+  );
+}

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -245,8 +245,6 @@ export default function Browser({ onClose }: BrowserProps) {
 
   if (!width || !height) return null;
 
-  console.log(browserDimensions.width / 2);
-
   return (
     <Draggable
       bounds="parent"

--- a/src/renderer/components/Browser.tsx
+++ b/src/renderer/components/Browser.tsx
@@ -161,6 +161,49 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
     browserDimensions.height,
   ]);
 
+  // Add this function inside the Browser component, before the return statement
+  const handleBottomLeftResize = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!browserRef.current) return;
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startWidth = browserRef.current.offsetWidth;
+    const startHeight = browserRef.current.offsetHeight;
+    const startLeft = position.x;
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const deltaX = startX - moveEvent.clientX;
+      const deltaY = moveEvent.clientY - startY;
+
+      const newWidth = Math.min(
+        Math.max(400, startWidth + deltaX),
+        width ? width - 20 : 1200,
+      );
+      const newHeight = Math.min(
+        Math.max(200, startHeight + deltaY),
+        height ? height - 60 - 120 : 800,
+      );
+      const newLeft = startLeft - (newWidth - startWidth);
+
+      setBrowserDimensions({
+        width: newWidth,
+        height: newHeight,
+      });
+      setPosition((prev) => ({
+        ...prev,
+        x: newLeft,
+      }));
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
   const renderRow = (
     list: string[],
     selectedItem: string | null,
@@ -224,6 +267,14 @@ export default function Browser({ width, height, onClose }: BrowserProps) {
           maxHeight: height ? height - 60 - 120 : '800px',
         }}
       >
+        {/* Add this line right after the opening div */}
+        <div
+          aria-label="Resize browser"
+          className="resize-handle-sw"
+          onMouseDown={handleBottomLeftResize}
+          role="button"
+          tabIndex={0}
+        />
         <div className="drag-handle flex items-center justify-between px-2 py-0.5 border-b border-neutral-800 cursor-move border-t-2 border-l-2 border-r-2">
           <div className="flex items-center gap-2">
             <DragIndicatorIcon className="text-neutral-400" fontSize="small" />

--- a/src/renderer/components/ImportNewSongsButtons.tsx
+++ b/src/renderer/components/ImportNewSongsButtons.tsx
@@ -72,7 +72,7 @@ export default function ImportNewSongsButton({
     <Tooltip title="Import New Songs">
       <button
         aria-label="import to songs"
-        className="nodrag absolute top-[60px] md:top-4 right-4 items-center justify-center
+        className="absolute top-[60px] md:top-4 right-4 items-center justify-center
     rounded-md text-[18px] ring-offset-background transition-colors
     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
     focus-visible:ring-offset-2 disabled:pointer-events-none

--- a/src/renderer/components/LibraryList.tsx
+++ b/src/renderer/components/LibraryList.tsx
@@ -619,7 +619,7 @@ export default function LibraryList({
               <Tooltip title="Import Library">
                 <button
                   aria-label="select library folder"
-                  className="nodrag items-center justify-center
+                  className="items-center justify-center
           rounded-md text-[18px] ring-offset-background transition-colors
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
           focus-visible:ring-offset-2 disabled:pointer-events-none

--- a/src/renderer/components/LibraryList.tsx
+++ b/src/renderer/components/LibraryList.tsx
@@ -348,17 +348,17 @@ export default function LibraryList({
   ) => {
     if (!currentHeight || !currentWidth) return;
 
-    const artContainerHeight =
-      document.querySelector('.art')?.clientHeight || 0;
-
-    // current width is greater than tailwind's sm breakpoint
-    if (currentWidth > 500) {
-      // 106 is the height of the static player
-      setRowContainerHeight(currentHeight - artContainerHeight - 106);
-    } else {
-      // 160 is the height of the mobile static player
-      setRowContainerHeight(currentHeight - artContainerHeight - 160);
-    }
+    // Add setTimeout to ensure AlbumArt has finished resizing
+    setTimeout(() => {
+      const artContainerHeight =
+        document.querySelector('.art')?.clientHeight || 0;
+      if (currentWidth > 500) {
+        const newHeight = currentHeight - artContainerHeight - 106;
+        setRowContainerHeight(newHeight);
+      } else {
+        setRowContainerHeight(currentHeight - artContainerHeight - 160);
+      }
+    }, 100);
   };
 
   /**
@@ -369,6 +369,7 @@ export default function LibraryList({
   useEffect(() => {
     updateRowContainerHeight(height, width);
   }, [height, width]);
+
   /**
    * @dev update the row container height when the album art width changes
    * using the draggable component to resize the album art.

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -15,6 +15,7 @@ import ImportProgressDialog from './Dialog/ImportProgressDialog';
 import AlbumArt from './AlbumArt';
 import ImportNewSongsButton from './ImportNewSongsButtons';
 import SearchBar from './SearchBar';
+import Browser from './Browser';
 
 type AlbumArtMenuState =
   | {
@@ -93,6 +94,7 @@ export default function Main() {
     useState(false);
   const [showBackingUpLibraryDialog, setShowBackingUpLibraryDialog] =
     useState(false);
+  const [showBrowser, setShowBrowser] = useState(false);
 
   /**
    * @def functions
@@ -419,6 +421,10 @@ export default function Main() {
       setShowBackingUpLibraryDialog(false);
       setShowBackupConfirmationDialog(false);
     });
+
+    window.electron.ipcRenderer.on('menu-toggle-browser', () => {
+      setShowBrowser((prev) => !prev);
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
@@ -520,6 +526,14 @@ export default function Main() {
 
         <SearchBar className="absolute h-[45px] top-4 md:top-4 md:right-[4.5rem] right-4 w-auto text-white" />
       </div>
+
+      {showBrowser && (
+        <Browser
+          height={height || null}
+          onClose={() => setShowBrowser(false)}
+          width={width || null}
+        />
+      )}
 
       {/**
        * @dev middle chunk of the screen's UX

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -422,6 +422,10 @@ export default function Main() {
       setShowBackupConfirmationDialog(false);
     });
 
+    window.addEventListener('toggle-browser-view', () => {
+      setShowBrowser((prev) => !prev);
+    });
+
     window.electron.ipcRenderer.on('menu-toggle-browser', () => {
       setShowBrowser((prev) => !prev);
     });

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -474,16 +474,13 @@ export default function Main() {
         }}
         src={`my-magic-protocol://getMediaFile/${currentSong}`}
       />
-
       <ImportProgressDialog
         estimatedTimeRemainingString={estimatedTimeRemainingString}
         open={showImportingProgress}
         songsImported={songsImported}
         totalSongs={totalSongs}
       />
-
       <DedupingProgressDialog open={showDedupingProgress} />
-
       <BackupConfirmationDialog
         onBackup={() => {
           setShowBackupConfirmationDialog(false);
@@ -493,9 +490,7 @@ export default function Main() {
         onClose={() => setShowBackupConfirmationDialog(false)}
         open={showBackupConfirmationDialog}
       />
-
       <BackingUpLibraryDialog open={showBackingUpLibraryDialog} />
-
       <ConfirmDedupingDialog
         onClose={() => setShowConfirmDedupeAndDeleteDialog(false)}
         onConfirm={() => {
@@ -506,11 +501,10 @@ export default function Main() {
         }}
         open={showConfirmDedupeAndDeleteDialog}
       />
-
       {/**
        * @dev top chunk of the screen's UX
        */}
-      <div className="flex art drag justify-center p-4 space-x-4 md:flex-row ">
+      <div className="flex drag art justify-center p-4 space-x-4 md:flex-row">
         <AlbumArt
           height={height || null}
           setShowAlbumArtMenu={setShowAlbumArtMenu}
@@ -558,7 +552,6 @@ export default function Main() {
           width={width}
         />
       )}
-
       {/**
        * @dev bottom chunk of the screen's UX
        */}

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -16,6 +16,7 @@ import AlbumArt from './AlbumArt';
 import ImportNewSongsButton from './ImportNewSongsButtons';
 import SearchBar from './SearchBar';
 import Browser from './Browser';
+import { WindowDimensionsProvider } from '../hooks/useWindowDimensions';
 
 type AlbumArtMenuState =
   | {
@@ -454,112 +455,106 @@ export default function Main() {
 
   return (
     <div ref={ref} className="h-full flex flex-col dark">
-      {/**
-       * @important This is the hidden audio tag that plays the song.
-       * We use it to hook into the current time, pause, and play states.
-       */}
-      <audio
-        ref={audioTagRef}
-        autoPlay={!paused}
-        className="hidden"
-        onEnded={playNextSong}
-        onPause={() => {
-          setPaused(true);
-        }}
-        onPlay={() => {
-          setPaused(false);
-        }}
-        onTimeUpdate={(e) => {
-          setCurrentSongTime(e.currentTarget.currentTime);
-        }}
-        src={`my-magic-protocol://getMediaFile/${currentSong}`}
-      />
-      <ImportProgressDialog
-        estimatedTimeRemainingString={estimatedTimeRemainingString}
-        open={showImportingProgress}
-        songsImported={songsImported}
-        totalSongs={totalSongs}
-      />
-      <DedupingProgressDialog open={showDedupingProgress} />
-      <BackupConfirmationDialog
-        onBackup={() => {
-          setShowBackupConfirmationDialog(false);
-          setShowBackingUpLibraryDialog(true);
-          window.electron.ipcRenderer.sendMessage('menu-backup-library');
-        }}
-        onClose={() => setShowBackupConfirmationDialog(false)}
-        open={showBackupConfirmationDialog}
-      />
-      <BackingUpLibraryDialog open={showBackingUpLibraryDialog} />
-      <ConfirmDedupingDialog
-        onClose={() => setShowConfirmDedupeAndDeleteDialog(false)}
-        onConfirm={() => {
-          setShowConfirmDedupeAndDeleteDialog(false);
-          setShowDedupingProgress(true);
-          // @note: responds with update-store
-          window.electron.ipcRenderer.sendMessage('menu-delete-dupes');
-        }}
-        open={showConfirmDedupeAndDeleteDialog}
-      />
-      {/**
-       * @dev top chunk of the screen's UX
-       */}
-      <div className="flex art drag justify-center p-4 space-x-4 md:flex-row">
-        <AlbumArt
-          height={height || null}
-          setShowAlbumArtMenu={setShowAlbumArtMenu}
-          showAlbumArtMenu={showAlbumArtMenu}
-          width={width || null}
+      <WindowDimensionsProvider height={height ?? null} width={width ?? null}>
+        {/**
+         * @important This is the hidden audio tag that plays the song.
+         * We use it to hook into the current time, pause, and play states.
+         */}
+        <audio
+          ref={audioTagRef}
+          autoPlay={!paused}
+          className="hidden"
+          onEnded={playNextSong}
+          onPause={() => {
+            setPaused(true);
+          }}
+          onPlay={() => {
+            setPaused(false);
+          }}
+          onTimeUpdate={(e) => {
+            setCurrentSongTime(e.currentTarget.currentTime);
+          }}
+          src={`my-magic-protocol://getMediaFile/${currentSong}`}
         />
-
-        <div ref={importNewSongsButtonRef}>
-          <ImportNewSongsButton
-            setEstimatedTimeRemainingString={setEstimatedTimeRemainingString}
-            setInitialScrollIndex={setInitialScrollIndex}
-            setShowImportingProgress={setShowImportingProgress}
-            setSongsImported={setSongsImported}
-            setTotalSongs={setTotalSongs}
+        <ImportProgressDialog
+          estimatedTimeRemainingString={estimatedTimeRemainingString}
+          open={showImportingProgress}
+          songsImported={songsImported}
+          totalSongs={totalSongs}
+        />
+        <DedupingProgressDialog open={showDedupingProgress} />
+        <BackupConfirmationDialog
+          onBackup={() => {
+            setShowBackupConfirmationDialog(false);
+            setShowBackingUpLibraryDialog(true);
+            window.electron.ipcRenderer.sendMessage('menu-backup-library');
+          }}
+          onClose={() => setShowBackupConfirmationDialog(false)}
+          open={showBackupConfirmationDialog}
+        />
+        <BackingUpLibraryDialog open={showBackingUpLibraryDialog} />
+        <ConfirmDedupingDialog
+          onClose={() => setShowConfirmDedupeAndDeleteDialog(false)}
+          onConfirm={() => {
+            setShowConfirmDedupeAndDeleteDialog(false);
+            setShowDedupingProgress(true);
+            // @note: responds with update-store
+            window.electron.ipcRenderer.sendMessage('menu-delete-dupes');
+          }}
+          open={showConfirmDedupeAndDeleteDialog}
+        />
+        {/**
+         * @dev top chunk of the screen's UX
+         */}
+        <div className="flex art drag justify-center p-4 space-x-4 md:flex-row">
+          <AlbumArt
+            setShowAlbumArtMenu={setShowAlbumArtMenu}
+            showAlbumArtMenu={showAlbumArtMenu}
           />
+
+          <div ref={importNewSongsButtonRef}>
+            <ImportNewSongsButton
+              setEstimatedTimeRemainingString={setEstimatedTimeRemainingString}
+              setInitialScrollIndex={setInitialScrollIndex}
+              setShowImportingProgress={setShowImportingProgress}
+              setSongsImported={setSongsImported}
+              setTotalSongs={setTotalSongs}
+            />
+          </div>
+
+          <SearchBar className="absolute h-[45px] top-4 md:top-4 md:right-[4.5rem] right-4 w-auto text-white" />
         </div>
 
-        <SearchBar className="absolute h-[45px] top-4 md:top-4 md:right-[4.5rem] right-4 w-auto text-white" />
-      </div>
+        {showBrowser && <Browser onClose={() => setShowBrowser(false)} />}
 
-      {showBrowser && (
-        <Browser
-          height={height || null}
-          onClose={() => setShowBrowser(false)}
-          width={width || null}
+        {/**
+         * @dev middle chunk of the screen's UX
+         */}
+        {width && (
+          <LibraryList
+            height={height}
+            initialScrollIndex={initialScrollIndex}
+            onImportLibrary={importNewLibrary}
+            playSong={async (song, meta) => {
+              // if the user clicks on the currently playing song, start it over
+              if (currentSong === song) {
+                await startCurrentSongOver();
+              } else {
+                await playSong(song, meta);
+              }
+            }}
+            width={width}
+          />
+        )}
+        {/**
+         * @dev bottom chunk of the screen's UX
+         */}
+        <StaticPlayer
+          audioTagRef={audioTagRef}
+          playNextSong={playNextSong}
+          playPreviousSong={playPreviousSong}
         />
-      )}
-
-      {/**
-       * @dev middle chunk of the screen's UX
-       */}
-      {width && (
-        <LibraryList
-          height={height}
-          initialScrollIndex={initialScrollIndex}
-          onImportLibrary={importNewLibrary}
-          playSong={async (song, meta) => {
-            // if the user clicks on the currently playing song, start it over
-            if (currentSong === song) {
-              await startCurrentSongOver();
-            } else {
-              await playSong(song, meta);
-            }
-          }}
-          width={width}
-        />
-      )}
-      {/**
-       * @dev bottom chunk of the screen's UX
-       */}
-      <StaticPlayer
-        audioTagRef={audioTagRef}
-        playNextSong={playNextSong}
-        playPreviousSong={playPreviousSong}
-      />
+      </WindowDimensionsProvider>
     </div>
   );
 }

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -504,7 +504,7 @@ export default function Main() {
       {/**
        * @dev top chunk of the screen's UX
        */}
-      <div className="flex drag art justify-center p-4 space-x-4 md:flex-row">
+      <div className="flex art drag justify-center p-4 space-x-4 md:flex-row">
         <AlbumArt
           height={height || null}
           setShowAlbumArtMenu={setShowAlbumArtMenu}

--- a/src/renderer/components/SongProgressBar.tsx
+++ b/src/renderer/components/SongProgressBar.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from '@mui/material';
 import Marquee from 'react-fast-marquee';
 import { LessOpaqueTinyText } from './SimpleStyledMaterialUIComponents';
 import usePlayerStore from '../store/player';
+import { useWindowDimensions } from '../hooks/useWindowDimensions';
 
 export default function SongProgressBar({
   value,
@@ -18,6 +19,7 @@ export default function SongProgressBar({
   const [position, setPosition] = React.useState(32);
   const [isScrolling, setIsScrolling] = React.useState(false);
   const [isArtistScrolling, setIsArtistScrolling] = React.useState(false);
+  const { width, height } = useWindowDimensions();
 
   const filteredLibrary = usePlayerStore((state) => state.filteredLibrary);
   const currentSongMetadata = usePlayerStore(
@@ -71,7 +73,7 @@ export default function SongProgressBar({
         resizeObserver.unobserve(currentTitleRef);
       }
     };
-  }, [currentSongMetadata.common?.title]);
+  }, [currentSongMetadata.common?.title, width, height]);
 
   React.useEffect(() => {
     const checkOverflow2 = () => {
@@ -100,7 +102,7 @@ export default function SongProgressBar({
         resizeObserver.unobserve(currentTitleRef2);
       }
     };
-  }, [currentSongMetadata.common?.title]);
+  }, [currentSongMetadata.common?.title, width, height]);
 
   React.useEffect(() => {
     const checkOverflow3 = () => {
@@ -126,7 +128,7 @@ export default function SongProgressBar({
         resizeObserver.unobserve(currentArtistRef);
       }
     };
-  }, [currentSongMetadata.common?.artist]);
+  }, [currentSongMetadata.common?.artist, width, height]);
 
   React.useEffect(() => {
     const checkOverflow4 = () => {
@@ -154,7 +156,7 @@ export default function SongProgressBar({
         resizeObserver.unobserve(currentArtistRef);
       }
     };
-  }, [currentSongMetadata.common?.artist]);
+  }, [currentSongMetadata.common?.artist, width, height]);
 
   return (
     <Box

--- a/src/renderer/components/SongRightClickMenu.tsx
+++ b/src/renderer/components/SongRightClickMenu.tsx
@@ -216,6 +216,7 @@ export default function SongRightClickMenu(props: SongRightClickMenuProps) {
         }}
         anchorPosition={{ top: mouseY, left: mouseX }}
         anchorReference="anchorPosition"
+        className="nodrag"
         id="basic-menu"
         MenuListProps={{
           'aria-labelledby': 'basic-button',

--- a/src/renderer/components/SongRightClickMenu.tsx
+++ b/src/renderer/components/SongRightClickMenu.tsx
@@ -232,6 +232,17 @@ export default function SongRightClickMenu(props: SongRightClickMenuProps) {
           Show In Finder
         </MenuItem>
         <MenuItem
+          onClick={() => {
+            window.dispatchEvent(new Event('toggle-browser-view'));
+            onClose();
+          }}
+          sx={{
+            fontSize: '11px',
+          }}
+        >
+          Toggle Browser View
+        </MenuItem>
+        <MenuItem
           onClick={downloadAlbumArt}
           sx={{
             fontSize: '11px',

--- a/src/renderer/hooks/useWindowDimensions.tsx
+++ b/src/renderer/hooks/useWindowDimensions.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type WindowDimensionsContextType = {
+  width: number | null;
+  height: number | null;
+};
+
+const WindowDimensionsContext = createContext<WindowDimensionsContextType>({
+  width: null,
+  height: null,
+});
+
+export function WindowDimensionsProvider({
+  children,
+  width,
+  height,
+}: {
+  children: React.ReactNode;
+  width: number | null;
+  height: number | null;
+}) {
+  const [dimensions, setDimensions] = useState<WindowDimensionsContextType>({
+    width,
+    height,
+  });
+
+  useEffect(() => {
+    setDimensions({ width, height });
+  }, [width, height]);
+
+  return (
+    <WindowDimensionsContext.Provider value={dimensions}>
+      {children}
+    </WindowDimensionsContext.Provider>
+  );
+}
+
+export const useWindowDimensions = () => {
+  const context = useContext(WindowDimensionsContext);
+  if (context === undefined) {
+    throw new Error(
+      'useWindowDimensions must be used within a WindowDimensionsProvider',
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
## This PR

Allows the user to filter by artist and album easily using an iTunes-like "Browser" UX. It floats over the main UX of the screen and is completely resizable using the bottom two corners. Once closed, the filters stop taking effect. 

Closes #33 

It's toggle-able from 
* the right click menu of a song
* the right click menu of the album art
* the View menu
* by hitting "CMD+B".

![image](https://github.com/user-attachments/assets/51fc06d3-6ff7-41dd-a2bc-865a1ec02f40)

https://github.com/user-attachments/assets/9e51cba0-7a58-4283-a1b0-400ff5bf41b4

<img width="423" alt="Screenshot 2024-10-29 at 5 06 49 PM" src="https://github.com/user-attachments/assets/88493ebb-a50a-4fd8-a177-9a48d83c17dd">

## Notes

Fully respects window resizing. If you make the window tiny, it'll auto adjust the Browser's window size to still be somewhat usable.

If you try to drag it such that it eclipses the bottom viewer, it snaps up to a better spot.

If you try to drag it such that it eclipses the search bar at the top and the close/min/enalarge buttons, it will snap down to a better spot.

## Additional Fixes

* `.drag` class conflicting with floating menus and the browser floating panel, ie you could not click on menus if they went over the black background next to the album art, or the static player at the bottom.
* static player "disappearing" because the library list would evaluate its height before the album art had finished deciding its height.