### PR TITLE
Patch: Corrupt album art not displaying placeholder

### DIFF
--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A minimalist offline music player for OSX audiophiles :: Based on iTunes circa 2002 :: by White Lights",
   "license": "MIT",
   "author": {

--- a/src/renderer/components/AlbumArt.tsx
+++ b/src/renderer/components/AlbumArt.tsx
@@ -38,6 +38,13 @@ export default function AlbumArt({
    * @dev component state
    */
   const [albumArtMaxWidth, setAlbumArtMaxWidth] = useState(320);
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    if (currentSongDataURL) {
+      setLoadError(false);
+    }
+  }, [currentSongDataURL]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -60,7 +67,7 @@ export default function AlbumArt({
     };
   }, [width, height]);
 
-  if (!currentSongDataURL) {
+  if (!currentSongDataURL || loadError) {
     return (
       <div
         className="relative aspect-square w-full bg-gradient-to-r from-neutral-800 via-neutral-700 to-neutral-600 border-2 border-neutral-700 shadow-2xl rounded-lg"
@@ -145,6 +152,10 @@ export default function AlbumArt({
             mouseX: e.clientX - 2,
             mouseY: e.clientY - 4,
           });
+        }}
+        onError={() => {
+          // @note: this is reset back to false when the image url is updated
+          setLoadError(true);
         }}
         src={currentSongDataURL}
         style={{


### PR DESCRIPTION
## This PR

See #42, bumps to `1.1.1`

If the album art is set but the image it leads to is actually a corrupt JPG/PNG, we should display the same UX as if there was no image set.


### Before

![image](https://github.com/user-attachments/assets/5166e85c-30da-41af-8f7b-b194b5020dfe)


### After

https://github.com/user-attachments/assets/e4b7928a-4568-4494-8ba9-1b54ed7b7e6c

