### PR TITLE
Phase 1 (upgrade): migrate MUI Grid v1 → Grid2 in Settings

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -17,9 +17,9 @@ import {
   DialogTitle,
   DialogContent,
   LinearProgress,
-  Grid,
   Divider,
 } from '@mui/material';
+import Grid from '@mui/material/Grid2';
 import FolderIcon from '@mui/icons-material/Folder';
 import WarningIcon from '@mui/icons-material/Warning';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -665,7 +665,7 @@ export default function Settings({ onClose }: SettingsProps) {
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
           <Grid container spacing={3}>
             {/* Library Path Section */}
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Typography gutterBottom variant="h2">
                 Music Folder
               </Typography>
@@ -698,11 +698,11 @@ export default function Settings({ onClose }: SettingsProps) {
               </FormControl>
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Divider sx={{ my: 2 }} />
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Typography gutterBottom variant="h2">
                 Import Music
               </Typography>
@@ -729,12 +729,12 @@ export default function Settings({ onClose }: SettingsProps) {
               </Box>
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Divider sx={{ my: 2 }} />
             </Grid>
 
             {/* Library Operations Section */}
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Typography gutterBottom variant="h2">
                 Rescan Library
               </Typography>
@@ -759,12 +759,12 @@ export default function Settings({ onClose }: SettingsProps) {
               </Box>
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Divider sx={{ my: 2 }} />
             </Grid>
 
             {/* Backup Section */}
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Typography gutterBottom variant="h2">
                 Backup Library
               </Typography>


### PR DESCRIPTION
## Summary
Phase 1 of the Electron/React/MUI upgrade path. Targets the integration branch `feature/upgrade-electron-react-mui-erb35`.

Migrate the 8 `<Grid item xs={12}>` usages in `src/renderer/components/Settings.tsx` to the new Grid2 API (`<Grid size={12}>`). MUI 7+ removes the legacy Grid v1 API entirely, so this is a prerequisite for the MUI 6 → 9 bump in Phase 4. The new Grid API is available in MUI 6 via `import Grid from '@mui/material/Grid2'`, so the migration lands cleanly on the current stack with identical visual layout.

## Scope decisions
Two items originally scoped for this phase have been deferred to Phase 2 (Electron 26 → 35):

1. **`protocol.registerFileProtocol` → `protocol.handle` migration** — attempted here but reverted. The custom `hihat-audio://` scheme interacts subtly with Gapless-5's Web Audio pipeline (`useHTML5Audio: false`) and the `net.fetch` semantics around range requests on custom schemes need to be validated against the actual target Electron runtime. The deprecated API still works on Electron 26, so keeping it lets Phase 1 ship fast.
2. **ERB main-process dev webpack workflow** — moved to Phase 2 alongside the Electron bump it actually unblocks. Changes to `start:main` and preload-path resolution in `main.ts`/`miniPlayer.ts` should land against the Electron version they're solving for.

Phase 2 (Electron 26 → 35 + full ERB tooling stack) will land both, plus every webpack/loader/ESLint-plugin bump.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:e2e` — 121 passed, 1 pre-existing skip (18.9m)
- [x] Verified `settings.spec.ts` (2/2) and `ui-visual-verification.spec.ts` (9/9 including the settings slide-over panel test) — Grid2 migration is visually indistinguishable from Grid v1

## Context
See `/Users/johnshankman/.claude/plans/noble-soaring-blanket.md` for the full 5-phase path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)