### PR TITLE
refactor: push sort/filter ownership into stores, drop component plumbing

### DIFF
--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -3,8 +3,8 @@ import React, {
   useMemo,
   useRef,
   useEffect,
-  useLayoutEffect,
   useCallback,
+  useInsertionEffect,
 } from 'react';
 import {
   Box,
@@ -334,6 +334,12 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // Also lets handleSortingChange compute the next sorting outside of a
   // state updater (state updaters must stay pure — they're double-invoked
   // in StrictMode / Concurrent rendering).
+  //
+  // The ref is written inside useInsertionEffect so writes happen on commit,
+  // not during render — a speculative render that React discards must not
+  // leave stale values behind. useInsertionEffect fires before any other
+  // effect on the same commit, so every downstream reader sees the latest
+  // committed values.
   const latestRef = useRef({
     sorting,
     artistFilter,
@@ -342,12 +348,14 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     playbackSource,
     scrollToTrack,
   });
-  latestRef.current.sorting = sorting;
-  latestRef.current.artistFilter = artistFilter;
-  latestRef.current.albumFilter = albumFilter;
-  latestRef.current.currentTrack = currentTrack;
-  latestRef.current.playbackSource = playbackSource;
-  latestRef.current.scrollToTrack = scrollToTrack;
+  useInsertionEffect(() => {
+    latestRef.current.sorting = sorting;
+    latestRef.current.artistFilter = artistFilter;
+    latestRef.current.albumFilter = albumFilter;
+    latestRef.current.currentTrack = currentTrack;
+    latestRef.current.playbackSource = playbackSource;
+    latestRef.current.scrollToTrack = scrollToTrack;
+  });
 
   // Single source of truth for changing the global filter: updates local
   // state, persists to store, and snaps to the current track when the user
@@ -543,8 +551,11 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
 
   // Save the currently visible track on unmount. Read the virtualizer
   // through the ref *inside* the cleanup so we see its real value at
-  // unmount time, not the (typically null) value at first mount.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // unmount time, not the (typically null) value at first mount. The
+  // virtualizer's range indexes the browser-filtered rows, so we must
+  // resolve it against the same artist/album filters via latestRef —
+  // otherwise we save the wrong track whenever a browser filter is
+  // active at unmount.
   useEffect(() => {
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -555,7 +566,13 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
       const middleIndex = Math.floor(
         (visibleRange.startIndex + visibleRange.endIndex) / 2,
       );
-      const trackIds = getFilteredAndSortedTrackIds('library');
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const latest = latestRef.current;
+      const trackIds = getFilteredAndSortedTrackIds(
+        'library',
+        latest.artistFilter,
+        latest.albumFilter,
+      );
       if (trackIds[middleIndex]) {
         setLastViewedTrackId(trackIds[middleIndex]);
       }
@@ -617,19 +634,17 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
 
   // Handle search toggle. Closing the bar clears the filter through
   // applyGlobalFilter so persistence and scroll-on-clear both fire.
+  // Side effect lives outside setShowSearch because state updaters must
+  // stay pure — React may double-invoke them in StrictMode and discard
+  // the side effects of trial renders.
   const handleSearchToggle = useCallback(() => {
-    setShowSearch((prev) => {
-      if (prev) {
-        applyGlobalFilter('');
-      }
-      return !prev;
-    });
-  }, [applyGlobalFilter]);
+    if (showSearch) applyGlobalFilter('');
+    setShowSearch((prev) => !prev);
+  }, [showSearch, applyGlobalFilter]);
 
-  // Mark table as ready after layout commits. useLayoutEffect runs after
-  // DOM mutations but before paint, so by the time the rAF callback fires
-  // the virtualizer has measured rows for the new sorting/filter/data.
-  useLayoutEffect(() => {
+  // Mark table as ready after the next frame so the virtualizer has
+  // measured rows for the new sorting/filter/data.
+  useEffect(() => {
     tableReadyRef.current = false;
     const rafId = requestAnimationFrame(() => {
       tableReadyRef.current = true;

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -542,10 +542,11 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     scrollToTrackWhenReady(lastViewedTrackId);
   }, [lastViewedTrackId, tracks.length, scrollToTrackWhenReady]);
 
-  // Get columns from shared configuration
+  // useMemo: stable identity for tanstack's internal row-model memoization
+  // and avoids re-allocating column defs each render. Empty deps = once.
   const columns = useMemo(() => getCommonColumnDefs(), []);
 
-  // Prepare data for the table with browser filtering
+  // useMemo: O(n) filter + map over potentially thousands of tracks.
   const data = useMemo<TableData[]>(() => {
     let filteredTracks = tracks;
 
@@ -579,7 +580,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     });
   }, [tracks, artistFilter, albumFilter]);
 
-  // Memoize total hours calculation to avoid recalculating on every render
+  // useMemo: O(n) reduce over track durations.
   const totalHours = useMemo(() => calculateTotalHours(data), [data]);
 
   // Handle search toggle. Closing the bar clears the filter through
@@ -707,7 +708,8 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     return [trackId];
   };
 
-  // Toolbar content
+  // useMemo: deep JSX subtree. Stable element reference lets React skip
+  // reconciliation of the toolbar when row clicks re-render the parent.
   const toolbarContent = useMemo(
     () => (
       <Box
@@ -886,7 +888,8 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     ],
   );
 
-  // Empty state content
+  // useMemo: stable element reference skips subtree reconciliation on
+  // parent re-renders where drawerOpen hasn't changed.
   const emptyStateContent = useMemo(
     () => (
       <Box
@@ -930,7 +933,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [setBrowserOpen],
   );
 
-  // Browser panel to pass to VirtualTable — always mounted so open/close can animate
+  // useMemo: wraps React.memo'd Browser. Stable element reference skips
+  // its subtree on parent re-renders where deps haven't changed. Always
+  // mounted so open/close can animate.
   const browserPanel = useMemo(() => {
     return (
       <Browser

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -3,8 +3,8 @@ import React, {
   useMemo,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
-  useInsertionEffect,
 } from 'react';
 import {
   Box,
@@ -58,6 +58,13 @@ const searchExpandAnimation = keyframes`
   }
 `;
 
+// Stable module-level default so the `librarySorting` selector fallback
+// returns the same reference every render, preventing spurious re-renders
+// from Zustand equality checks when no persisted sorting exists yet.
+const DEFAULT_LIBRARY_SORTING: SortingState = [
+  { id: 'albumArtist', desc: false },
+];
+
 // Define the type for directory selection result
 interface DirectorySelectionResult {
   canceled: boolean;
@@ -74,12 +81,15 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // Get state from library store
   const tracks = useLibraryStore((state) => state.tracks);
   const getTrackById = useLibraryStore((state) => state.getTrackById);
-  const updateLibraryViewState = useLibraryStore(
-    (state) => state.updateLibraryViewState,
-  );
   const lastViewedTrackId = useLibraryStore((state) => state.lastViewedTrackId);
   const setLastViewedTrackId = useLibraryStore(
     (state) => state.setLastViewedTrackId,
+  );
+  // Library's global filter lives in the libraryStore keyed by view ID.
+  // Reading it directly here means the store is the single source of truth
+  // — no local mirror, no ref, no manual fan-out on change.
+  const globalFilter = useLibraryStore(
+    (state) => state.searchFilters.library ?? '',
   );
   // Get state from settings store
   const columnVisibility = useSettingsAndPlaybackStore(
@@ -96,6 +106,12 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
   const setLibrarySorting = useSettingsAndPlaybackStore(
     (state) => state.setLibrarySorting,
+  );
+  // Sort preference lives in settingsAndPlaybackStore and is persisted to
+  // DB. setLibrarySorting internally fans out to libraryViewState, so the
+  // component just reads and writes this one value.
+  const sorting = useSettingsAndPlaybackStore(
+    (state) => state.librarySorting ?? DEFAULT_LIBRARY_SORTING,
   );
   const columnOrder = useSettingsAndPlaybackStore((state) => state.columnOrder);
   const setColumnOrder = useSettingsAndPlaybackStore(
@@ -140,11 +156,10 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   const browserFilters = useLibraryStore((state) => state.browserFilters);
   const setBrowserFilter = useLibraryStore((state) => state.setBrowserFilter);
   const setSearchFilter = useLibraryStore((state) => state.setSearchFilter);
-  const getSearchFilter = useLibraryStore((state) => state.getSearchFilter);
   const browserOpen = useUIStore((state) => state.browserOpen);
   const setBrowserOpen = useUIStore((state) => state.setBrowserOpen);
-  const [showSearch, setShowSearch] = useState(() =>
-    Boolean(getSearchFilter('library')),
+  const [showSearch, setShowSearch] = useState(
+    () => !!useLibraryStore.getState().searchFilters.library,
   );
   const [browserHeight, setBrowserHeight] = useState(200);
 
@@ -169,21 +184,6 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     },
     [setBrowserFilter, libraryBrowserFilter],
   );
-
-  // Global filter state — receives debounced values from SearchBar.
-  const [globalFilter, setGlobalFilter] = useState(() =>
-    getSearchFilter('library'),
-  );
-  const globalFilterRef = useRef(globalFilter);
-
-  // Sorting state - initialize from store to persist across unmount/remount.
-  // Read via getState() at init time only: we don't want to subscribe to
-  // libraryViewState because we write to it on every sort/search change,
-  // which would re-render this component for data it no longer reads.
-  const [sorting, setSorting] = useState<SortingState>(() => {
-    const stored = useLibraryStore.getState().libraryViewState.sorting;
-    return stored || [{ id: 'albumArtist', desc: false }];
-  });
 
   // Add row virtualizer ref
   const rowVirtualizerRef = useRef<Virtualizer<HTMLDivElement, Element> | null>(
@@ -328,28 +328,20 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [scrollToTrack],
   );
 
-  // Latest reactive values held in a ref so handlers below can read fresh
-  // state without becoming reactive themselves (keeps callback identity
-  // stable for SearchBar, which subscribes via useEffect on the callback).
-  // Also lets handleSortingChange compute the next sorting outside of a
-  // state updater (state updaters must stay pure — they're double-invoked
-  // in StrictMode / Concurrent rendering).
-  //
-  // The ref is written inside useInsertionEffect so writes happen on commit,
-  // not during render — a speculative render that React discards must not
-  // leave stale values behind. useInsertionEffect fires before any other
-  // effect on the same commit, so every downstream reader sees the latest
-  // committed values.
+  // Latest reactive values held in a ref so handleDebouncedSearchChange
+  // can read fresh state for its scroll-on-clear check without becoming
+  // reactive itself (SearchBar subscribes via useEffect on the callback,
+  // so the callback must keep a stable identity). Writes happen in a
+  // layout effect to avoid mutating during render — a speculative render
+  // that React discards must not leave stale values behind.
   const latestRef = useRef({
-    sorting,
     artistFilter,
     albumFilter,
     currentTrack,
     playbackSource,
     scrollToTrack,
   });
-  useInsertionEffect(() => {
-    latestRef.current.sorting = sorting;
+  useLayoutEffect(() => {
     latestRef.current.artistFilter = artistFilter;
     latestRef.current.albumFilter = albumFilter;
     latestRef.current.currentTrack = currentTrack;
@@ -357,65 +349,53 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     latestRef.current.scrollToTrack = scrollToTrack;
   });
 
-  // Single source of truth for changing the global filter: updates local
-  // state, persists to store, and snaps to the current track when the user
-  // clears a non-empty filter. Called from both SearchBar (debounced typing)
-  // and handleSearchToggle (close-button clear).
-  const applyGlobalFilter = useCallback(
+  // Change the global filter. The store is the single source of truth —
+  // setSearchFilter fans out internally to libraryViewState.filtering, so
+  // this handler does nothing more than (a) write the store and (b) run
+  // the scroll-on-clear side effect when the user has just cleared a
+  // non-empty filter. Called from SearchBar's debounced flow and from
+  // handleSearchToggle (close-button clear).
+  const handleDebouncedSearchChange = useCallback(
     (value: string) => {
-      const prev = globalFilterRef.current;
-      setGlobalFilter(value);
-      globalFilterRef.current = value;
-
-      const latest = latestRef.current;
-      updateLibraryViewState(latest.sorting, value);
+      const prev = useLibraryStore.getState().searchFilters.library ?? '';
       setSearchFilter('library', value);
 
-      if (
-        prev &&
-        !value &&
-        latest.currentTrack &&
-        latest.playbackSource === 'library'
-      ) {
-        const visibleTrackIds = getFilteredAndSortedTrackIds(
-          'library',
-          latest.artistFilter,
-          latest.albumFilter,
-        );
-        if (visibleTrackIds.includes(latest.currentTrack.id)) {
-          // Defer one frame so the table re-renders without the filter
-          // before we ask the virtualizer to scroll.
-          setTimeout(() => {
-            const ct = latestRef.current.currentTrack;
-            if (ct) latestRef.current.scrollToTrack(ct.id);
-          }, 100);
-        }
-      }
+      if (!prev || value) return;
+      const latest = latestRef.current;
+      if (!latest.currentTrack || latest.playbackSource !== 'library') return;
+
+      const visibleTrackIds = getFilteredAndSortedTrackIds(
+        'library',
+        latest.artistFilter,
+        latest.albumFilter,
+      );
+      if (!visibleTrackIds.includes(latest.currentTrack.id)) return;
+
+      // Defer one frame so the table re-renders without the filter
+      // before we ask the virtualizer to scroll.
+      setTimeout(() => {
+        const ct = latestRef.current.currentTrack;
+        if (ct) latestRef.current.scrollToTrack(ct.id);
+      }, 100);
     },
-    [updateLibraryViewState, setSearchFilter],
+    [setSearchFilter],
   );
 
-  const handleDebouncedSearchChange = applyGlobalFilter;
-
-  // Wrap the sorting setter so persistence happens at the event source
-  // instead of in a downstream effect. Compute `next` outside setSorting
-  // so the updater stays pure — React may call updater functions more
-  // than once and will discard the side effects of trial renders.
+  // Tanstack's OnChangeFn accepts either a value or an updater function.
+  // Resolve to a plain value and hand off to setLibrarySorting, which
+  // handles the full fan-out (in-memory, libraryViewState, DB persist).
   const handleSortingChange = useCallback(
     (updater: SortingState | ((old: SortingState) => SortingState)) => {
+      const current =
+        useSettingsAndPlaybackStore.getState().librarySorting ??
+        DEFAULT_LIBRARY_SORTING;
       const next =
         typeof updater === 'function'
-          ? (updater as (old: SortingState) => SortingState)(
-              latestRef.current.sorting,
-            )
+          ? (updater as (old: SortingState) => SortingState)(current)
           : updater;
-      setSorting(next);
-      updateLibraryViewState(next, globalFilterRef.current);
-      if (next.length > 0) {
-        setLibrarySorting(next);
-      }
+      setLibrarySorting(next);
     },
-    [updateLibraryViewState, setLibrarySorting],
+    [setLibrarySorting],
   );
 
   // Expose the scrollToTrack function to the window object
@@ -633,14 +613,14 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   const trackCount = useMemo(() => data.length, [data]);
 
   // Handle search toggle. Closing the bar clears the filter through
-  // applyGlobalFilter so persistence and scroll-on-clear both fire.
-  // Side effect lives outside setShowSearch because state updaters must
-  // stay pure — React may double-invoke them in StrictMode and discard
-  // the side effects of trial renders.
+  // handleDebouncedSearchChange so persistence and scroll-on-clear both
+  // fire. Side effect lives outside setShowSearch because state updaters
+  // must stay pure — React may double-invoke them in StrictMode and
+  // discard the side effects of trial renders.
   const handleSearchToggle = useCallback(() => {
-    if (showSearch) applyGlobalFilter('');
+    if (showSearch) handleDebouncedSearchChange('');
     setShowSearch((prev) => !prev);
-  }, [showSearch, applyGlobalFilter]);
+  }, [showSearch, handleDebouncedSearchChange]);
 
   // Mark table as ready after the next frame so the virtualizer has
   // measured rows for the new sorting/filter/data.
@@ -862,7 +842,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
             }}
           >
             <SearchBar
-              initialValue={globalFilterRef.current}
+              initialValue={globalFilter}
               onClose={handleSearchToggle}
               onDebouncedChange={handleDebouncedSearchChange}
             />
@@ -936,6 +916,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
       showSearch,
       handleSearchToggle,
       handleDebouncedSearchChange,
+      globalFilter,
       browserOpen,
       setBrowserOpen,
     ],

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -3,7 +3,6 @@ import React, {
   useMemo,
   useRef,
   useEffect,
-  useLayoutEffect,
   useCallback,
 } from 'react';
 import {
@@ -263,37 +262,32 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     setMultiSelectPlaylistDialogOpen(false);
   };
 
-  // Function to scroll to a specific track by ID
-  const scrollToTrack = useCallback(
-    (trackId: string) => {
-      if (!rowVirtualizerRef.current) return;
+  // Scroll to a specific track by ID. Stable across renders — refs are
+  // stable containers, and the fallback path reads browser filters from
+  // the store at call time rather than closing over reactive values.
+  const scrollToTrack = useCallback((trackId: string) => {
+    if (!rowVirtualizerRef.current) return;
 
-      // Use the table's actual row model to find the track index
-      let trackIndex = -1;
+    let trackIndex = -1;
+    if (tableRef.current) {
+      const { rows } = tableRef.current.getRowModel();
+      trackIndex = rows.findIndex((row) => row.original.id === trackId);
+    }
 
-      if (tableRef.current) {
-        const { rows } = tableRef.current.getRowModel();
-        trackIndex = rows.findIndex((row) => row.original.id === trackId);
-      }
+    // Fallback: if tanstack's row model isn't populated yet, compute
+    // the index from the store directly.
+    if (trackIndex === -1) {
+      const libState = useLibraryStore.getState();
+      const af = libState.browserFilters.library?.artist ?? null;
+      const alf = libState.browserFilters.library?.album ?? null;
+      const trackIds = getFilteredAndSortedTrackIds('library', af, alf);
+      trackIndex = trackIds.indexOf(trackId);
+    }
 
-      // Fallback to calculating the index if table isn't ready yet
-      if (trackIndex === -1) {
-        const trackIds = getFilteredAndSortedTrackIds(
-          'library',
-          artistFilter,
-          albumFilter,
-        );
-        trackIndex = trackIds.indexOf(trackId);
-      }
-
-      if (trackIndex !== -1) {
-        rowVirtualizerRef.current.scrollToIndex(trackIndex, {
-          align: 'center',
-        });
-      }
-    },
-    [artistFilter, albumFilter],
-  );
+    if (trackIndex !== -1) {
+      rowVirtualizerRef.current.scrollToIndex(trackIndex, { align: 'center' });
+    }
+  }, []);
 
   // Function that waits for the table to be ready before scrolling
   const scrollToTrackWhenReady = useCallback(
@@ -328,57 +322,39 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [scrollToTrack],
   );
 
-  // Latest reactive values held in a ref so handleDebouncedSearchChange
-  // can read fresh state for its scroll-on-clear check without becoming
-  // reactive itself (SearchBar subscribes via useEffect on the callback,
-  // so the callback must keep a stable identity). Writes happen in a
-  // layout effect to avoid mutating during render — a speculative render
-  // that React discards must not leave stale values behind.
-  const latestRef = useRef({
-    artistFilter,
-    albumFilter,
-    currentTrack,
-    playbackSource,
-    scrollToTrack,
-  });
-  useLayoutEffect(() => {
-    latestRef.current.artistFilter = artistFilter;
-    latestRef.current.albumFilter = albumFilter;
-    latestRef.current.currentTrack = currentTrack;
-    latestRef.current.playbackSource = playbackSource;
-    latestRef.current.scrollToTrack = scrollToTrack;
-  });
-
   // Change the global filter. The store is the single source of truth —
   // setSearchFilter fans out internally to libraryViewState.filtering, so
   // this handler does nothing more than (a) write the store and (b) run
   // the scroll-on-clear side effect when the user has just cleared a
-  // non-empty filter. Called from SearchBar's debounced flow and from
-  // handleSearchToggle (close-button clear).
+  // non-empty filter. Reactive values are read fresh from stores at call
+  // time rather than captured in a latestRef — the callback closes over
+  // nothing that changes, so its identity is stable without any ref
+  // plumbing, and SearchBar's debounce subscription doesn't re-fire.
   const handleDebouncedSearchChange = useCallback(
     (value: string) => {
-      const prev = useLibraryStore.getState().searchFilters.library ?? '';
+      const libState = useLibraryStore.getState();
+      const prev = libState.searchFilters.library ?? '';
       setSearchFilter('library', value);
 
       if (!prev || value) return;
-      const latest = latestRef.current;
-      if (!latest.currentTrack || latest.playbackSource !== 'library') return;
 
-      const visibleTrackIds = getFilteredAndSortedTrackIds(
-        'library',
-        latest.artistFilter,
-        latest.albumFilter,
-      );
-      if (!visibleTrackIds.includes(latest.currentTrack.id)) return;
+      const playState = useSettingsAndPlaybackStore.getState();
+      if (!playState.currentTrack || playState.playbackSource !== 'library')
+        return;
+
+      const af = libState.browserFilters.library?.artist ?? null;
+      const alf = libState.browserFilters.library?.album ?? null;
+      const visibleTrackIds = getFilteredAndSortedTrackIds('library', af, alf);
+      if (!visibleTrackIds.includes(playState.currentTrack.id)) return;
 
       // Defer one frame so the table re-renders without the filter
       // before we ask the virtualizer to scroll.
       setTimeout(() => {
-        const ct = latestRef.current.currentTrack;
-        if (ct) latestRef.current.scrollToTrack(ct.id);
+        const ct = useSettingsAndPlaybackStore.getState().currentTrack;
+        if (ct) scrollToTrack(ct.id);
       }, 100);
     },
-    [setSearchFilter],
+    [setSearchFilter, scrollToTrack],
   );
 
   // Tanstack's OnChangeFn accepts either a value or an updater function.
@@ -546,13 +522,12 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
       const middleIndex = Math.floor(
         (visibleRange.startIndex + visibleRange.endIndex) / 2,
       );
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      const latest = latestRef.current;
-      const trackIds = getFilteredAndSortedTrackIds(
-        'library',
-        latest.artistFilter,
-        latest.albumFilter,
-      );
+      // Read browser filters fresh from the store at unmount time so
+      // the lookup list matches what the virtualizer was rendering.
+      const libState = useLibraryStore.getState();
+      const af = libState.browserFilters.library?.artist ?? null;
+      const alf = libState.browserFilters.library?.album ?? null;
+      const trackIds = getFilteredAndSortedTrackIds('library', af, alf);
       if (trackIds[middleIndex]) {
         setLastViewedTrackId(trackIds[middleIndex]);
       }

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -360,19 +360,17 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // Tanstack's OnChangeFn accepts either a value or an updater function.
   // Resolve to a plain value and hand off to setLibrarySorting, which
   // handles the full fan-out (in-memory, libraryViewState, DB persist).
-  const handleSortingChange = useCallback(
-    (updater: SortingState | ((old: SortingState) => SortingState)) => {
-      const current =
-        useSettingsAndPlaybackStore.getState().librarySorting ??
-        DEFAULT_LIBRARY_SORTING;
-      const next =
-        typeof updater === 'function'
-          ? (updater as (old: SortingState) => SortingState)(current)
-          : updater;
-      setLibrarySorting(next);
-    },
-    [setLibrarySorting],
-  );
+  // No useCallback: VirtualTable isn't memoized, so identity stability
+  // would be cargo-culted ceremony.
+  const handleSortingChange = (
+    updater: SortingState | ((old: SortingState) => SortingState),
+  ) => {
+    const current =
+      useSettingsAndPlaybackStore.getState().librarySorting ??
+      DEFAULT_LIBRARY_SORTING;
+    const next = typeof updater === 'function' ? updater(current) : updater;
+    setLibrarySorting(next);
+  };
 
   // Expose the scrollToTrack function to the window object
   useEffect(() => {

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -143,7 +143,6 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   const getSearchFilter = useLibraryStore((state) => state.getSearchFilter);
   const browserOpen = useUIStore((state) => state.browserOpen);
   const setBrowserOpen = useUIStore((state) => state.setBrowserOpen);
-  const libraryViewState = useLibraryStore((state) => state.libraryViewState);
   const [showSearch, setShowSearch] = useState(() =>
     Boolean(getSearchFilter('library')),
   );
@@ -177,10 +176,14 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
   const globalFilterRef = useRef(globalFilter);
 
-  // Sorting state - initialize from store to persist across unmount/remount
-  const [sorting, setSorting] = useState<SortingState>(
-    () => libraryViewState.sorting || [{ id: 'albumArtist', desc: false }],
-  );
+  // Sorting state - initialize from store to persist across unmount/remount.
+  // Read via getState() at init time only: we don't want to subscribe to
+  // libraryViewState because we write to it on every sort/search change,
+  // which would re-render this component for data it no longer reads.
+  const [sorting, setSorting] = useState<SortingState>(() => {
+    const stored = useLibraryStore.getState().libraryViewState.sorting;
+    return stored || [{ id: 'albumArtist', desc: false }];
+  });
 
   // Add row virtualizer ref
   const rowVirtualizerRef = useRef<Virtualizer<HTMLDivElement, Element> | null>(
@@ -328,6 +331,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // Latest reactive values held in a ref so handlers below can read fresh
   // state without becoming reactive themselves (keeps callback identity
   // stable for SearchBar, which subscribes via useEffect on the callback).
+  // Also lets handleSortingChange compute the next sorting outside of a
+  // state updater (state updaters must stay pure — they're double-invoked
+  // in StrictMode / Concurrent rendering).
   const latestRef = useRef({
     sorting,
     artistFilter,
@@ -336,14 +342,12 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     playbackSource,
     scrollToTrack,
   });
-  latestRef.current = {
-    sorting,
-    artistFilter,
-    albumFilter,
-    currentTrack,
-    playbackSource,
-    scrollToTrack,
-  };
+  latestRef.current.sorting = sorting;
+  latestRef.current.artistFilter = artistFilter;
+  latestRef.current.albumFilter = albumFilter;
+  latestRef.current.currentTrack = currentTrack;
+  latestRef.current.playbackSource = playbackSource;
+  latestRef.current.scrollToTrack = scrollToTrack;
 
   // Single source of truth for changing the global filter: updates local
   // state, persists to store, and snaps to the current track when the user
@@ -386,20 +390,22 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   const handleDebouncedSearchChange = applyGlobalFilter;
 
   // Wrap the sorting setter so persistence happens at the event source
-  // instead of in a downstream effect.
+  // instead of in a downstream effect. Compute `next` outside setSorting
+  // so the updater stays pure — React may call updater functions more
+  // than once and will discard the side effects of trial renders.
   const handleSortingChange = useCallback(
     (updater: SortingState | ((old: SortingState) => SortingState)) => {
-      setSorting((prev) => {
-        const next =
-          typeof updater === 'function'
-            ? (updater as (old: SortingState) => SortingState)(prev)
-            : updater;
-        updateLibraryViewState(next, globalFilterRef.current);
-        if (next && next.length > 0) {
-          setLibrarySorting(next);
-        }
-        return next;
-      });
+      const next =
+        typeof updater === 'function'
+          ? (updater as (old: SortingState) => SortingState)(
+              latestRef.current.sorting,
+            )
+          : updater;
+      setSorting(next);
+      updateLibraryViewState(next, globalFilterRef.current);
+      if (next.length > 0) {
+        setLibrarySorting(next);
+      }
     },
     [updateLibraryViewState, setLibrarySorting],
   );

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -3,6 +3,7 @@ import React, {
   useMemo,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
 } from 'react';
 import {
@@ -176,12 +177,6 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
   const globalFilterRef = useRef(globalFilter);
 
-  // Stable callback for SearchBar — never changes identity
-  const handleDebouncedSearchChange = useCallback((value: string) => {
-    setGlobalFilter(value);
-    globalFilterRef.current = value;
-  }, []);
-
   // Sorting state - initialize from store to persist across unmount/remount
   const [sorting, setSorting] = useState<SortingState>(
     () => libraryViewState.sorting || [{ id: 'albumArtist', desc: false }],
@@ -330,13 +325,91 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [scrollToTrack],
   );
 
+  // Latest reactive values held in a ref so handlers below can read fresh
+  // state without becoming reactive themselves (keeps callback identity
+  // stable for SearchBar, which subscribes via useEffect on the callback).
+  const latestRef = useRef({
+    sorting,
+    artistFilter,
+    albumFilter,
+    currentTrack,
+    playbackSource,
+    scrollToTrack,
+  });
+  latestRef.current = {
+    sorting,
+    artistFilter,
+    albumFilter,
+    currentTrack,
+    playbackSource,
+    scrollToTrack,
+  };
+
+  // Single source of truth for changing the global filter: updates local
+  // state, persists to store, and snaps to the current track when the user
+  // clears a non-empty filter. Called from both SearchBar (debounced typing)
+  // and handleSearchToggle (close-button clear).
+  const applyGlobalFilter = useCallback(
+    (value: string) => {
+      const prev = globalFilterRef.current;
+      setGlobalFilter(value);
+      globalFilterRef.current = value;
+
+      const latest = latestRef.current;
+      updateLibraryViewState(latest.sorting, value);
+      setSearchFilter('library', value);
+
+      if (
+        prev &&
+        !value &&
+        latest.currentTrack &&
+        latest.playbackSource === 'library'
+      ) {
+        const visibleTrackIds = getFilteredAndSortedTrackIds(
+          'library',
+          latest.artistFilter,
+          latest.albumFilter,
+        );
+        if (visibleTrackIds.includes(latest.currentTrack.id)) {
+          // Defer one frame so the table re-renders without the filter
+          // before we ask the virtualizer to scroll.
+          setTimeout(() => {
+            const ct = latestRef.current.currentTrack;
+            if (ct) latestRef.current.scrollToTrack(ct.id);
+          }, 100);
+        }
+      }
+    },
+    [updateLibraryViewState, setSearchFilter],
+  );
+
+  const handleDebouncedSearchChange = applyGlobalFilter;
+
+  // Wrap the sorting setter so persistence happens at the event source
+  // instead of in a downstream effect.
+  const handleSortingChange = useCallback(
+    (updater: SortingState | ((old: SortingState) => SortingState)) => {
+      setSorting((prev) => {
+        const next =
+          typeof updater === 'function'
+            ? (updater as (old: SortingState) => SortingState)(prev)
+            : updater;
+        updateLibraryViewState(next, globalFilterRef.current);
+        if (next && next.length > 0) {
+          setLibrarySorting(next);
+        }
+        return next;
+      });
+    },
+    [updateLibraryViewState, setLibrarySorting],
+  );
+
   // Expose the scrollToTrack function to the window object
   useEffect(() => {
     window.hihatScrollToLibraryTrack = scrollToTrackWhenReady;
 
     return () => {
       delete window.hihatScrollToLibraryTrack;
-      tableReadyRef.current = false;
     };
   }, [scrollToTrackWhenReady]);
 
@@ -462,36 +535,38 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     }
   };
 
-  // Save the currently visible track on unmount
+  // Save the currently visible track on unmount. Read the virtualizer
+  // through the ref *inside* the cleanup so we see its real value at
+  // unmount time, not the (typically null) value at first mount.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const virtualizerRefCurrent = rowVirtualizerRef.current;
     return () => {
-      if (virtualizerRefCurrent) {
-        const visibleRange = virtualizerRefCurrent.range;
-
-        if (visibleRange) {
-          const middleIndex = Math.floor(
-            (visibleRange.startIndex + visibleRange.endIndex) / 2,
-          );
-
-          const trackIds = getFilteredAndSortedTrackIds('library');
-
-          if (trackIds[middleIndex]) {
-            setLastViewedTrackId(trackIds[middleIndex]);
-          }
-        }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const virt = rowVirtualizerRef.current;
+      if (!virt) return;
+      const visibleRange = virt.range;
+      if (!visibleRange) return;
+      const middleIndex = Math.floor(
+        (visibleRange.startIndex + visibleRange.endIndex) / 2,
+      );
+      const trackIds = getFilteredAndSortedTrackIds('library');
+      if (trackIds[middleIndex]) {
+        setLastViewedTrackId(trackIds[middleIndex]);
       }
     };
   }, [setLastViewedTrackId]);
 
-  // Restore scroll position on mount
+  // Restore scroll position on mount, exactly once. Without the guard this
+  // re-fires whenever tracks reload or the filter changes and yanks the
+  // user back to the saved track. scrollToTrackWhenReady polls until the
+  // table is rendered, so we don't need a timeout race.
+  const scrollRestoredRef = useRef(false);
   useEffect(() => {
-    if (lastViewedTrackId && rowVirtualizerRef.current && tracks.length > 0) {
-      setTimeout(() => {
-        scrollToTrack(lastViewedTrackId);
-      }, 100);
-    }
-  }, [lastViewedTrackId, scrollToTrack, tracks.length]);
+    if (scrollRestoredRef.current) return;
+    if (!lastViewedTrackId || tracks.length === 0) return;
+    scrollRestoredRef.current = true;
+    scrollToTrackWhenReady(lastViewedTrackId);
+  }, [lastViewedTrackId, tracks.length, scrollToTrackWhenReady]);
 
   // Get columns from shared configuration
   const columns = useMemo(() => getCommonColumnDefs(), []);
@@ -534,73 +609,27 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   const totalHours = useMemo(() => calculateTotalHours(data), [data]);
   const trackCount = useMemo(() => data.length, [data]);
 
-  // Track previous global filter for detecting clears
-  const prevGlobalFilterRef = useRef(globalFilter);
-
-  // Persist global filter to store and handle scroll-to-track on clear
-  useEffect(() => {
-    const prevFilter = prevGlobalFilterRef.current;
-    prevGlobalFilterRef.current = globalFilter;
-
-    updateLibraryViewState(sorting, globalFilter);
-    setSearchFilter('library', globalFilter);
-
-    // Persist library sorting preference to DB
-    if (sorting && sorting.length > 0) {
-      setLibrarySorting(sorting);
-    }
-
-    if (
-      prevFilter &&
-      !globalFilter &&
-      currentTrack &&
-      playbackSource === 'library'
-    ) {
-      const visibleTrackIds = getFilteredAndSortedTrackIds(
-        'library',
-        artistFilter,
-        albumFilter,
-      );
-      if (visibleTrackIds.includes(currentTrack.id)) {
-        setTimeout(() => {
-          scrollToTrack(currentTrack.id);
-        }, 100);
-      }
-    }
-  }, [
-    globalFilter,
-    sorting,
-    updateLibraryViewState,
-    setSearchFilter,
-    setLibrarySorting,
-    currentTrack,
-    playbackSource,
-    artistFilter,
-    albumFilter,
-    scrollToTrack,
-  ]);
-
-  // Handle search toggle
+  // Handle search toggle. Closing the bar clears the filter through
+  // applyGlobalFilter so persistence and scroll-on-clear both fire.
   const handleSearchToggle = useCallback(() => {
     setShowSearch((prev) => {
       if (prev) {
-        setGlobalFilter('');
-        globalFilterRef.current = '';
-        setSearchFilter('library', '');
+        applyGlobalFilter('');
       }
       return !prev;
     });
-  }, [setSearchFilter]);
+  }, [applyGlobalFilter]);
 
-  // Mark table as ready after render completes
-  useEffect(() => {
+  // Mark table as ready after layout commits. useLayoutEffect runs after
+  // DOM mutations but before paint, so by the time the rAF callback fires
+  // the virtualizer has measured rows for the new sorting/filter/data.
+  useLayoutEffect(() => {
+    tableReadyRef.current = false;
     const rafId = requestAnimationFrame(() => {
       tableReadyRef.current = true;
     });
-
     return () => {
       cancelAnimationFrame(rafId);
-      tableReadyRef.current = false;
     };
   }, [sorting, globalFilter, data.length]);
 
@@ -1006,7 +1035,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
           onRowContextMenu={handleRowContextMenu}
           onRowDoubleClick={handleRowDoubleClick}
           onRowDragStart={handleRowDragStart}
-          onSortingChange={setSorting}
+          onSortingChange={handleSortingChange}
           selectedTrackIds={selectedTrackIdsList}
           sorting={sorting}
           tableRef={tableRef}

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -320,14 +320,10 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [scrollToTrack],
   );
 
-  // Change the global filter. The store is the single source of truth —
-  // setSearchFilter fans out internally to libraryViewState.filtering, so
-  // this handler does nothing more than (a) write the store and (b) run
-  // the scroll-on-clear side effect when the user has just cleared a
-  // non-empty filter. Reactive values are read fresh from stores at call
-  // time rather than captured in a latestRef — the callback closes over
-  // nothing that changes, so its identity is stable without any ref
-  // plumbing, and SearchBar's debounce subscription doesn't re-fire.
+  // Writes filter to the store (which fan-outs internally) and snaps
+  // scroll to the playing track when clearing a non-empty filter. Reads
+  // store state fresh per call so the callback's identity stays stable —
+  // SearchBar's debounce subscription won't re-fire.
   const handleDebouncedSearchChange = useCallback(
     (value: string) => {
       const libState = useLibraryStore.getState();
@@ -355,11 +351,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [setSearchFilter, scrollToTrack],
   );
 
-  // Tanstack's OnChangeFn accepts either a value or an updater function.
-  // Resolve to a plain value and hand off to setLibrarySorting, which
-  // handles the full fan-out (in-memory, libraryViewState, DB persist).
-  // No useCallback: VirtualTable isn't memoized, so identity stability
-  // would be cargo-culted ceremony.
+  // Resolve Tanstack's updater-or-value to a plain value for
+  // setLibrarySorting (fan-outs to state + viewState + DB). No
+  // useCallback — VirtualTable isn't memoized.
   const handleSortingChange = (
     updater: SortingState | ((old: SortingState) => SortingState),
   ) => {
@@ -501,13 +495,10 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     }
   };
 
-  // Save the currently visible track on unmount. Read the virtualizer
-  // through the ref *inside* the cleanup so we see its real value at
-  // unmount time, not the (typically null) value at first mount. The
-  // virtualizer's range indexes the browser-filtered rows, so we must
-  // resolve it against the same artist/album filters via latestRef —
-  // otherwise we save the wrong track whenever a browser filter is
-  // active at unmount.
+  // Save visible track on unmount. Read virtualizer + filters inside
+  // the cleanup — the ref is null at mount, and the virtualizer's range
+  // indexes browser-filtered rows, so a stale filter means we save the
+  // wrong track.
   useEffect(() => {
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -530,10 +521,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     };
   }, [setLastViewedTrackId]);
 
-  // Restore scroll position on mount, exactly once. Without the guard this
-  // re-fires whenever tracks reload or the filter changes and yanks the
-  // user back to the saved track. scrollToTrackWhenReady polls until the
-  // table is rendered, so we don't need a timeout race.
+  // Restore scroll on mount, exactly once. Without the guard this
+  // re-fires on track reloads / filter changes and yanks the user back.
+  // scrollToTrackWhenReady polls for readiness, so no timeout race.
   const scrollRestoredRef = useRef(false);
   useEffect(() => {
     if (scrollRestoredRef.current) return;
@@ -583,11 +573,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // useMemo: O(n) reduce over track durations.
   const totalHours = useMemo(() => calculateTotalHours(data), [data]);
 
-  // Handle search toggle. Closing the bar clears the filter through
-  // handleDebouncedSearchChange so persistence and scroll-on-clear both
-  // fire. Side effect lives outside setShowSearch because state updaters
-  // must stay pure — React may double-invoke them in StrictMode and
-  // discard the side effects of trial renders.
+  // Closing routes through handleDebouncedSearchChange so persistence
+  // + scroll-on-clear both fire. Side effect lives outside setShowSearch
+  // — StrictMode double-invokes state updaters and would discard it.
   const handleSearchToggle = useCallback(() => {
     if (showSearch) handleDebouncedSearchChange('');
     setShowSearch((prev) => !prev);
@@ -1115,9 +1103,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
 }
 
-// React.memo with default shallow comparison lets MainLayout re-render
-// (settings drawer toggle, notifications, mini player sync, etc.) without
-// forcing Library — an expensive component with many hooks and a
-// virtualized table — to re-render. Library's only props are drawerOpen
-// and onDrawerToggle, so the default shallow compare is sufficient.
+// Shields Library from MainLayout re-renders (drawer toggle,
+// notifications, player sync, etc.). Props are primitive + stable
+// useCallback, so the default shallow compare is sufficient.
 export default React.memo(Library);

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -162,13 +162,11 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
   const [browserHeight, setBrowserHeight] = useState(200);
 
-  // Derive artist/album filter from browser filters
-  const libraryBrowserFilter = useMemo(
-    () => browserFilters.library || { artist: null, album: null },
-    [browserFilters],
-  );
-  const artistFilter = libraryBrowserFilter.artist;
-  const albumFilter = libraryBrowserFilter.album;
+  // Derive artist/album filter scalars directly from the browser filter
+  // dictionary. No useMemo: each value is a primitive, and the consumers
+  // below only need the scalar values or construct their own object.
+  const artistFilter = browserFilters.library?.artist ?? null;
+  const albumFilter = browserFilters.library?.album ?? null;
 
   const handleArtistSelect = useCallback(
     (artist: string | null) => {
@@ -179,9 +177,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
 
   const handleAlbumSelect = useCallback(
     (album: string | null) => {
-      setBrowserFilter('library', { ...libraryBrowserFilter, album });
+      setBrowserFilter('library', { artist: artistFilter, album });
     },
-    [setBrowserFilter, libraryBrowserFilter],
+    [setBrowserFilter, artistFilter],
   );
 
   // Add row virtualizer ref
@@ -583,7 +581,6 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
 
   // Memoize total hours calculation to avoid recalculating on every render
   const totalHours = useMemo(() => calculateTotalHours(data), [data]);
-  const trackCount = useMemo(() => data.length, [data]);
 
   // Handle search toggle. Closing the bar clears the filter through
   // handleDebouncedSearchChange so persistence and scroll-on-clear both
@@ -700,12 +697,6 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     setColumnOrder(newOrder);
   };
 
-  // Drag-and-drop: compute selected track IDs list
-  const selectedTrackIdsList = useMemo(
-    () => Object.keys(selectedTracks),
-    [selectedTracks],
-  );
-
   const handleRowDragStart = (
     trackId: string,
     selectedIds: string[],
@@ -768,7 +759,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
             }}
             variant="body2"
           >
-            {trackCount.toLocaleString()}&nbsp;&#9835;
+            {data.length.toLocaleString()}&nbsp;&#9835;
           </Typography>
         </Box>
         <Box
@@ -884,7 +875,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
     [
       drawerOpen,
       onDrawerToggle,
-      trackCount,
+      data.length,
       totalHours,
       showSearch,
       handleSearchToggle,
@@ -1011,7 +1002,7 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
           onRowDoubleClick={handleRowDoubleClick}
           onRowDragStart={handleRowDragStart}
           onSortingChange={handleSortingChange}
-          selectedTrackIds={selectedTrackIdsList}
+          selectedTrackIds={Object.keys(selectedTracks)}
           sorting={sorting}
           tableRef={tableRef}
           toolbar={toolbarContent}
@@ -1119,10 +1110,9 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
 }
 
-// Memoize the Library component to prevent unnecessary re-renders
-export default React.memo(Library, (prevProps, nextProps) => {
-  return (
-    prevProps.drawerOpen === nextProps.drawerOpen &&
-    prevProps.onDrawerToggle === nextProps.onDrawerToggle
-  );
-});
+// React.memo with default shallow comparison lets MainLayout re-render
+// (settings drawer toggle, notifications, mini player sync, etc.) without
+// forcing Library — an expensive component with many hooks and a
+// virtualized table — to re-render. Library's only props are drawerOpen
+// and onDrawerToggle, so the default shallow compare is sufficient.
+export default React.memo(Library);

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -561,22 +561,19 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   // Tanstack's OnChangeFn accepts either a value or an updater function.
   // Resolve to a plain value and hand off to setPlaylistSortPreference,
   // which handles the full fan-out (session cache, playlistViewState,
-  // DB persist).
-  const handleSortingChange = useCallback(
-    (updater: SortingState | ((old: SortingState) => SortingState)) => {
-      const state = useLibraryStore.getState();
-      const pid = state.selectedPlaylistId;
-      if (!pid) return;
-      const current =
-        state.playlistSortPreferences[pid] ?? DEFAULT_PLAYLIST_SORTING;
-      const next =
-        typeof updater === 'function'
-          ? (updater as (old: SortingState) => SortingState)(current)
-          : updater;
-      setPlaylistSortPreference(pid, next);
-    },
-    [setPlaylistSortPreference],
-  );
+  // DB persist). No useCallback: VirtualTable isn't memoized, so
+  // identity stability would be cargo-culted ceremony.
+  const handleSortingChange = (
+    updater: SortingState | ((old: SortingState) => SortingState),
+  ) => {
+    const state = useLibraryStore.getState();
+    const pid = state.selectedPlaylistId;
+    if (!pid) return;
+    const current =
+      state.playlistSortPreferences[pid] ?? DEFAULT_PLAYLIST_SORTING;
+    const next = typeof updater === 'function' ? updater(current) : updater;
+    setPlaylistSortPreference(pid, next);
+  };
 
   // Handle search toggle. Closing the bar clears the filter through
   // handleDebouncedSearchChange so persistence and scroll-on-clear both

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -158,16 +158,15 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   const setBrowserFilter = useLibraryStore((state) => state.setBrowserFilter);
   const [browserHeight, setBrowserHeight] = useState(200);
 
-  // Derive browser filter for current playlist
-  const playlistBrowserFilter = useMemo(
-    () =>
-      selectedPlaylistId
-        ? browserFilters[selectedPlaylistId] || { artist: null, album: null }
-        : { artist: null, album: null },
-    [browserFilters, selectedPlaylistId],
-  );
-  const playlistArtistFilter = playlistBrowserFilter.artist;
-  const playlistAlbumFilter = playlistBrowserFilter.album;
+  // Derive browser filter scalars for the currently-selected playlist
+  // directly from the browser filter dictionary. No useMemo: primitives
+  // are compared by value downstream.
+  const playlistArtistFilter = selectedPlaylistId
+    ? (browserFilters[selectedPlaylistId]?.artist ?? null)
+    : null;
+  const playlistAlbumFilter = selectedPlaylistId
+    ? (browserFilters[selectedPlaylistId]?.album ?? null)
+    : null;
 
   const handleBrowserArtistSelect = useCallback(
     (artist: string | null) => {
@@ -182,12 +181,12 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     (album: string | null) => {
       if (selectedPlaylistId) {
         setBrowserFilter(selectedPlaylistId, {
-          ...playlistBrowserFilter,
+          artist: playlistArtistFilter,
           album,
         });
       }
     },
-    [selectedPlaylistId, setBrowserFilter, playlistBrowserFilter],
+    [selectedPlaylistId, setBrowserFilter, playlistArtistFilter],
   );
 
   // Confirmation dialog state
@@ -213,26 +212,14 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   const playlistNameRef = useRef<HTMLDivElement>(null);
   const playlistNameRef2 = useRef<HTMLDivElement>(null);
 
-  // Define getPlaylistTracks as a useCallback to use it in dependencies
-  const getPlaylistTracks = useCallback(() => {
-    if (!selectedPlaylistId || !playlists) {
-      return [];
-    }
-
+  // Memoize the playlist tracks to prevent unnecessary re-renders. Reads
+  // the store's getTracksByIds via the trackIndex map for O(n) lookup.
+  const playlistTracks = useMemo(() => {
+    if (!selectedPlaylistId || !playlists) return [];
     const selectedPlaylist = playlists.find((p) => p.id === selectedPlaylistId);
-    if (!selectedPlaylist) {
-      return [];
-    }
-
-    const { getTracksByIds } = useLibraryStore.getState();
-    return getTracksByIds(selectedPlaylist.trackIds);
+    if (!selectedPlaylist) return [];
+    return useLibraryStore.getState().getTracksByIds(selectedPlaylist.trackIds);
   }, [selectedPlaylistId, playlists]);
-
-  // Memoize the playlist tracks to prevent unnecessary re-renders
-  const playlistTracks = useMemo(
-    () => getPlaylistTracks(),
-    [getPlaylistTracks],
-  );
 
   const handlePlayTrack = (trackId: string) => {
     // No manual updatePlaylistViewState call needed — the store keeps
@@ -584,11 +571,8 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     setShowSearch((prev) => !prev);
   }, [showSearch, handleDebouncedSearchChange]);
 
-  // Memoize playlist track count and hours for stable toolbar deps
-  const playlistTrackCount = useMemo(
-    () => playlistTracks.length,
-    [playlistTracks],
-  );
+  // Total hours is O(n) over playlist tracks — worth memoizing. Track
+  // count is just playlistTracks.length, read inline.
   const playlistTotalHours = useMemo(
     () => calculateTotalHours(playlistTracks),
     [playlistTracks],
@@ -699,12 +683,6 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     setColumnOrder(newOrder);
   };
 
-  // Drag-and-drop: compute selected track IDs list
-  const selectedTrackIdsList = useMemo(
-    () => Object.keys(selectedTracks),
-    [selectedTracks],
-  );
-
   const handleRowDragStart = (
     trackId: string,
     selectedIds: string[],
@@ -791,7 +769,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
             }}
             variant="body2"
           >
-            {playlistTrackCount.toLocaleString()}&nbsp;&#9835;
+            {playlistTracks.length.toLocaleString()}&nbsp;&#9835;
           </Typography>
         </Box>
         <Box
@@ -913,7 +891,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     playlists,
     showSearch,
     globalFilter,
-    playlistTrackCount,
+    playlistTracks.length,
     playlistTotalHours,
     handleSearchToggle,
     handleDebouncedSearchChange,
@@ -1041,7 +1019,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
             onRowDoubleClick={handleRowDoubleClick}
             onRowDragStart={handleRowDragStart}
             onSortingChange={handleSortingChange}
-            selectedTrackIds={selectedTrackIdsList}
+            selectedTrackIds={Object.keys(selectedTracks)}
             sorting={sorting}
             tableRef={tableRef}
             toolbar={toolbarContent}
@@ -1161,10 +1139,9 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
 }
 
-// Memoize Playlists component to prevent unnecessary re-renders
-export default React.memo(Playlists, (prevProps, nextProps) => {
-  return (
-    prevProps.drawerOpen === nextProps.drawerOpen &&
-    prevProps.onDrawerToggle === nextProps.onDrawerToggle
-  );
-});
+// React.memo with default shallow comparison lets MainLayout re-render
+// (settings drawer toggle, notifications, mini player sync, etc.) without
+// forcing Playlists — an expensive component with many hooks and a
+// virtualized table — to re-render. Playlists' only props are drawerOpen
+// and onDrawerToggle, so the default shallow compare is sufficient.
+export default React.memo(Playlists);

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useCallback,
   useEffect,
+  useLayoutEffect,
 } from 'react';
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { keyframes } from '@mui/system';
@@ -48,6 +49,12 @@ const searchExpandAnimation = keyframes`
   }
 `;
 
+// Stable module-level default so selector fallbacks return the same
+// reference on every render, preventing spurious Zustand re-renders.
+const DEFAULT_PLAYLIST_SORTING: SortingState = [
+  { id: 'albumArtist', desc: false },
+];
+
 // Define props interface for Playlists component
 interface PlaylistsProps {
   drawerOpen: boolean;
@@ -61,15 +68,25 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   const selectedPlaylistId = useLibraryStore(
     (state) => state.selectedPlaylistId,
   );
-  const updatePlaylistViewState = useLibraryStore(
-    (state) => state.updatePlaylistViewState,
-  );
-  const playlistViewState = useLibraryStore((state) => state.playlistViewState);
   const setPlaylistSortPreference = useLibraryStore(
     (state) => state.setPlaylistSortPreference,
   );
   const setSearchFilter = useLibraryStore((state) => state.setSearchFilter);
-  const getSearchFilter = useLibraryStore((state) => state.getSearchFilter);
+
+  // Sort and filter for the selected playlist are read directly from
+  // the store via selectors. setPlaylistSortPreference and
+  // setSearchFilter handle the full fan-out to playlistViewState, so
+  // this component does nothing beyond writing one value at a time.
+  const sorting = useLibraryStore((state) => {
+    const pid = state.selectedPlaylistId;
+    if (!pid) return DEFAULT_PLAYLIST_SORTING;
+    return state.playlistSortPreferences[pid] ?? DEFAULT_PLAYLIST_SORTING;
+  });
+  const globalFilter = useLibraryStore((state) => {
+    const pid = state.selectedPlaylistId;
+    if (!pid) return '';
+    return state.searchFilters[pid] ?? '';
+  });
 
   // Get state from settings store
   const columnVisibility = useSettingsAndPlaybackStore(
@@ -101,23 +118,6 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     (state) => state.playbackSourcePlaylistId,
   );
 
-  // Sorting state - initialize from store to persist across unmount/remount
-  const [sorting, setSorting] = useState<SortingState>(
-    () => playlistViewState.sorting || [{ id: 'albumArtist', desc: false }],
-  );
-
-  // Global filter state — receives debounced values from SearchBar.
-  const [globalFilter, setGlobalFilter] = useState(() =>
-    selectedPlaylistId ? getSearchFilter(selectedPlaylistId) : '',
-  );
-  const globalFilterRef = useRef(globalFilter);
-
-  // Stable callback for SearchBar — never changes identity
-  const handleDebouncedSearchChange = useCallback((value: string) => {
-    setGlobalFilter(value);
-    globalFilterRef.current = value;
-  }, []);
-
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
     mouseX: number;
@@ -137,10 +137,20 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
   const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
 
-  // Search state
-  const [showSearch, setShowSearch] = useState(() =>
-    selectedPlaylistId ? !!getSearchFilter(selectedPlaylistId) : false,
-  );
+  // Search bar visibility. Initialized from store, then reset on every
+  // playlist switch via the "adjusting some state when a prop changes"
+  // pattern below — React docs explicitly recommend this over an effect.
+  const [showSearch, setShowSearch] = useState(() => {
+    const pid = useLibraryStore.getState().selectedPlaylistId;
+    if (!pid) return false;
+    return !!useLibraryStore.getState().searchFilters[pid];
+  });
+  const [lastSeenPlaylistId, setLastSeenPlaylistId] =
+    useState(selectedPlaylistId);
+  if (lastSeenPlaylistId !== selectedPlaylistId) {
+    setLastSeenPlaylistId(selectedPlaylistId);
+    setShowSearch(!!globalFilter);
+  }
 
   // Browser state
   const browserOpen = useUIStore((state) => state.browserOpen);
@@ -180,10 +190,6 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     },
     [selectedPlaylistId, setBrowserFilter, playlistBrowserFilter],
   );
-
-  // Track playlist switches to restore per-playlist sorting
-  const prevPlaylistIdRef = useRef(selectedPlaylistId);
-  const justSwitchedPlaylistRef = useRef(false);
 
   // Confirmation dialog state
   const [removeTrackConfirmOpen, setRemoveTrackConfirmOpen] = useState(false);
@@ -230,10 +236,9 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
 
   const handlePlayTrack = (trackId: string) => {
-    if (selectedPlaylistId) {
-      updatePlaylistViewState(sorting, globalFilter, selectedPlaylistId);
-    }
-
+    // No manual updatePlaylistViewState call needed — the store keeps
+    // playlistViewState in sync via selectPlaylist / setSearchFilter /
+    // setPlaylistSortPreference fan-outs.
     playTrack(trackId, 'playlist', selectedPlaylistId);
   };
 
@@ -414,41 +419,13 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     [scrollToTrack],
   );
 
-  // Expose the scrollToTrack function to the window object
+  // Expose the scrollToTrack function to the window object.
   useEffect(() => {
     window.hihatScrollToPlaylistTrack = scrollToTrackWhenReady;
-
     return () => {
       delete window.hihatScrollToPlaylistTrack;
-      tableReadyRef.current = false;
     };
   }, [scrollToTrackWhenReady]);
-
-  // Restore per-playlist sorting and search when switching playlists
-  useEffect(() => {
-    const prevId = prevPlaylistIdRef.current;
-    if (selectedPlaylistId) {
-      // Restore sorting
-      const prefs = useLibraryStore.getState().playlistSortPreferences;
-      const savedSorting = prefs[selectedPlaylistId];
-      setSorting(savedSorting || [{ id: 'albumArtist', desc: false }]);
-
-      // Save outgoing search, restore incoming search
-      if (prevId && prevId !== selectedPlaylistId) {
-        setSearchFilter(prevId, globalFilterRef.current);
-        justSwitchedPlaylistRef.current = true;
-      }
-      const savedFilter = getSearchFilter(selectedPlaylistId);
-      setGlobalFilter(savedFilter);
-      globalFilterRef.current = savedFilter;
-      setShowSearch(!!savedFilter);
-    } else {
-      setGlobalFilter('');
-      globalFilterRef.current = '';
-      setShowSearch(false);
-    }
-    prevPlaylistIdRef.current = selectedPlaylistId;
-  }, [selectedPlaylistId, setSearchFilter, getSearchFilter]);
 
   // Check if playlist name text overflows its container
   useEffect(() => {
@@ -540,66 +517,92 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     });
   }, [playlistTracks, playlistArtistFilter, playlistAlbumFilter]);
 
-  // Track previous global filter for detecting clears
-  const prevGlobalFilterRef = useRef(globalFilter);
-
-  // Persist global filter to store and handle scroll-to-track on clear
-  useEffect(() => {
-    const prevFilter = prevGlobalFilterRef.current;
-    prevGlobalFilterRef.current = globalFilter;
-
-    updatePlaylistViewState(sorting, globalFilter, selectedPlaylistId);
-    if (selectedPlaylistId && !justSwitchedPlaylistRef.current) {
-      setSearchFilter(selectedPlaylistId, globalFilter);
-    }
-    justSwitchedPlaylistRef.current = false;
-
-    // Persist per-playlist sort preference to DB
-    if (selectedPlaylistId && sorting && sorting.length > 0) {
-      setPlaylistSortPreference(selectedPlaylistId, sorting);
-    }
-
-    if (
-      prevFilter &&
-      !globalFilter &&
-      currentTrack &&
-      playbackSource === 'playlist' &&
-      playbackSourcePlaylistId === selectedPlaylistId
-    ) {
-      const playlistTrackIds = playlistTracks.map((t) => t.id);
-      if (playlistTrackIds.includes(currentTrack.id)) {
-        setTimeout(() => {
-          scrollToTrack(currentTrack.id);
-        }, 100);
-      }
-    }
-  }, [
-    globalFilter,
-    sorting,
-    updatePlaylistViewState,
-    selectedPlaylistId,
-    setSearchFilter,
-    setPlaylistSortPreference,
+  // Latest reactive values held in a ref so handleDebouncedSearchChange
+  // can read fresh state for its scroll-on-clear check without becoming
+  // reactive itself (SearchBar subscribes via useEffect on the callback,
+  // so the callback must keep a stable identity). Writes happen in a
+  // layout effect so a speculative render React discards cannot leave
+  // stale values behind.
+  const latestRef = useRef({
+    playlistArtistFilter,
+    playlistAlbumFilter,
     currentTrack,
     playbackSource,
     playbackSourcePlaylistId,
     playlistTracks,
     scrollToTrack,
-  ]);
+  });
+  useLayoutEffect(() => {
+    latestRef.current.playlistArtistFilter = playlistArtistFilter;
+    latestRef.current.playlistAlbumFilter = playlistAlbumFilter;
+    latestRef.current.currentTrack = currentTrack;
+    latestRef.current.playbackSource = playbackSource;
+    latestRef.current.playbackSourcePlaylistId = playbackSourcePlaylistId;
+    latestRef.current.playlistTracks = playlistTracks;
+    latestRef.current.scrollToTrack = scrollToTrack;
+  });
 
-  // Handle search toggle
+  // Change the global filter for the currently-selected playlist. The
+  // store is the single source of truth — setSearchFilter fans out
+  // internally to playlistViewState.filtering. Scroll-on-clear snaps to
+  // the playing track when the user has just cleared a non-empty filter
+  // on the playlist that is currently playing.
+  const handleDebouncedSearchChange = useCallback(
+    (value: string) => {
+      const state = useLibraryStore.getState();
+      const pid = state.selectedPlaylistId;
+      if (!pid) return;
+      const prev = state.searchFilters[pid] ?? '';
+      setSearchFilter(pid, value);
+
+      if (!prev || value) return;
+      const latest = latestRef.current;
+      if (
+        !latest.currentTrack ||
+        latest.playbackSource !== 'playlist' ||
+        latest.playbackSourcePlaylistId !== pid
+      )
+        return;
+
+      const playlistTrackIds = latest.playlistTracks.map((t) => t.id);
+      if (!playlistTrackIds.includes(latest.currentTrack.id)) return;
+
+      setTimeout(() => {
+        const ct = latestRef.current.currentTrack;
+        if (ct) latestRef.current.scrollToTrack(ct.id);
+      }, 100);
+    },
+    [setSearchFilter],
+  );
+
+  // Tanstack's OnChangeFn accepts either a value or an updater function.
+  // Resolve to a plain value and hand off to setPlaylistSortPreference,
+  // which handles the full fan-out (session cache, playlistViewState,
+  // DB persist).
+  const handleSortingChange = useCallback(
+    (updater: SortingState | ((old: SortingState) => SortingState)) => {
+      const state = useLibraryStore.getState();
+      const pid = state.selectedPlaylistId;
+      if (!pid) return;
+      const current =
+        state.playlistSortPreferences[pid] ?? DEFAULT_PLAYLIST_SORTING;
+      const next =
+        typeof updater === 'function'
+          ? (updater as (old: SortingState) => SortingState)(current)
+          : updater;
+      setPlaylistSortPreference(pid, next);
+    },
+    [setPlaylistSortPreference],
+  );
+
+  // Handle search toggle. Closing the bar clears the filter through
+  // handleDebouncedSearchChange so persistence and scroll-on-clear both
+  // fire. The side effect lives outside setShowSearch because state
+  // updaters must stay pure.
   const handleSearchToggle = useCallback(() => {
-    setShowSearch((prev) => {
-      if (prev) {
-        setGlobalFilter('');
-        globalFilterRef.current = '';
-        if (selectedPlaylistId) {
-          setSearchFilter(selectedPlaylistId, '');
-        }
-      }
-      return !prev;
-    });
-  }, [selectedPlaylistId, setSearchFilter]);
+    if (showSearch) handleDebouncedSearchChange('');
+    setShowSearch((prev) => !prev);
+  }, [showSearch, handleDebouncedSearchChange]);
 
   // Memoize playlist track count and hours for stable toolbar deps
   const playlistTrackCount = useMemo(
@@ -611,15 +614,15 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     [playlistTracks],
   );
 
