### PR TITLE
Upgrade: Node v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '20.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '20.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '20.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/releaselatest.yml
+++ b/.github/workflows/releaselatest.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '20.x'
 
     - name: Install dependencies
       run: |

--- a/package.json
+++ b/package.json
@@ -236,8 +236,8 @@
     "url": "https://opencollective.com/electron-react-boilerplate-594"
   },
   "devEngines": {
-    "node": ">=14.x",
-    "npm": ">=7.x"
+    "node": ">=20.x",
+    "npm": ">=10.x"
   },
   "electronmon": {
     "patterns": [


### PR DESCRIPTION
## This PR

Upgrades whole build process to use node v20.

https://nodejs.org/en/about/previous-releases

16 is no longer getting maintenance etc.

I've been unwittingly using v20 locally during dev so this def works.