### PR TITLE
refactor: drop dead useCallback wrappers in Library & Playlists

### DIFF
--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -192,13 +192,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     null,
   );
 
-  const handlePlayTrack = useCallback(
-    (trackId: string) => {
-      // Play the track with 'library' as the source
-      playTrack(trackId, 'library');
-    },
-    [playTrack],
-  );
+  const handlePlayTrack = (trackId: string) => {
+    playTrack(trackId, 'library');
+  };
 
   const handleSelectFolder = async () => {
     try {
@@ -235,18 +231,14 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     setDialogOpen(false);
   };
 
-  // Context menu handlers
-  const handleContextMenu = useCallback(
-    (event: React.MouseEvent, trackId: string) => {
-      event.preventDefault();
-      setContextMenu({
-        mouseX: event.clientX,
-        mouseY: event.clientY,
-      });
-      setSelectedTrackId(trackId);
-    },
-    [],
-  );
+  const handleContextMenu = (event: React.MouseEvent, trackId: string) => {
+    event.preventDefault();
+    setContextMenu({
+      mouseX: event.clientX,
+      mouseY: event.clientY,
+    });
+    setSelectedTrackId(trackId);
+  };
 
   const handleCloseContextMenu = () => {
     setContextMenu(null);
@@ -612,115 +604,98 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     };
   }, [sorting, globalFilter, data.length]);
 