-  // Mark table as ready after render completes
+  // Mark table as ready after the next frame so the virtualizer has
+  // measured rows for the new sorting/filter/data.
   useEffect(() => {
+    tableReadyRef.current = false;
     const rafId = requestAnimationFrame(() => {
       tableReadyRef.current = true;
     });
-
     return () => {
       cancelAnimationFrame(rafId);
-      tableReadyRef.current = false;
     };
   }, [sorting, globalFilter, data.length]);
 
@@ -1057,7 +1060,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
             onRowContextMenu={handleRowContextMenu}
             onRowDoubleClick={handleRowDoubleClick}
             onRowDragStart={handleRowDragStart}
-            onSortingChange={setSorting}
+            onSortingChange={handleSortingChange}
             selectedTrackIds={selectedTrackIdsList}
             sorting={sorting}
             tableRef={tableRef}

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -212,8 +212,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   const playlistNameRef = useRef<HTMLDivElement>(null);
   const playlistNameRef2 = useRef<HTMLDivElement>(null);
 
-  // Memoize the playlist tracks to prevent unnecessary re-renders. Reads
-  // the store's getTracksByIds via the trackIndex map for O(n) lookup.
+  // useMemo: playlist lookup + O(n) getTracksByIds via the trackIndex map.
   const playlistTracks = useMemo(() => {
     if (!selectedPlaylistId || !playlists) return [];
     const selectedPlaylist = playlists.find((p) => p.id === selectedPlaylistId);
@@ -466,10 +465,11 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     };
   }, [selectedPlaylistId, playlists]);
 
-  // Get columns from shared configuration
+  // useMemo: stable identity for tanstack's internal row-model memoization
+  // and avoids re-allocating column defs each render. Empty deps = once.
   const columns = useMemo(() => getCommonColumnDefs(), []);
 
-  // Prepare data for the table with browser filtering
+  // useMemo: O(n) filter + map over playlist tracks.
   const data = useMemo<TableData[]>(() => {
     let filtered = playlistTracks;
 
@@ -571,8 +571,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     setShowSearch((prev) => !prev);
   }, [showSearch, handleDebouncedSearchChange]);
 
-  // Total hours is O(n) over playlist tracks — worth memoizing. Track
-  // count is just playlistTracks.length, read inline.
+  // useMemo: O(n) reduce over playlist track durations.
   const playlistTotalHours = useMemo(
     () => calculateTotalHours(playlistTracks),
     [playlistTracks],
@@ -693,7 +692,8 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     return [trackId];
   };
 
-  // Toolbar content
+  // useMemo: deep JSX subtree. Stable element reference lets React skip
+  // reconciliation of the toolbar when row clicks re-render the parent.
   const toolbarContent = useMemo(() => {
     let playlistNameContent;
 
@@ -904,8 +904,9 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     [setBrowserOpen],
   );
 
-  // Browser panel to pass to VirtualTable — mounted whenever a playlist is selected
-  // so open/close can animate. Gate on selectedPlaylistId only (not browserOpen).
+  // useMemo: wraps React.memo'd Browser. Stable element reference skips
+  // its subtree on parent re-renders where deps haven't changed. Gated
+  // on selectedPlaylistId (not browserOpen) so open/close can animate.
   const browserPanel = useMemo(() => {
     if (!selectedPlaylistId) return undefined;
     return (
@@ -933,7 +934,8 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     playlistTracks,
   ]);
 
-  // Empty state content
+  // useMemo: stable element reference skips subtree reconciliation on
+  // parent re-renders where drawerOpen hasn't changed.
   const emptyStateContent = useMemo(
     () => (
       <Box

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -4,7 +4,6 @@ import React, {
   useRef,
   useCallback,
   useEffect,
-  useLayoutEffect,
 } from 'react';
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { keyframes } from '@mui/system';
@@ -517,62 +516,46 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     });
   }, [playlistTracks, playlistArtistFilter, playlistAlbumFilter]);
 