-  // Row event handlers
-  const handleRowClick = useCallback(
-    (row: Row<TableData>, index: number, e: React.MouseEvent) => {
-      const trackId = row.original.id;
+  const handleRowClick = (
+    row: Row<TableData>,
+    index: number,
+    e: React.MouseEvent,
+  ) => {
+    const trackId = row.original.id;
 
-      setSelectedTracks((prev) => {
-        if ((e.metaKey || e.ctrlKey) && !e.shiftKey) {
-          const newSelectedTracks = { ...prev };
-          if (newSelectedTracks[trackId]) {
-            delete newSelectedTracks[trackId];
-          } else {
-            newSelectedTracks[trackId] = true;
-          }
+    setSelectedTracks((prev) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey) {
+        const newSelectedTracks = { ...prev };
+        if (newSelectedTracks[trackId]) {
+          delete newSelectedTracks[trackId];
+        } else {
+          newSelectedTracks[trackId] = true;
+        }
+        setLastClickedIndex(index);
+        return newSelectedTracks;
+      }
+
+      if (e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (lastClickedIndex === null) {
           setLastClickedIndex(index);
-          return newSelectedTracks;
+          return { [trackId]: true };
         }
 
-        if (e.shiftKey && !e.metaKey && !e.ctrlKey) {
-          if (lastClickedIndex === null) {
-            setLastClickedIndex(index);
-            return { [trackId]: true };
-          }
+        const start = Math.min(lastClickedIndex, index);
+        const end = Math.max(lastClickedIndex, index);
 
-          const start = Math.min(lastClickedIndex, index);
-          const end = Math.max(lastClickedIndex, index);
+        const rangeSelection: Record<string, boolean> = {};
 
-          const rangeSelection: Record<string, boolean> = {};
-
-          if (tableRef.current) {
-            const visibleRows = tableRef.current.getRowModel().rows;
-            for (let i = start; i <= end; i += 1) {
-              const rowData = visibleRows[i]?.original;
-              if (rowData) {
-                rangeSelection[rowData.id] = true;
-              }
+        if (tableRef.current) {
+          const visibleRows = tableRef.current.getRowModel().rows;
+          for (let i = start; i <= end; i += 1) {
+            const rowData = visibleRows[i]?.original;
+            if (rowData) {
+              rangeSelection[rowData.id] = true;
             }
           }
-
-          return rangeSelection;
         }
 
-        setLastClickedIndex(index);
-        return { [trackId]: true };
-      });
-    },
-    [lastClickedIndex],
-  );
-
-  const handleRowDoubleClick = useCallback(
-    (row: Row<TableData>, _index: number) => {
-      handlePlayTrack(row.original.id);
-      setSelectedTracks({ [row.original.id]: true });
-    },
-    [handlePlayTrack],
-  );
-
-  const handleRowContextMenu = useCallback(
-    (row: Row<TableData>, _index: number, e: React.MouseEvent) => {
-      const trackId = row.original.id;
-
-      if (selectedTracks[trackId]) {
-        handleContextMenu(e, trackId);
-      } else {
-        setSelectedTracks({ [trackId]: true });
-        handleContextMenu(e, trackId);
+        return rangeSelection;
       }
-    },
-    [selectedTracks, handleContextMenu],
-  );
 
-  const handleGetRowClassName = useCallback(
-    (row: Row<TableData>, index: number) => {
-      return getRowClassName(
-        row.original.id,
-        currentTrack?.id || undefined,
-        Object.keys(selectedTracks),
-        playbackSource || '',
-        'library',
-        undefined,
-        undefined,
-        index,
-      );
-    },
-    [currentTrack?.id, selectedTracks, playbackSource],
-  );
+      setLastClickedIndex(index);
+      return { [trackId]: true };
+    });
+  };
 
-  // Column visibility toggle handler
-  const handleColumnVisibilityToggle = useCallback(
-    (columnId: string, visible: boolean) => {
-      updateColumnVisibility(columnId, visible);
-    },
-    [updateColumnVisibility],
-  );
+  const handleRowDoubleClick = (row: Row<TableData>, _index: number) => {
+    handlePlayTrack(row.original.id);
+    setSelectedTracks({ [row.original.id]: true });
+  };
 
-  // Column sizing persistence handler
-  const handleColumnSizingPersist = useCallback(
-    (sizing: Record<string, number>) => {
-      setColumnWidths(sizing);
-    },
-    [setColumnWidths],
-  );
+  const handleRowContextMenu = (
+    row: Row<TableData>,
+    _index: number,
+    e: React.MouseEvent,
+  ) => {
+    const trackId = row.original.id;
 
-  // Column order change handler
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
+    if (selectedTracks[trackId]) {
+      handleContextMenu(e, trackId);
+    } else {
+      setSelectedTracks({ [trackId]: true });
+      handleContextMenu(e, trackId);
+    }
+  };
+
+  const handleGetRowClassName = (row: Row<TableData>, index: number) => {
+    return getRowClassName(
+      row.original.id,
+      currentTrack?.id || undefined,
+      Object.keys(selectedTracks),
+      playbackSource || '',
+      'library',
+      undefined,
+      undefined,
+      index,
+    );
+  };
+
+  const handleColumnVisibilityToggle = (columnId: string, visible: boolean) => {
+    updateColumnVisibility(columnId, visible);
+  };
+
+  const handleColumnSizingPersist = (sizing: Record<string, number>) => {
+    setColumnWidths(sizing);
+  };
+
+  const handleColumnOrderChange = (newOrder: string[]) => {
+    setColumnOrder(newOrder);
+  };
 
   // Drag-and-drop: compute selected track IDs list
   const selectedTrackIdsList = useMemo(
@@ -728,16 +703,15 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [selectedTracks],
   );
 
-  // Drag-and-drop: handle row drag start
-  const handleRowDragStart = useCallback(
-    (trackId: string, selectedIds: string[]): string[] => {
-      if (selectedIds.includes(trackId)) {
-        return selectedIds;
-      }
-      return [trackId];
-    },
-    [],
-  );
+  const handleRowDragStart = (
+    trackId: string,
+    selectedIds: string[],
+  ): string[] => {
+    if (selectedIds.includes(trackId)) {
+      return selectedIds;
+    }
+    return [trackId];
+  };
 
   // Toolbar content
   const toolbarContent = useMemo(

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -623,122 +623,98 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     };
   }, [sorting, globalFilter, data.length]);
 
-  // Row event handlers
-  const handleRowClick = useCallback(
-    (row: Row<TableData>, index: number, e: React.MouseEvent) => {
-      const trackId = row.original.id;
+  const handleRowClick = (
+    row: Row<TableData>,
+    index: number,
+    e: React.MouseEvent,
+  ) => {
+    const trackId = row.original.id;
 
-      setSelectedTracks((prev) => {
-        if ((e.metaKey || e.ctrlKey) && !e.shiftKey) {
-          const newSelectedTracks = { ...prev };
-          if (newSelectedTracks[trackId]) {
-            delete newSelectedTracks[trackId];
-          } else {
-            newSelectedTracks[trackId] = true;
-          }
+    setSelectedTracks((prev) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey) {
+        const newSelectedTracks = { ...prev };
+        if (newSelectedTracks[trackId]) {
+          delete newSelectedTracks[trackId];
+        } else {
+          newSelectedTracks[trackId] = true;
+        }
+        setLastClickedIndex(index);
+        return newSelectedTracks;
+      }
+
+      if (e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (lastClickedIndex === null) {
           setLastClickedIndex(index);
-          return newSelectedTracks;
+          return { [trackId]: true };
         }
 
-        if (e.shiftKey && !e.metaKey && !e.ctrlKey) {
-          if (lastClickedIndex === null) {
-            setLastClickedIndex(index);
-            return { [trackId]: true };
-          }
+        const start = Math.min(lastClickedIndex, index);
+        const end = Math.max(lastClickedIndex, index);
 
-          const start = Math.min(lastClickedIndex, index);
-          const end = Math.max(lastClickedIndex, index);
+        const rangeSelection: Record<string, boolean> = {};
 
-          const rangeSelection: Record<string, boolean> = {};
-
-          if (tableRef.current) {
-            const visibleRows = tableRef.current.getRowModel().rows;
-            for (let i = start; i <= end; i += 1) {
-              const rowData = visibleRows[i]?.original;
-              if (rowData) {
-                rangeSelection[rowData.id] = true;
-              }
+        if (tableRef.current) {
+          const visibleRows = tableRef.current.getRowModel().rows;
+          for (let i = start; i <= end; i += 1) {
+            const rowData = visibleRows[i]?.original;
+            if (rowData) {
+              rangeSelection[rowData.id] = true;
             }
           }
-
-          return rangeSelection;
         }
 
-        setLastClickedIndex(index);
-        return { [trackId]: true };
-      });
-    },
-    [lastClickedIndex],
-  );
-
-  const handleRowDoubleClick = useCallback(
-    (row: Row<TableData>, _index: number) => {
-      handlePlayTrack(row.original.id);
-      setSelectedTracks({ [row.original.id]: true });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedPlaylistId, sorting, globalFilter],
-  );
-
-  const handleRowContextMenu = useCallback(
-    (row: Row<TableData>, _index: number, e: React.MouseEvent) => {
-      const trackId = row.original.id;
-
-      if (selectedTracks[trackId]) {
-        handleContextMenu(e, trackId);
-      } else {
-        setSelectedTracks({ [trackId]: true });
-        handleContextMenu(e, trackId);
+        return rangeSelection;
       }
-    },
-    [selectedTracks],
-  );
 
-  const handleGetRowClassName = useCallback(
-    (row: Row<TableData>, index: number) => {
-      return getRowClassName(
-        row.original.id,
-        currentTrack?.id || undefined,
-        Object.keys(selectedTracks),
-        playbackSource || '',
-        'playlist',
-        playbackSourcePlaylistId || undefined,
-        selectedPlaylistId || undefined,
-        index,
-      );
-    },
-    [
-      currentTrack?.id,
-      selectedTracks,
-      playbackSource,
-      playbackSourcePlaylistId,
-      selectedPlaylistId,
-    ],
-  );
+      setLastClickedIndex(index);
+      return { [trackId]: true };
+    });
+  };
 
-  // Column visibility toggle handler
-  const handleColumnVisibilityToggle = useCallback(
-    (columnId: string, visible: boolean) => {
-      updateColumnVisibility(columnId, visible);
-    },
-    [updateColumnVisibility],
-  );
+  const handleRowDoubleClick = (row: Row<TableData>, _index: number) => {
+    handlePlayTrack(row.original.id);
+    setSelectedTracks({ [row.original.id]: true });
+  };
 
-  // Column sizing persistence handler
-  const handleColumnSizingPersist = useCallback(
-    (sizing: Record<string, number>) => {
-      setColumnWidths(sizing);
-    },
-    [setColumnWidths],
-  );
+  const handleRowContextMenu = (
+    row: Row<TableData>,
+    _index: number,
+    e: React.MouseEvent,
+  ) => {
+    const trackId = row.original.id;
 
-  // Column order change handler
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
+    if (selectedTracks[trackId]) {
+      handleContextMenu(e, trackId);
+    } else {
+      setSelectedTracks({ [trackId]: true });
+      handleContextMenu(e, trackId);
+    }
+  };
+
+  const handleGetRowClassName = (row: Row<TableData>, index: number) => {
+    return getRowClassName(
+      row.original.id,
+      currentTrack?.id || undefined,
+      Object.keys(selectedTracks),
+      playbackSource || '',
+      'playlist',
+      playbackSourcePlaylistId || undefined,
+      selectedPlaylistId || undefined,
+      index,
+    );
+  };
+
+  const handleColumnVisibilityToggle = (columnId: string, visible: boolean) => {
+    updateColumnVisibility(columnId, visible);
+  };
+
+  const handleColumnSizingPersist = (sizing: Record<string, number>) => {
+    setColumnWidths(sizing);
+  };
+
+  const handleColumnOrderChange = (newOrder: string[]) => {
+    setColumnOrder(newOrder);
+  };
 
   // Drag-and-drop: compute selected track IDs list
   const selectedTrackIdsList = useMemo(
@@ -746,16 +722,15 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     [selectedTracks],
   );
 
-  // Drag-and-drop: handle row drag start
-  const handleRowDragStart = useCallback(
-    (trackId: string, selectedIds: string[]): string[] => {
-      if (selectedIds.includes(trackId)) {
-        return selectedIds;
-      }
-      return [trackId];
-    },
-    [],
-  );
+  const handleRowDragStart = (
+    trackId: string,
+    selectedIds: string[],
+  ): string[] => {
+    if (selectedIds.includes(trackId)) {
+      return selectedIds;
+    }
+    return [trackId];
+  };
 
   // Toolbar content
   const toolbarContent = useMemo(() => {


### PR DESCRIPTION
## Summary

Removes 18 dead-weight `useCallback` wrappers across `Library.tsx` (10) and `Playlists.tsx` (8). Each wrapped handler was consumed exclusively by `VirtualTable`, which is **not** wrapped in `React.memo` and additionally wraps row handlers in fresh inline arrow functions on every render (see `VirtualTable.tsx:456-488`). Stable callback identity at that boundary buys nothing, and none of these handlers feed any `useEffect`/`useMemo` dep array.

Load-bearing `useCallback` wrappers are preserved in both files (7 in Library, 8 in Playlists) where identity actually matters — specifically those feeding `toolbarContent`/`browserPanel` `useMemo` dep arrays and `scrollToTrack`/`scrollToTrackWhenReady` chains consumed by effects.

## Library.tsx — 10 wrappers dropped
`handlePlayTrack`, `handleContextMenu`, `handleRowClick`, `handleRowDoubleClick`, `handleRowContextMenu`, `handleGetRowClassName`, `handleColumnVisibilityToggle`, `handleColumnSizingPersist`, `handleColumnOrderChange`, `handleRowDragStart`

`handlePlayTrack` and `handleContextMenu` only existed to give stable refs to the row handlers that wrapped them; with those wrappers gone, they also become dead weight and revert to plain functions.

## Playlists.tsx — 8 wrappers dropped
`handleRowClick`, `handleRowDoubleClick`, `handleRowContextMenu`, `handleGetRowClassName`, `handleColumnVisibilityToggle`, `handleColumnSizingPersist`, `handleColumnOrderChange`, `handleRowDragStart`

This also removes a misleading `// eslint-disable-next-line react-hooks/exhaustive-deps` on `handleRowDoubleClick` whose dep array listed `[selectedPlaylistId, sorting, globalFilter]` — values the callback never actually read. The wrapper was load-bearing only for a lie to the linter; without the wrapper, no lie is needed.

`React.memo(Playlists)` at module level is unaffected: it gates re-renders from the parent based on incoming props and is independent of the identity of internal handlers.

## Why this is safe

- `VirtualTable` has no `React.memo` wrapper (`VirtualTable.tsx:563` — `export default VirtualTable`, no HOC)
- Row handlers are consumed inside inline arrow wrappers in JSX (`onClick={(e) => onRowClick(row, virtualRow.index, e)}`), so the parent's callback identity is laundered through a fresh closure every render regardless
- `onColumnSizingPersist` is called inside a debounced effect in `VirtualTable` whose dep array intentionally excludes it (`VirtualTable.tsx:134` — `eslint-disable-next-line react-hooks/exhaustive-deps`), so stable identity was never needed there either
- None of the removed handlers were referenced in any other `useMemo` / `useEffect` / `useCallback` dep array in either file (verified by grep)

## Based on PR #60

This branch is rebased onto `feature/upgrade-electron-react-mui-erb35` so it stacks cleanly on top of #60. Both target files are identical between `main` and that branch, so there are no upgrade-related conflicts.

## Diffstat

- `Library.tsx`:  +96 / −122
- `Playlists.tsx`: +85 / −110
- Net: **−51 lines**

## Test plan

- [x] `npm run typecheck` passes (Library/Playlists errors = 0; pre-existing unrelated Settings.tsx Grid errors remain on the base branch)
- [x] `npm run lint` passes for `src/renderer/components/Library.tsx` and `src/renderer/components/Playlists.tsx`
- [x] Manual smoke via `npm run start`: row click / shift-click / cmd-click / double-click / right-click, column resize, column reorder, column visibility toggle, drag-and-drop to playlist — all behave identically in both views
- [x] Playlist switching still restores per-playlist sorting/search (unaffected by the removed wrappers but worth confirming since `handleRowDoubleClick`'s dep-array lie touched that state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)