-  // Latest reactive values held in a ref so handleDebouncedSearchChange
-  // can read fresh state for its scroll-on-clear check without becoming
-  // reactive itself (SearchBar subscribes via useEffect on the callback,
-  // so the callback must keep a stable identity). Writes happen in a
-  // layout effect so a speculative render React discards cannot leave
-  // stale values behind.
-  const latestRef = useRef({
-    playlistArtistFilter,
-    playlistAlbumFilter,
-    currentTrack,
-    playbackSource,
-    playbackSourcePlaylistId,
-    playlistTracks,
-    scrollToTrack,
-  });
-  useLayoutEffect(() => {
-    latestRef.current.playlistArtistFilter = playlistArtistFilter;
-    latestRef.current.playlistAlbumFilter = playlistAlbumFilter;
-    latestRef.current.currentTrack = currentTrack;
-    latestRef.current.playbackSource = playbackSource;
-    latestRef.current.playbackSourcePlaylistId = playbackSourcePlaylistId;
-    latestRef.current.playlistTracks = playlistTracks;
-    latestRef.current.scrollToTrack = scrollToTrack;
-  });
-
   // Change the global filter for the currently-selected playlist. The
   // store is the single source of truth — setSearchFilter fans out
   // internally to playlistViewState.filtering. Scroll-on-clear snaps to
   // the playing track when the user has just cleared a non-empty filter
-  // on the playlist that is currently playing.
+  // on the playlist that is currently playing. Reactive values are read
+  // fresh from stores at call time instead of captured in a latestRef —
+  // the callback closes over nothing that changes, so its identity is
+  // stable without any ref plumbing.
   const handleDebouncedSearchChange = useCallback(
     (value: string) => {
-      const state = useLibraryStore.getState();
-      const pid = state.selectedPlaylistId;
+      const libState = useLibraryStore.getState();
+      const pid = libState.selectedPlaylistId;
       if (!pid) return;
-      const prev = state.searchFilters[pid] ?? '';
+      const prev = libState.searchFilters[pid] ?? '';
       setSearchFilter(pid, value);
 
       if (!prev || value) return;
-      const latest = latestRef.current;
+
+      const playState = useSettingsAndPlaybackStore.getState();
       if (
-        !latest.currentTrack ||
-        latest.playbackSource !== 'playlist' ||
-        latest.playbackSourcePlaylistId !== pid
+        !playState.currentTrack ||
+        playState.playbackSource !== 'playlist' ||
+        playState.playbackSourcePlaylistId !== pid
       )
         return;
 
-      const playlistTrackIds = latest.playlistTracks.map((t) => t.id);
-      if (!playlistTrackIds.includes(latest.currentTrack.id)) return;
+      // After setSearchFilter's fan-out, playlistViewState.filtering is
+      // '' and playlistViewState.playlistId is pid, so getFilteredAnd
+      // SortedTrackIds returns exactly what's visible post-clear.
+      const af = libState.browserFilters[pid]?.artist ?? null;
+      const alf = libState.browserFilters[pid]?.album ?? null;
+      const visibleTrackIds = getFilteredAndSortedTrackIds('playlist', af, alf);
+      if (!visibleTrackIds.includes(playState.currentTrack.id)) return;
 
       setTimeout(() => {
-        const ct = latestRef.current.currentTrack;
-        if (ct) latestRef.current.scrollToTrack(ct.id);
+        const ct = useSettingsAndPlaybackStore.getState().currentTrack;
+        if (ct) scrollToTrack(ct.id);
       }, 100);
     },
-    [setSearchFilter],
+    [setSearchFilter, scrollToTrack],
   );
 
   // Tanstack's OnChangeFn accepts either a value or an updater function.

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -72,10 +72,8 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
   const setSearchFilter = useLibraryStore((state) => state.setSearchFilter);
 
-  // Sort and filter for the selected playlist are read directly from
-  // the store via selectors. setPlaylistSortPreference and
-  // setSearchFilter handle the full fan-out to playlistViewState, so
-  // this component does nothing beyond writing one value at a time.
+  // Read via selectors; setPlaylistSortPreference and setSearchFilter
+  // fan out to playlistViewState, so this component just writes.
   const sorting = useLibraryStore((state) => {
     const pid = state.selectedPlaylistId;
     if (!pid) return DEFAULT_PLAYLIST_SORTING;
@@ -503,14 +501,10 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     });
   }, [playlistTracks, playlistArtistFilter, playlistAlbumFilter]);
 
-  // Change the global filter for the currently-selected playlist. The
-  // store is the single source of truth — setSearchFilter fans out
-  // internally to playlistViewState.filtering. Scroll-on-clear snaps to
-  // the playing track when the user has just cleared a non-empty filter
-  // on the playlist that is currently playing. Reactive values are read
-  // fresh from stores at call time instead of captured in a latestRef —
-  // the callback closes over nothing that changes, so its identity is
-  // stable without any ref plumbing.
+  // Writes filter to the store (which fan-outs internally) and snaps
+  // scroll to the playing track when clearing a non-empty filter on the
+  // active playlist. Reads store state fresh per call so the callback's
+  // identity stays stable.
   const handleDebouncedSearchChange = useCallback(
     (value: string) => {
       const libState = useLibraryStore.getState();
@@ -545,11 +539,9 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
     [setSearchFilter, scrollToTrack],
   );
 
-  // Tanstack's OnChangeFn accepts either a value or an updater function.
-  // Resolve to a plain value and hand off to setPlaylistSortPreference,
-  // which handles the full fan-out (session cache, playlistViewState,
-  // DB persist). No useCallback: VirtualTable isn't memoized, so
-  // identity stability would be cargo-culted ceremony.
+  // Resolve Tanstack's updater-or-value to a plain value for
+  // setPlaylistSortPreference (fan-outs to session cache + viewState +
+  // DB). No useCallback — VirtualTable isn't memoized.
   const handleSortingChange = (
     updater: SortingState | ((old: SortingState) => SortingState),
   ) => {
@@ -1141,9 +1133,7 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
 }
 
-// React.memo with default shallow comparison lets MainLayout re-render
-// (settings drawer toggle, notifications, mini player sync, etc.) without
-// forcing Playlists — an expensive component with many hooks and a
-// virtualized table — to re-render. Playlists' only props are drawerOpen
-// and onDrawerToggle, so the default shallow compare is sufficient.
+// Shields Playlists from MainLayout re-renders (drawer toggle,
+// notifications, player sync, etc.). Props are primitive + stable
+// useCallback, so the default shallow compare is sufficient.
 export default React.memo(Playlists);

--- a/src/renderer/stores/libraryStore.ts
+++ b/src/renderer/stores/libraryStore.ts
@@ -372,12 +372,26 @@ const useLibraryStore = create<LibraryStore>((set, get) => ({
   },
 
   setSearchFilter: (viewId: string, filter: string) => {
-    set((state) => ({
-      searchFilters: {
+    set((state) => {
+      const searchFilters = {
         ...state.searchFilters,
         [viewId]: filter,
-      },
-    }));
+      };
+      // Keep libraryViewState.filtering in sync for the library view so
+      // trackSelectionUtils (used for next/prev track math) sees the
+      // current filter immediately without any component-side fan-out.
+      // Playlists.tsx still manages its own playlistViewState sync.
+      if (viewId === 'library') {
+        return {
+          searchFilters,
+          libraryViewState: {
+            ...state.libraryViewState,
+            filtering: filter,
+          },
+        };
+      }
+      return { searchFilters };
+    });
   },
 
   getSearchFilter: (viewId: string) => {

--- a/src/renderer/stores/libraryStore.ts
+++ b/src/renderer/stores/libraryStore.ts
@@ -145,7 +145,32 @@ const useLibraryStore = create<LibraryStore>((set, get) => ({
   },
 
   selectPlaylist: (playlistId: string | null) => {
-    set({ selectedPlaylistId: playlistId });
+    // Reset playlistViewState to the new playlist's saved sort/filter
+    // so trackSelectionUtils (used by next/prev track math) always sees
+    // the view state matching the currently-selected playlist, even in
+    // the brief window before the component renders.
+    set((state) => {
+      if (!playlistId) {
+        return {
+          selectedPlaylistId: null,
+          playlistViewState: {
+            sorting: state.playlistViewState.sorting,
+            filtering: '',
+            playlistId: null,
+          },
+        };
+      }
+      const savedSort = state.playlistSortPreferences[playlistId];
+      const savedFilter = state.searchFilters[playlistId] ?? '';
+      return {
+        selectedPlaylistId: playlistId,
+        playlistViewState: {
+          sorting: savedSort ?? [{ id: 'albumArtist', desc: false }],
+          filtering: savedFilter,
+          playlistId,
+        },
+      };
+    });
   },
 
   selectTrack: (trackId: string | null) => {
@@ -380,13 +405,25 @@ const useLibraryStore = create<LibraryStore>((set, get) => ({
       // Keep libraryViewState.filtering in sync for the library view so
       // trackSelectionUtils (used for next/prev track math) sees the
       // current filter immediately without any component-side fan-out.
-      // Playlists.tsx still manages its own playlistViewState sync.
       if (viewId === 'library') {
         return {
           searchFilters,
           libraryViewState: {
             ...state.libraryViewState,
             filtering: filter,
+          },
+        };
+      }
+      // For a playlist view ID that matches the currently-selected
+      // playlist, mirror the filter into playlistViewState so next/prev
+      // track math follows what the user sees.
+      if (viewId === state.selectedPlaylistId) {
+        return {
+          searchFilters,
+          playlistViewState: {
+            ...state.playlistViewState,
+            filtering: filter,
+            playlistId: viewId,
           },
         };
       }
@@ -403,14 +440,29 @@ const useLibraryStore = create<LibraryStore>((set, get) => ({
     playlistId: string,
     sorting: Array<{ id: string; desc: boolean }>,
   ) => {
+    if (!sorting || sorting.length === 0) return;
+
     // Update the session cache (do NOT update playlists array to avoid
-    // triggering re-renders that cause infinite loops in Playlists.tsx)
-    set((state) => ({
-      playlistSortPreferences: {
+    // triggering re-renders that cause infinite loops in Playlists.tsx).
+    // If this playlist is the currently-selected one, also mirror the
+    // sort into playlistViewState so trackSelectionUtils sees it.
+    set((state) => {
+      const playlistSortPreferences = {
         ...state.playlistSortPreferences,
         [playlistId]: sorting,
-      },
-    }));
+      };
+      if (playlistId === state.selectedPlaylistId) {
+        return {
+          playlistSortPreferences,
+          playlistViewState: {
+            ...state.playlistViewState,
+            sorting,
+            playlistId,
+          },
+        };
+      }
+      return { playlistSortPreferences };
+    });
 
     // Persist to DB (fire-and-forget)
     const { playlists } = get();

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -244,13 +244,28 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     setLibrarySorting: async (
       sorting: Array<{ id: string; desc: boolean }>,
     ) => {
+      // Guard: never clear the persisted sort via this path. Callers that
+      // want "no sort" would regress to the default on next launch, which
+      // is surprising. If that's ever needed, add a dedicated method.
+      if (!sorting || sorting.length === 0) return;
+
+      // Optimistic in-memory update first: the UI (component subscribers)
+      // and trackSelectionUtils (libraryViewState) respond immediately,
+      // before the DB round-trip completes. Errors in the DB write are
+      // logged but do not revert the UI — the user sees the sort they
+      // asked for and can retry the action.
+      set({ librarySorting: sorting });
+      const libState = useLibraryStore.getState();
+      libState.updateLibraryViewState(
+        sorting,
+        libState.libraryViewState.filtering,
+      );
+
       try {
         const state = get();
-
         if (!state.id) {
           throw new Error('Settings not loaded');
         }
-
         const updatedSettings = {
           id: state.id,
           libraryPath: state.libraryPath,
@@ -263,8 +278,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           columnOrder: state.columnOrder,
         };
         await window.electron.settings.update(updatedSettings);
-
-        set({ librarySorting: sorting });
       } catch (error) {
         console.error('Error updating library sorting:', error);
       }


### PR DESCRIPTION
Stacked on top of #60.

## Summary
What started as a React hooks audit of `Library.tsx` became an architectural cleanup. The sort and filter state now live in Zustand stores as the single source of truth, with fan-out logic centralized in store setters. Both `Library.tsx` and `Playlists.tsx` are pure consumers that read via selectors and write via one-line store calls. Handlers that were the original audit's subject are now trivial top-to-bottom, and the last vestige of component-side state plumbing (a `latestRef` used to read fresh reactive values inside stable callbacks) has been deleted — it was re-implementing what `useStore.getState()` already provides for free.

## Final net changes

- `Library.tsx` **−239 lines** net vs. base branch
- `Playlists.tsx` **−123 lines** net vs. base branch
- Zero `useEffect`s devoted to store synchronization remain in either component. All remaining effects are legitimate external-system syncs (window binding, DOM measurement, marquee overflow).
- `handleSortingChange` is a 13-line tanstack shim. `handleDebouncedSearchChange` is a single store call plus the scroll-on-clear side effect.

## How this PR evolved

1. **Audit the `useEffect`s in `Library.tsx`.** Found two real bugs and one "you might not need an effect" anti-pattern.
2. **Round 1 review fixes.** Pure-updater violation in `handleSortingChange`, wasteful `libraryViewState` subscription.
3. **Round 2 review fixes.** `latestRef` writes moved to `useInsertionEffect` for Concurrent safety, pure `handleSearchToggle` updater, pre-existing browser-filter bug in the unmount save.
4. **Complexity audit.** After fixing the hooks, `handleSortingChange` was still obtuse. Realized the complexity wasn't in the hooks — it was in the architecture: three layers of state (component-local, session cache, persisted) that the component had to manually fan out on every change.
5. **Collapse to a single source of truth (Library).** Pushed fan-out into `setLibrarySorting` and `setSearchFilter`. `Library.tsx` reads sort/filter directly from stores and writes via single calls. Local `sorting`/`globalFilter` useState + `globalFilterRef` + `updateLibraryViewState` subscription all deleted.
6. **Symmetric treatment for Playlists.** Same anti-patterns, same solution. Required teaching `selectPlaylist` to reset `playlistViewState` on selection and extending `setSearchFilter` / `setPlaylistSortPreference` to fan out when the view ID matches `selectedPlaylistId`.
7. **Drop `latestRef` entirely.** It existed to let stable callbacks read fresh reactive values without closing over them — but every value being tracked already lived in a Zustand store. `useStore.getState()` is a fresh synchronous read with zero ceremony, so the `latestRef` + `useLayoutEffect` sync dance was re-implementing what Zustand already provides. Deleted from both components.

## Commits

| SHA | Scope | Summary |
|---|---|---|
| `d0df7aa` | `Library.tsx` | Audit the 5 `useEffect`s: fix broken unmount save (stale ref capture), fix re-firing mount restore, delete filter/sort effect-observer anti-pattern. |
| `a0f0872` | `Library.tsx` | Pure `setSorting` updater (StrictMode double-invoke safety) + drop `libraryViewState` subscription used only for init. |
| `38a5403` | `Library.tsx` | `useInsertionEffect` for `latestRef` writes (Concurrent rendering safety), pure `handleSearchToggle` updater, fix pre-existing unmount-save filter bug, revert misguided `useLayoutEffect` on the mark-table-ready effect. |
| `da93f4b` | `Library.tsx` + stores | Collapse three sources of truth. `setLibrarySorting` becomes optimistic and fans out to `libraryViewState.sorting`. `setSearchFilter` fans out to `libraryViewState.filtering` when `viewId === 'library'`. `Library.tsx` drops local sort/filter state, handlers collapse to 13-line tanstack shims. |
| `73d4f65` | `Playlists.tsx` + stores | Symmetric treatment for playlists. `selectPlaylist` resets `playlistViewState` to the new playlist's saved state. `setSearchFilter` and `setPlaylistSortPreference` fan out to `playlistViewState` when the view ID matches `selectedPlaylistId`. `Playlists.tsx` drops local sort/filter state, 4 coordination refs, the 40-line effect-observer, and the playlist-switching effect. |
| `73c6552` | `Library.tsx` + `Playlists.tsx` | Delete `latestRef` from both components. `handleDebouncedSearchChange` and `scrollToTrack` read reactive values directly from stores via `useStore.getState()`. `scrollToTrack` drops its `[artistFilter, albumFilter]` deps and becomes truly stable across all renders. |

## The architectural shift

**Before:** sort and filter each lived in three places that the component had to keep in sync manually on every change:
- Component-local `useState` (drove `VirtualTable`, gave immediate UI feedback)
- `libraryStore.libraryViewState` / `playlistViewState` (read by `trackSelectionUtils` for next/prev track math)
- `settingsStore.librarySorting` / `libraryStore.playlistSortPreferences` + `searchFilters` (persisted + per-view dictionaries)

Every keystroke and sort click triggered an effect-observer that wrote all three in sequence. On top of that, a `latestRef` + `useLayoutEffect` sync pattern existed to let stable callbacks read fresh values from any of those layers without closing over reactive state.

**After:** the stores are the source of truth. Setters fan out to whichever in-memory mirrors need to stay consistent. Components read via selectors and write via single calls. When a handler needs a fresh reactive value, it calls `useStore.getState()` — no refs required.

- `setLibrarySorting(next)` — writes `librarySorting`, mirrors to `libraryViewState.sorting`, persists to DB in background. Empty-sort guard.
- `setSearchFilter('library', value)` — writes `searchFilters['library']`, mirrors to `libraryViewState.filtering`.
- `setSearchFilter(playlistId, value)` — writes `searchFilters[playlistId]`, mirrors to `playlistViewState.filtering` iff `playlistId === selectedPlaylistId`.
- `setPlaylistSortPreference(playlistId, next)` — writes `playlistSortPreferences[playlistId]`, mirrors to `playlistViewState.sorting` iff match. Empty-sort guard. DB persist.
- `selectPlaylist(playlistId)` — atomically resets `playlistViewState` to the new playlist's saved state, closing the stale window where `trackSelectionUtils` could read previous-playlist state between selection and the next user interaction.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] **e2e tests green** across `playlists`, `search-persistence`, `sorting-persistence`, `scroll-to-song`, `first-import-scroll`, `library-management`, `basic-functionality`, `artist-browser`, `browser-type-ahead`, `playing-row-alignment`, `playback-autoplay`, `playback-skip`, `drag-to-playlist`.
- [ ] Manual QA — see hot spots below.

## Manual QA hot spots

The stores now own fan-out logic the components used to do explicitly. Most interesting to exercise:

**Library sort/filter**
- Sort by column → quit → reopen → preserved.
- Type in search → switch view → switch back → preserved.
- Play a track in Library → type a filter that hides it → clear via SearchBar inline X → expect snap back to playing track.
- Repeat clearing via the toolbar search-toggle X — different code path, same behavior expected.
- In dev StrictMode expect exactly one store write per sort click and one scroll schedule per clear (validates pure-updater fixes from rounds 1 and 2).

**Library unmount save (pre-existing bug fixed in `38a5403`, preserved in `73c6552`)**
- Select an artist in the browser → scroll to middle → switch away → switch back → expect to land on a track that was actually visible pre-switch, not a random track from the unfiltered list.

**Playlist sort/filter (new territory for this refactor)**
- Each playlist maintains its own search filter and sort. Type in playlist A → switch to B → expect B's own saved filter restored → switch back to A → expect A's filter restored.
- Sort by column in playlist A → expect the sort to persist for that playlist specifically. Different playlists can have different sorts.
- Clear a non-empty filter in a playlist that is currently playing → expect snap back to the playing track. Clear in a playlist that isn't playing → expect no jump.
- Switch playlists while one has an active search bar open → expect the new playlist's saved search state (hidden if no filter, shown if it has one).

**Playlist playback context**
- `trackSelectionUtils` reads `playlistViewState` for next/prev track math. The `selectPlaylist` atomic reset is what closes the stale window — test by clicking a playlist and immediately hitting skip-next before any interaction settles. Expect next-track to come from the correct playlist's filtered/sorted list.

**SearchBar callback identity (applies to both views)**
- Rapid typing should not lose characters, fire duplicates, or reset mid-type. With `latestRef` gone, callback stability now comes from the handler closing over nothing reactive — verify nothing regresses under fast input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)