### PR TITLE
refactor: split MainLayout, drop React.memo on Library and Playlists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,30 @@ e2e/                        # Playwright E2E tests
 - **libraryStore**: tracks array, playlists, indexed lookups (Map-based O(1)), library/playlist view state, artist filter
 - **settingsAndPlaybackStore**: settings (theme, columns, libraryPath, volume), playback state (currentTrack, position, shuffle/repeat), Gapless-5 player instance
 - **uiStore**: notifications, currentView, artistBrowserOpen
-- Stores access each other via `useXStore.getState()` (not hooks) when needed cross-store
+
+#### When to subscribe (`useXStore(selector)`) vs read at call time (`useXStore.getState()`)
+
+When a component pulls state or actions from a Zustand store, the access pattern depends on **where the value is consumed**, not on whether it's a state slice or an action. Get this wrong and you either pay for subscriptions you don't need, or you reintroduce stale-closure bugs inside effects.
+
+**Use a top-level selector** — `const x = useXStore((s) => s.x);` near the top of the component — when the value is read in any of:
+- JSX render output
+- Callbacks bound directly to JSX elements (`onClick`, `onChange`, `onClose`, `onConfirm`, drag handlers, etc.)
+- `useMemo` / `useCallback` bodies whose result feeds JSX
+- Anywhere else that should trigger a re-render when the slice changes
+
+**Use `useXStore.getState().x` at call time** — inside the body of the function that needs it — when the value is read **only** in any of:
+- `useEffect` bodies and their cleanup functions
+- Listeners attached to non-React sources (IPC handlers, `document.addEventListener`, MediaSession callbacks, etc.)
+- Async handlers that fire long after mount and don't drive renders themselves
+
+**Why it matters:**
+1. Every top-level selector creates a Zustand subscription for the lifetime of the component — one closure, one listener slot, one shallow compare per store update. For state values you want this (re-render on change). For actions it's technically a no-op (Zustand action references are stable, so the selector returns the same value and never schedules a render), but you still pay the per-update cost and you add noise: an extra binding, an extra dep-array entry, one more thing for the next reader to track.
+2. Inside a `useEffect` or async event handler, a top-level selector also captures its value into the effect's closure at render time. For state *values* that means stale reads — `getState()` reads the latest value at the moment the event fires, with no stale-closure trap.
+3. For actions specifically, both patterns are functionally equivalent (the reference is stable), so the choice comes down to subscription cost and component clarity.
+
+**If a value is read in both render-driving code and inside an effect, declare it once as a top-level selector and use the variable inside the effect.** Add it to the effect's dep array — Zustand action references are stable, so the effect still only runs once on mount for action-only deps, and ESLint stays happy. Splitting the same action between a top-level selector and a `getState()` call in the same component is a smell — pick one.
+
+**Cross-store reads:** stores access other stores exclusively via `useXStore.getState()` (lazy `require()` if a circular import is involved — see `uiStore.setBrowserOpen`). React hooks aren't available inside store modules, so `getState()` is the only option there.
 
 ### Audio Playback
 - Gapless-5 player initialized lazily in `initPlayer()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,15 +85,15 @@ e2e/                        # Playwright E2E tests
 
 #### When to subscribe (`useXStore(selector)`) vs read at call time (`useXStore.getState()`)
 
-When a component pulls state or actions from a Zustand store, the access pattern depends on **where the value is consumed**, not on whether it's a state slice or an action. Get this wrong and you either pay for subscriptions you don't need, or you reintroduce stale-closure bugs inside effects.
+When a component pulls anything out of a Zustand store — whether that's reading a state slice, displaying it, or **invoking an action** — the access pattern depends on **where the access happens**, not on whether you're reading data or calling a mutator. (Invoking an action is itself a read: you pull the function reference out of the store, then call it. The rule below treats both the same.) Get this wrong and you either pay for subscriptions you don't need, or you reintroduce stale-closure bugs inside effects.
 
-**Use a top-level selector** — `const x = useXStore((s) => s.x);` near the top of the component — when the value is read in any of:
+**Use a top-level selector** — `const x = useXStore((s) => s.x);` near the top of the component — when the value is read **or the action is invoked** in any of:
 - JSX render output
 - Callbacks bound directly to JSX elements (`onClick`, `onChange`, `onClose`, `onConfirm`, drag handlers, etc.)
 - `useMemo` / `useCallback` bodies whose result feeds JSX
 - Anywhere else that should trigger a re-render when the slice changes
 
-**Use `useXStore.getState().x` at call time** — inside the body of the function that needs it — when the value is read **only** in any of:
+**Use `useXStore.getState().x` at call time** — inside the body of the function that needs it — when the value is read **or the action is invoked** **only** in any of:
 - `useEffect` bodies and their cleanup functions
 - Listeners attached to non-React sources (IPC handlers, `document.addEventListener`, MediaSession callbacks, etc.)
 - Async handlers that fire long after mount and don't drive renders themselves

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -156,6 +156,8 @@ function Library() {
   const setSearchFilter = useLibraryStore((state) => state.setSearchFilter);
   const browserOpen = useUIStore((state) => state.browserOpen);
   const setBrowserOpen = useUIStore((state) => state.setBrowserOpen);
+  const showNotification = useUIStore((state) => state.showNotification);
+  const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
   const [showSearch, setShowSearch] = useState(
     () => !!useLibraryStore.getState().searchFilters.library,
   );
@@ -385,8 +387,6 @@ function Library() {
     if (selectedTrackIds.length === 0) return;
 
     try {
-      const { showNotification } = useUIStore.getState();
-
       const currentTrackIds = getFilteredAndSortedTrackIds(
         'library',
         artistFilter,
@@ -489,7 +489,6 @@ function Library() {
       );
     } catch (error) {
       console.error('Error deleting tracks:', error);
-      const { showNotification } = useUIStore.getState();
       showNotification('Failed to delete tracks', 'error');
     }
   };
@@ -1081,7 +1080,7 @@ function Library() {
         onCancel={() => setScanConfirmOpen(false)}
         onConfirm={() => {
           setScanConfirmOpen(false);
-          useUIStore.getState().setSettingsOpen(true);
+          setSettingsOpen(true);
         }}
         open={scanConfirmOpen}
         title="Scan Library"

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -71,8 +71,7 @@ interface DirectorySelectionResult {
 }
 
 function Library() {
-  // Sidebar drawer state lives in uiStore — read it directly here so
-  // the parent doesn't need to thread it through as a prop.
+  // Subscribe directly so the parent doesn't need a drawer prop.
   const drawerOpen = useUIStore((state) => state.sidebarOpen);
   const onDrawerToggle = useUIStore((state) => state.toggleSidebar);
 

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -70,13 +70,12 @@ interface DirectorySelectionResult {
   filePaths: string[];
 }
 
-// Define props interface for Library component
-interface LibraryProps {
-  drawerOpen: boolean;
-  onDrawerToggle: () => void;
-}
+function Library() {
+  // Sidebar drawer state lives in uiStore — read it directly here so
+  // the parent doesn't need to thread it through as a prop.
+  const drawerOpen = useUIStore((state) => state.sidebarOpen);
+  const onDrawerToggle = useUIStore((state) => state.toggleSidebar);
 
-function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   // Get state from library store
   const tracks = useLibraryStore((state) => state.tracks);
   const getTrackById = useLibraryStore((state) => state.getTrackById);
@@ -1103,7 +1102,4 @@ function Library({ drawerOpen, onDrawerToggle }: LibraryProps) {
   );
 }
 
-// Shields Library from MainLayout re-renders (drawer toggle,
-// notifications, player sync, etc.). Props are primitive + stable
-// useCallback, so the default shallow compare is sufficient.
-export default React.memo(Library);
+export default Library;

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+import { useUIStore } from '../stores';
+import Library from './Library';
+import Playlists from './Playlists';
+
+export default function MainContent() {
+  const currentView = useUIStore((state) => state.currentView);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'calc(100vh - 100px)',
+        width: '100%',
+        WebkitAppRegion: 'drag',
+        '& button, & input, & a, & [role="button"], & .MuiTableContainer-root, & .MuiDataGrid-root, & .MuiSlider-root':
+          {
+            WebkitAppRegion: 'no-drag',
+          },
+      }}
+    >
+      {currentView === 'library' && <Library />}
+      {currentView === 'playlists' && <Playlists />}
+    </Box>
+  );
+}

--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -63,6 +63,7 @@ export default function MainLayout() {
     const unsubToggleSidebar = window.electron.ipcRenderer.on(
       'ui:toggleSidebar',
       () => {
+        // toggleSidebar is not used in JSX so it actually saves overhead to pull it in during runtime
         useUIStore.getState().toggleSidebar();
       },
     );

--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -1,45 +1,17 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import { styled } from '@mui/material/styles';
-import {
-  Box,
-  Drawer,
-  Typography,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  CssBaseline,
-  IconButton,
-  Menu,
-  MenuItem,
-  Tooltip,
-  Paper,
-} from '@mui/material';
+import { Box, Drawer, Typography, CssBaseline } from '@mui/material';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
-import QueueMusicIcon from '@mui/icons-material/QueueMusic';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
-import SettingsIcon from '@mui/icons-material/Settings';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
-import EditIcon from '@mui/icons-material/Edit';
-import CloseIcon from '@mui/icons-material/Close';
-import MinimizeIcon from '@mui/icons-material/Remove';
-import MaximizeIcon from '@mui/icons-material/CropSquare';
-import RestoreIcon from '@mui/icons-material/FilterNone';
-import ViewSidebarRoundedIcon from '@mui/icons-material/ViewSidebarRounded';
 import {
   useLibraryStore,
   useSettingsAndPlaybackStore,
   useUIStore,
 } from '../stores';
-import Library from './Library';
-import Playlists from './Playlists';
+import Sidebar from './Sidebar';
+import MainContent from './MainContent';
 import Settings from './Settings';
 import Player from './Player';
 import NotificationSystem from './NotificationSystem';
-import RenamePlaylistDialog from './RenamePlaylistDialog';
-import CreatePlaylistDialog from './CreatePlaylistDialog';
-import { mutedIconButtonSx } from '../styles/iconButtonStyles';
 
 const drawerWidth = 200;
 
@@ -66,7 +38,6 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
   }),
 }));
 
-// Create a styled component for the Player
 const PlayerWrapper = styled('div')(() => ({
   position: 'fixed',
   bottom: 0,
@@ -76,312 +47,72 @@ const PlayerWrapper = styled('div')(() => ({
   height: '100px',
 }));
 
-type View = 'library' | 'playlists';
-
 export default function MainLayout() {
-  // Get state and actions from library store
   const isLoading = useLibraryStore((state) => state.isLoading);
-  const playlists = useLibraryStore((state) => state.playlists);
-  const selectedPlaylistId = useLibraryStore(
-    (state) => state.selectedPlaylistId,
-  );
-  const selectPlaylist = useLibraryStore((state) => state.selectPlaylist);
-  const deletePlaylist = useLibraryStore((state) => state.deletePlaylist);
-
   const theme = useSettingsAndPlaybackStore((state) => state.theme);
-
-  const currentView = useUIStore((state) => state.currentView);
-  const setCurrentView = useUIStore((state) => state.setCurrentView);
   const settingsOpen = useUIStore((state) => state.settingsOpen);
   const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
+  const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
-  const [open, setOpen] = useState(true);
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [isMaximized, setIsMaximized] = useState(false);
-  const [dragOverPlaylistId, setDragOverPlaylistId] = useState<string | null>(
-    null,
-  );
-
-  // Rename dialog state - simplified to only track open/close and playlist ID
-  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const [renamePlaylistId, setRenamePlaylistId] = useState<string | null>(null);
-
-  // Context menu for playlist deletion
-  const [contextMenu, setContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
-    playlistId: string;
-    isSmart?: boolean;
-  } | null>(null);
-
-  // Check if window is maximized
-  const checkMaximized = useCallback(async () => {
-    const maximized = await window.electron.window.isMaximized();
-    setIsMaximized(maximized);
-  }, []);
-
-  // Handle maximize/restore
-  const handleMaximize = useCallback(() => {
-    window.electron.window.maximize();
-    // Update maximized state after a short delay to allow the window to change state
-    setTimeout(checkMaximized, 100);
-  }, [checkMaximized]);
-
-  const handleDrawerToggle = useCallback(() => {
-    setOpen((prevOpen) => !prevOpen);
-  }, []);
-
-  const handleViewChange = (view: View) => {
-    setCurrentView(view);
-  };
-
-  const handlePlaylistSelect = (playlistId: string) => {
-    selectPlaylist(playlistId);
-    setCurrentView('playlists');
-  };
-
-  const handlePlaylistContextMenu = (
-    event: React.MouseEvent,
-    playlistId: string,
-  ) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Find the playlist to check if it's a smart playlist
-    const playlist = playlists.find((p) => p.id === playlistId);
-
-    setContextMenu({
-      mouseX: event.clientX,
-      mouseY: event.clientY,
-      playlistId,
-      isSmart: playlist?.isSmart || false, // Store whether this is a smart playlist
-    });
-  };
-
-  const handleContextMenuClose = () => {
-    setContextMenu(null);
-  };
-
-  const handleDeletePlaylist = async () => {
-    if (contextMenu) {
-      // Don't allow deletion of smart playlists
-      if (contextMenu.isSmart) {
-        useUIStore
-          .getState()
-          .showNotification('Smart playlists cannot be deleted', 'warning');
-        setContextMenu(null);
-        return;
-      }
-
-      await deletePlaylist(contextMenu.playlistId);
-      if (selectedPlaylistId === contextMenu.playlistId) {
-        selectPlaylist(null);
-      }
-      setContextMenu(null);
-    }
-  };
-
-  const handleRenamePlaylist = () => {
-    if (contextMenu) {
-      setRenamePlaylistId(contextMenu.playlistId);
-      setRenameDialogOpen(true);
-      setContextMenu(null);
-    }
-  };
-
-  const closeRenameDialog = () => {
-    setRenameDialogOpen(false);
-    setRenamePlaylistId(null);
-  };
-
-  const handleAddPlaylistClick = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    setCreateDialogOpen(true);
-  };
-
-  const closeCreateDialog = () => {
-    setCreateDialogOpen(false);
-  };
-
-  // Drag-and-drop handlers for playlist sidebar items
-  const handlePlaylistDragOver = useCallback(
-    (e: React.DragEvent, playlistId: string, isSmart: boolean) => {
-      if (
-        isSmart ||
-        !e.dataTransfer.types.includes('application/x-hihat-tracks')
-      ) {
-        e.dataTransfer.dropEffect = 'none';
-        return;
-      }
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'copy';
-      setDragOverPlaylistId(playlistId);
-    },
-    [],
-  );
-
-  const handlePlaylistDragLeave = useCallback((e: React.DragEvent) => {
-    const related = e.relatedTarget as Node | null;
-    if (related && (e.currentTarget as Node).contains(related)) {
-      return;
-    }
-    setDragOverPlaylistId(null);
-  }, []);
-
-  const handlePlaylistDrop = useCallback(
-    async (e: React.DragEvent, playlistId: string, isSmart: boolean) => {
-      setDragOverPlaylistId(null);
-      if (isSmart) return;
-
-      const raw = e.dataTransfer.getData('application/x-hihat-tracks');
-      if (!raw) return;
-      e.preventDefault();
-
-      let trackIds: string[];
-      try {
-        trackIds = JSON.parse(raw);
-      } catch {
-        return;
-      }
-
-      if (!Array.isArray(trackIds) || trackIds.length === 0) return;
-
-      const { showNotification } = useUIStore.getState();
-      const { addTrackToPlaylist } = useLibraryStore.getState();
-
-      if (trackIds.length === 1) {
-        await addTrackToPlaylist(trackIds[0], playlistId);
-        return;
-      }
-
-      // Batch multi-track add
-      const currentPlaylists = useLibraryStore.getState().playlists;
-      const playlist = currentPlaylists.find((p) => p.id === playlistId);
-      if (!playlist) return;
-
-      const existingSet = new Set(playlist.trackIds);
-      const newTrackIds = trackIds.filter((id) => !existingSet.has(id));
-      const dupeCount = trackIds.length - newTrackIds.length;
-
-      if (newTrackIds.length === 0) {
-        showNotification(
-          `All ${trackIds.length} tracks are already in "${playlist.name}"`,
-          'info',
-        );
-        return;
-      }
-
-      const updatedPlaylist = {
-        ...playlist,
-        trackIds: [...playlist.trackIds, ...newTrackIds],
-      };
-
-      await window.electron.playlists.update(updatedPlaylist);
-      useLibraryStore.setState((state) => ({
-        playlists: state.playlists.map((p) =>
-          p.id === playlistId ? updatedPlaylist : p,
-        ),
-      }));
-
-      const dupeMsg =
-        dupeCount > 0 ? ` (${dupeCount} already in playlist)` : '';
-      showNotification(
-        `Added ${newTrackIds.length} track${newTrackIds.length > 1 ? 's' : ''} to "${playlist.name}"${dupeMsg}`,
-        'success',
-      );
-    },
-    [],
-  );
-
-  // Clean up drag state on dragend (global)
+  // IPC: keyboard shortcut → toggle sidebar / open settings. Both store
+  // actions are referentially stable, so we read them from getState() at
+  // event time and keep the effect dep array empty.
   useEffect(() => {
-    const handleDragEnd = () => setDragOverPlaylistId(null);
-    document.addEventListener('dragend', handleDragEnd);
-    return () => document.removeEventListener('dragend', handleDragEnd);
-  }, []);
-
-  // Add keyboard shortcut handler
-  useEffect(() => {
-    // Listen for IPC event to toggle sidebar
     const unsubToggleSidebar = window.electron.ipcRenderer.on(
       'ui:toggleSidebar',
       () => {
-        handleDrawerToggle();
+        useUIStore.getState().toggleSidebar();
       },
     );
-
-    // Listen for IPC event to open settings
     const unsubOpenSettings = window.electron.ipcRenderer.on(
       'ui:openSettings',
       () => {
-        setSettingsOpen(true);
+        useUIStore.getState().setSettingsOpen(true);
       },
     );
-
-    // Check if window is maximized on mount
-    checkMaximized();
-
-    // Listen for window maximize/unmaximize events
-    const unsubMaximizedChange = window.electron.window.onMaximizedChange(
-      (maximized) => {
-        setIsMaximized(maximized);
-      },
-    );
-
-    // Cleanup
     return () => {
       unsubToggleSidebar();
       unsubOpenSettings();
-      unsubMaximizedChange();
     };
-  }, [handleDrawerToggle, checkMaximized, setSettingsOpen]);
+  }, []);
 
+  // Document-level custom events for in-app navigation (used by deep
+  // links, notification clicks, etc.).
   useEffect(() => {
-    // Listen for custom view change events
     const handleCustomViewChange = (event: Event) => {
       const customEvent = event as CustomEvent<{ view: string }>;
       const { view } = customEvent.detail;
       if (view === 'library' || view === 'playlists') {
-        setCurrentView(view);
+        useUIStore.getState().setCurrentView(view);
       } else if (view === 'settings') {
-        setSettingsOpen(true);
+        useUIStore.getState().setSettingsOpen(true);
       }
     };
-
-    // Add event listener
     document.addEventListener('hihat:viewChange', handleCustomViewChange);
-
-    // Clean up
     return () => {
       document.removeEventListener('hihat:viewChange', handleCustomViewChange);
     };
-  }, [setCurrentView, setSettingsOpen]);
+  }, []);
 
   useEffect(() => {
-    // Listen for custom playlist select events
     const handleCustomPlaylistSelect = (event: Event) => {
       const customEvent = event as CustomEvent<{ playlistId: string }>;
       const { playlistId } = customEvent.detail;
-      if (playlistId) {
-        selectPlaylist(playlistId);
-        setCurrentView('playlists');
-      }
+      if (!playlistId) return;
+      useLibraryStore.getState().selectPlaylist(playlistId);
+      useUIStore.getState().setCurrentView('playlists');
     };
-
-    // Add event listener
     document.addEventListener(
       'hihat:selectPlaylist',
       handleCustomPlaylistSelect,
     );
-
-    // Clean up
     return () => {
       document.removeEventListener(
         'hihat:selectPlaylist',
         handleCustomPlaylistSelect,
       );
     };
-  }, [setCurrentView, selectPlaylist]);
+  }, []);
 
   if (isLoading) {
     return (
@@ -400,7 +131,6 @@ export default function MainLayout() {
           overflow: 'hidden',
         }}
       >
-        {/* Centered animated loading element */}
         <Box
           sx={{
             position: 'relative',
@@ -420,7 +150,6 @@ export default function MainLayout() {
             justifyContent: 'center',
           }}
         >
-          {/* Music note icon with pulsing animation */}
           <LibraryMusicIcon
             sx={{
               color:
@@ -458,7 +187,6 @@ export default function MainLayout() {
           </Typography>
         </Box>
 
-        {/* Loading text with fade animation */}
         <Typography
           sx={{
             mt: 4,
@@ -480,7 +208,6 @@ export default function MainLayout() {
           music awaits
         </Typography>
 
-        {/* Loading dots with sequential animation */}
         <Box
           sx={{
             display: 'flex',
@@ -520,7 +247,7 @@ export default function MainLayout() {
         height: '100vh',
         overflow: 'hidden',
         flexDirection: 'column',
-        WebkitAppRegion: 'drag', // Make the entire window draggable by default
+        WebkitAppRegion: 'drag',
       }}
     >
       <Box
@@ -529,444 +256,16 @@ export default function MainLayout() {
           flexGrow: 1,
           position: 'relative',
           overflow: 'hidden',
-          WebkitAppRegion: 'drag', // Make this area draggable
+          WebkitAppRegion: 'drag',
         }}
       >
         <CssBaseline />
-        <Drawer
-          anchor="left"
-          open={open}
-          sx={{
-            width: drawerWidth,
-            flexShrink: 0,
-            '& .MuiDrawer-paper': {
-              width: drawerWidth,
-              boxSizing: 'border-box',
-              display: 'flex',
-              flexDirection: 'column',
-              height: 'calc(100vh - 100px)', // Stop above the player
-              WebkitAppRegion: 'drag', // Make drawer background draggable
-              '& .MuiListItemButton-root, & .MuiIconButton-root, & .MuiListItemIcon-root, & .MuiListItemText-root':
-                {
-                  WebkitAppRegion: 'no-drag', // Make interactive elements not draggable
-                },
-            },
-          }}
-          variant="persistent"
-        >
-          <Paper
-            elevation={0}
-            sx={{
-              borderRadius: '0px',
-              height: '100%',
-              backgroundColor: theme === 'dark' ? '#000000' : '#FFFFFF',
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-            }}
-          >
-            {/* Window Controls */}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                px: 1.5,
-                py: 0.5,
-                WebkitAppRegion: 'drag', // Make this area draggable
-                height: '44px',
-              }}
-            >
-              <Box
-                sx={{ display: 'flex', gap: '8px', WebkitAppRegion: 'no-drag' }}
-              >
-                <Tooltip title="Close">
-                  <IconButton
-                    onClick={() => window.electron.window.close()}
-                    size="small"
-                    sx={{
-                      width: '12px',
-                      height: '12px',
-                      bgcolor: (t) => t.palette.grey[500],
-                      '&:hover': {
-                        bgcolor: '#ff5f57',
-                        '& .MuiSvgIcon-root': {
-                          opacity: 1,
-                          color: 'black',
-                        },
-                      },
-                      padding: 0,
-                    }}
-                  >
-                    <CloseIcon
-                      sx={{
-                        fontSize: '8px',
-                        opacity: 0,
-                        transition: 'opacity 0.2s',
-                      }}
-                    />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Minimize">
-                  <IconButton
-                    onClick={() => window.electron.window.minimize()}
-                    size="small"
-                    sx={{
-                      width: '12px',
-                      height: '12px',
-                      bgcolor: (t) => t.palette.grey[500],
-                      '&:hover': {
-                        bgcolor: '#ffbd2e',
-                        '& .MuiSvgIcon-root': {
-                          opacity: 1,
-                          color: 'black',
-                        },
-                      },
-                      padding: 0,
-                    }}
-                  >
-                    <MinimizeIcon
-                      sx={{
-                        fontSize: '8px',
-                        opacity: 0,
-                        transition: 'opacity 0.2s',
-                      }}
-                    />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title={isMaximized ? 'Restore' : 'Maximize'}>
-                  <IconButton
-                    onClick={handleMaximize}
-                    size="small"
-                    sx={{
-                      width: '12px',
-                      height: '12px',
-                      bgcolor: (t) => t.palette.grey[500],
-                      '&:hover': {
-                        bgcolor: '#28c940',
-                        '& .MuiSvgIcon-root': {
-                          opacity: 1,
-                          color: 'black',
-                        },
-                      },
-                      padding: 0,
-                    }}
-                  >
-                    {isMaximized ? (
-                      <RestoreIcon
-                        sx={{
-                          fontSize: '8px',
-                          opacity: 0,
-                          transition: 'opacity 0.2s',
-                        }}
-                      />
-                    ) : (
-                      <MaximizeIcon
-                        sx={{
-                          fontSize: '8px',
-                          opacity: 0,
-                          transition: 'opacity 0.2s',
-                        }}
-                      />
-                    )}
-                  </IconButton>
-                </Tooltip>
-              </Box>
-              <Box
-                sx={{ display: 'flex', gap: 1.5, WebkitAppRegion: 'no-drag' }}
-              >
-                {/* Settings button */}
-                <Tooltip title="Settings">
-                  <IconButton
-                    data-testid="nav-settings"
-                    onClick={() => setSettingsOpen(!settingsOpen)}
-                    size="small"
-                    sx={{
-                      ...mutedIconButtonSx,
-                      padding: 0,
-                    }}
-                  >
-                    <SettingsIcon sx={{ fontSize: 20 }} />
-                  </IconButton>
-                </Tooltip>
-                {/* Sidebar toggle button */}
-                <Tooltip title={open ? 'Hide Sidebar' : 'Show Sidebar'}>
-                  <IconButton
-                    data-testid="sidebar-toggle-close"
-                    onClick={handleDrawerToggle}
-                    size="small"
-                    sx={{
-                      ...mutedIconButtonSx,
-                      padding: 0,
-                    }}
-                  >
-                    <ViewSidebarRoundedIcon sx={{ fontSize: 20 }} />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-            </Box>
-
-            <List
-              sx={{
-                flexGrow: 1,
-                paddingTop: 0,
-                px: 1,
-                overflow: 'auto',
-                minHeight: 0,
-              }}
-            >
-              {/* Library section */}
-              <Box sx={{ mb: 0.5 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    px: 1.5,
-                    py: 0.5,
-                    WebkitAppRegion: 'no-drag',
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      flexGrow: 1,
-                      fontSize: '11px',
-                      fontWeight: 600,
-                      letterSpacing: '0.5px',
-                      textTransform: 'uppercase',
-                      color: (t) => t.palette.text.secondary,
-                      opacity: 0.7,
-                    }}
-                    variant="caption"
-                  >
-                    Library
-                  </Typography>
-                </Box>
-                <ListItemButton
-                  data-testid="nav-library"
-                  data-view="library"
-                  onClick={() => handleViewChange('library')}
-                  selected={currentView === 'library'}
-                  sx={{
-                    py: 0.25,
-                    px: 1.5,
-                    WebkitAppRegion: 'no-drag',
-                    borderRadius: 1,
-                    mb: 0,
-                    '&.Mui-selected': {
-                      backgroundColor: (t) =>
-                        t.palette.mode === 'dark'
-                          ? 'rgba(255, 255, 255, 0.08)'
-                          : 'rgba(0, 0, 0, 0.08)',
-                      '& .MuiListItemText-primary': {
-                        fontWeight: 600,
-                      },
-                      '&:hover': {
-                        backgroundColor: (t) =>
-                          t.palette.mode === 'dark'
-                            ? 'rgba(255, 255, 255, 0.1)'
-                            : 'rgba(0, 0, 0, 0.1)',
-                      },
-                    },
-                    '&:hover': {
-                      backgroundColor: (t) =>
-                        t.palette.mode === 'dark'
-                          ? 'rgba(255, 255, 255, 0.04)'
-                          : 'rgba(0, 0, 0, 0.04)',
-                    },
-                  }}
-                >
-                  <ListItemIcon
-                    sx={{
-                      minWidth: '24px',
-                      opacity: 0.7,
-                    }}
-                  >
-                    <LibraryMusicIcon sx={{ fontSize: 16 }} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary="All"
-                    slotProps={{
-                      primary: {
-                        sx: {
-                          fontSize: '13px',
-                          fontWeight: currentView === 'library' ? 600 : 400,
-                        },
-                      },
-                    }}
-                  />
-                </ListItemButton>
-              </Box>
-
-              {/* Playlists section */}
-              <Box sx={{ mt: 0.5, mb: 0.5 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    pl: 1.5,
-                    pr: 1,
-                    py: 0.5,
-                    WebkitAppRegion: 'no-drag',
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      flexGrow: 1,
-                      fontSize: '11px',
-                      fontWeight: 600,
-                      letterSpacing: '0.5px',
-                      textTransform: 'uppercase',
-                      color: (t) => t.palette.text.secondary,
-                      opacity: 0.7,
-                    }}
-                    variant="caption"
-                  >
-                    Playlists
-                  </Typography>
-                  <Tooltip title="Create Playlist">
-                    <IconButton
-                      data-testid="add-playlist-button"
-                      onClick={handleAddPlaylistClick}
-                      size="small"
-                      sx={{
-                        ...mutedIconButtonSx,
-                        p: 0,
-                        left: '2px', // offset makes it perfectly centered underneath the "hide sidebar" icon
-                        WebkitAppRegion: 'no-drag',
-                      }}
-                    >
-                      <AddIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-
-                <List component="div" disablePadding>
-                  {playlists.map((playlist) => (
-                    <ListItemButton
-                      key={playlist.id}
-                      data-playlist-id={playlist.id}
-                      onClick={() => handlePlaylistSelect(playlist.id)}
-                      onContextMenu={(e) =>
-                        handlePlaylistContextMenu(e, playlist.id)
-                      }
-                      onDragLeave={handlePlaylistDragLeave}
-                      onDragOver={(e) =>
-                        handlePlaylistDragOver(
-                          e,
-                          playlist.id,
-                          !!playlist.isSmart,
-                        )
-                      }
-                      onDrop={(e) =>
-                        handlePlaylistDrop(e, playlist.id, !!playlist.isSmart)
-                      }
-                      selected={
-                        currentView === 'playlists' &&
-                        selectedPlaylistId === playlist.id
-                      }
-                      sx={{
-                        py: 0.25,
-                        px: 1.5,
-                        WebkitAppRegion: 'no-drag',
-                        borderRadius: 1,
-                        mb: 0,
-                        transition: 'background-color 0.1s, outline 0.1s',
-                        ...(dragOverPlaylistId === playlist.id &&
-                          !playlist.isSmart && {
-                            backgroundColor: (t) =>
-                              t.palette.mode === 'dark'
-                                ? 'rgba(66, 165, 245, 0.15)'
-                                : 'rgba(33, 150, 243, 0.12)',
-                            outline: (t) =>
-                              `1px solid ${t.palette.mode === 'dark' ? 'rgba(66, 165, 245, 0.5)' : 'rgba(33, 150, 243, 0.5)'}`,
-                          }),
-                        '&.Mui-selected': {
-                          backgroundColor: (t) =>
-                            t.palette.mode === 'dark'
-                              ? 'rgba(255, 255, 255, 0.08)'
-                              : 'rgba(0, 0, 0, 0.08)',
-                          '& .MuiListItemText-primary': {
-                            fontWeight: 600,
-                          },
-                          '&:hover': {
-                            backgroundColor: (t) =>
-                              t.palette.mode === 'dark'
-                                ? 'rgba(255, 255, 255, 0.1)'
-                                : 'rgba(0, 0, 0, 0.1)',
-                          },
-                        },
-                        '&:hover': {
-                          backgroundColor: (t) =>
-                            t.palette.mode === 'dark'
-                              ? 'rgba(255, 255, 255, 0.04)'
-                              : 'rgba(0, 0, 0, 0.04)',
-                        },
-                      }}
-                    >
-                      <ListItemIcon
-                        sx={{
-                          minWidth: '24px',
-                          opacity: 0.7,
-                        }}
-                      >
-                        {playlist.isSmart ? (
-                          <AutoAwesomeIcon sx={{ fontSize: 16 }} />
-                        ) : (
-                          <QueueMusicIcon sx={{ fontSize: 16 }} />
-                        )}
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={playlist.name}
-                        slotProps={{
-                          primary: {
-                            noWrap: true,
-                            title: playlist.name,
-                            sx: {
-                              fontSize: '13px',
-                              fontWeight:
-                                currentView === 'playlists' &&
-                                selectedPlaylistId === playlist.id
-                                  ? 600
-                                  : 400,
-                            },
-                          },
-                        }}
-                      />
-                    </ListItemButton>
-                  ))}
-                </List>
-              </Box>
-            </List>
-          </Paper>
-        </Drawer>
-        <Main open={open}>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              height: 'calc(100vh - 100px)', // Adjusted height since AppBar is removed
-              width: '100%',
-              WebkitAppRegion: 'drag', // Make content area draggable by default
-              '& button, & input, & a, & [role="button"], & .MuiTableContainer-root, & .MuiDataGrid-root, & .MuiSlider-root':
-                {
-                  WebkitAppRegion: 'no-drag', // Make all interactive elements not draggable
-                },
-            }}
-          >
-            {currentView === 'library' && (
-              <Library drawerOpen={open} onDrawerToggle={handleDrawerToggle} />
-            )}
-            {currentView === 'playlists' && (
-              <Playlists
-                drawerOpen={open}
-                onDrawerToggle={handleDrawerToggle}
-              />
-            )}
-          </Box>
+        <Sidebar />
+        <Main open={sidebarOpen}>
+          <MainContent />
         </Main>
       </Box>
 
-      {/* Settings slide-over panel */}
       <Drawer
         anchor="right"
         onClose={() => setSettingsOpen(false)}
@@ -989,63 +288,6 @@ export default function MainLayout() {
         <Player />
       </PlayerWrapper>
 
-      {/* Context Menu for Playlist */}
-      <Menu
-        anchorPosition={
-          contextMenu !== null
-            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-            : undefined
-        }
-        anchorReference="anchorPosition"
-        onClose={handleContextMenuClose}
-        open={contextMenu !== null}
-      >
-        {/* Only show options for non-smart playlists */}
-        {contextMenu && !contextMenu.isSmart ? (
-          <>
-            <MenuItem
-              data-testid="rename-playlist-menu-item"
-              onClick={handleRenamePlaylist}
-            >
-              <ListItemIcon>
-                <EditIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText>Rename</ListItemText>
-            </MenuItem>
-            <MenuItem
-              data-testid="delete-playlist-menu-item"
-              onClick={handleDeletePlaylist}
-            >
-              <ListItemIcon>
-                <DeleteIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText>Delete Playlist</ListItemText>
-            </MenuItem>
-          </>
-        ) : (
-          <MenuItem onClick={() => {}}>
-            <ListItemText>No options available</ListItemText>
-          </MenuItem>
-        )}
-      </Menu>
-
-      {/* Create Playlist Dialog */}
-      <CreatePlaylistDialog
-        onClose={closeCreateDialog}
-        open={createDialogOpen}
-      />
-
-      {/* Rename Playlist Dialog */}
-      <RenamePlaylistDialog
-        initialName={
-          playlists.find((p) => p.id === renamePlaylistId)?.name || ''
-        }
-        onClose={closeRenameDialog}
-        open={renameDialogOpen}
-        playlistId={renamePlaylistId}
-      />
-
-      {/* Add the NotificationSystem component */}
       <NotificationSystem />
     </Box>
   );

--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -54,9 +54,11 @@ export default function MainLayout() {
   const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
-  // IPC: keyboard shortcut → toggle sidebar / open settings. Both store
-  // actions are referentially stable, so we read them from getState() at
-  // event time and keep the effect dep array empty.
+  // IPC keyboard shortcuts. toggleSidebar uses getState() because no
+  // other code in this file reads it (no top-level subscription needed).
+  // setSettingsOpen already has a top-level selector via the JSX, so we
+  // reuse it and accept the dep — Zustand action references are stable
+  // so the effect still only mounts once.
   useEffect(() => {
     const unsubToggleSidebar = window.electron.ipcRenderer.on(
       'ui:toggleSidebar',
@@ -67,17 +69,19 @@ export default function MainLayout() {
     const unsubOpenSettings = window.electron.ipcRenderer.on(
       'ui:openSettings',
       () => {
-        useUIStore.getState().setSettingsOpen(true);
+        setSettingsOpen(true);
       },
     );
     return () => {
       unsubToggleSidebar();
       unsubOpenSettings();
     };
-  }, []);
+  }, [setSettingsOpen]);
 
   // Document-level custom events for in-app navigation (used by deep
-  // links, notification clicks, etc.).
+  // links, notification clicks, etc.). setCurrentView uses getState()
+  // because nothing else in this file reads it; setSettingsOpen reuses
+  // the top-level selector for the same reason as the effect above.
   useEffect(() => {
     const handleCustomViewChange = (event: Event) => {
       const customEvent = event as CustomEvent<{ view: string }>;
@@ -85,14 +89,14 @@ export default function MainLayout() {
       if (view === 'library' || view === 'playlists') {
         useUIStore.getState().setCurrentView(view);
       } else if (view === 'settings') {
-        useUIStore.getState().setSettingsOpen(true);
+        setSettingsOpen(true);
       }
     };
     document.addEventListener('hihat:viewChange', handleCustomViewChange);
     return () => {
       document.removeEventListener('hihat:viewChange', handleCustomViewChange);
     };
-  }, []);
+  }, [setSettingsOpen]);
 
   useEffect(() => {
     const handleCustomPlaylistSelect = (event: Event) => {

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -54,13 +54,12 @@ const DEFAULT_PLAYLIST_SORTING: SortingState = [
   { id: 'albumArtist', desc: false },
 ];
 
-// Define props interface for Playlists component
-interface PlaylistsProps {
-  drawerOpen: boolean;
-  onDrawerToggle: () => void;
-}
+function Playlists() {
+  // Sidebar drawer state lives in uiStore — read it directly here so
+  // the parent doesn't need to thread it through as a prop.
+  const drawerOpen = useUIStore((state) => state.sidebarOpen);
+  const onDrawerToggle = useUIStore((state) => state.toggleSidebar);
 
-function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   // Get state from library store
   const playlists = useLibraryStore((state) => state.playlists);
   const tracks = useLibraryStore((state) => state.tracks);
@@ -1133,7 +1132,4 @@ function Playlists({ drawerOpen, onDrawerToggle }: PlaylistsProps) {
   );
 }
 
-// Shields Playlists from MainLayout re-renders (drawer toggle,
-// notifications, player sync, etc.). Props are primitive + stable
-// useCallback, so the default shallow compare is sufficient.
-export default React.memo(Playlists);
+export default Playlists;

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -151,6 +151,7 @@ function Playlists() {
   // Browser state
   const browserOpen = useUIStore((state) => state.browserOpen);
   const setBrowserOpen = useUIStore((state) => state.setBrowserOpen);
+  const showNotification = useUIStore((state) => state.showNotification);
   const browserFilters = useLibraryStore((state) => state.browserFilters);
   const setBrowserFilter = useLibraryStore((state) => state.setBrowserFilter);
   const [browserHeight, setBrowserHeight] = useState(200);
@@ -273,8 +274,6 @@ function Playlists() {
     const track = tracks.find((t) => t.id === removeTrackId);
 
     try {
-      const { showNotification } = useUIStore.getState();
-
       const updatedPlaylist = {
         ...selectedPlaylist,
         trackIds: selectedPlaylist.trackIds.filter(
@@ -291,7 +290,6 @@ function Playlists() {
       );
     } catch (error) {
       console.error('Error removing track from playlist:', error);
-      const { showNotification } = useUIStore.getState();
       showNotification('Failed to remove track from playlist', 'error');
     }
 
@@ -320,8 +318,6 @@ function Playlists() {
     if (!selectedPlaylist) return;
 
     try {
-      const { showNotification } = useUIStore.getState();
-
       const updatedPlaylist = {
         ...selectedPlaylist,
         trackIds: selectedPlaylist.trackIds.filter(
@@ -340,7 +336,6 @@ function Playlists() {
       );
     } catch (error) {
       console.error('Error removing tracks from playlist:', error);
-      const { showNotification } = useUIStore.getState();
       showNotification('Failed to remove tracks from playlist', 'error');
     }
   };

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -55,8 +55,7 @@ const DEFAULT_PLAYLIST_SORTING: SortingState = [
 ];
 
 function Playlists() {
-  // Sidebar drawer state lives in uiStore — read it directly here so
-  // the parent doesn't need to thread it through as a prop.
+  // Subscribe directly so the parent doesn't need a drawer prop.
   const drawerOpen = useUIStore((state) => state.sidebarOpen);
   const onDrawerToggle = useUIStore((state) => state.toggleSidebar);
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,0 +1,586 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Drawer,
+  Typography,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Paper,
+} from '@mui/material';
+import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
+import QueueMusicIcon from '@mui/icons-material/QueueMusic';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import SettingsIcon from '@mui/icons-material/Settings';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import ViewSidebarRoundedIcon from '@mui/icons-material/ViewSidebarRounded';
+import {
+  useLibraryStore,
+  useSettingsAndPlaybackStore,
+  useUIStore,
+} from '../stores';
+import WindowControls from './WindowControls';
+import RenamePlaylistDialog from './RenamePlaylistDialog';
+import CreatePlaylistDialog from './CreatePlaylistDialog';
+import { mutedIconButtonSx } from '../styles/iconButtonStyles';
+
+const drawerWidth = 200;
+
+export default function Sidebar() {
+  const playlists = useLibraryStore((state) => state.playlists);
+  const selectedPlaylistId = useLibraryStore(
+    (state) => state.selectedPlaylistId,
+  );
+  const selectPlaylist = useLibraryStore((state) => state.selectPlaylist);
+  const deletePlaylist = useLibraryStore((state) => state.deletePlaylist);
+
+  const theme = useSettingsAndPlaybackStore((state) => state.theme);
+
+  const currentView = useUIStore((state) => state.currentView);
+  const setCurrentView = useUIStore((state) => state.setCurrentView);
+  const settingsOpen = useUIStore((state) => state.settingsOpen);
+  const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
+  const sidebarOpen = useUIStore((state) => state.sidebarOpen);
+  const toggleSidebar = useUIStore((state) => state.toggleSidebar);
+
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [dragOverPlaylistId, setDragOverPlaylistId] = useState<string | null>(
+    null,
+  );
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renamePlaylistId, setRenamePlaylistId] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    mouseX: number;
+    mouseY: number;
+    playlistId: string;
+    isSmart?: boolean;
+  } | null>(null);
+
+  const handleViewChange = (view: 'library' | 'playlists') => {
+    setCurrentView(view);
+  };
+
+  const handlePlaylistSelect = (playlistId: string) => {
+    selectPlaylist(playlistId);
+    setCurrentView('playlists');
+  };
+
+  const handlePlaylistContextMenu = (
+    event: React.MouseEvent,
+    playlistId: string,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const playlist = playlists.find((p) => p.id === playlistId);
+    setContextMenu({
+      mouseX: event.clientX,
+      mouseY: event.clientY,
+      playlistId,
+      isSmart: playlist?.isSmart || false,
+    });
+  };
+
+  const handleContextMenuClose = () => {
+    setContextMenu(null);
+  };
+
+  const handleDeletePlaylist = async () => {
+    if (!contextMenu) return;
+    if (contextMenu.isSmart) {
+      useUIStore
+        .getState()
+        .showNotification('Smart playlists cannot be deleted', 'warning');
+      setContextMenu(null);
+      return;
+    }
+    await deletePlaylist(contextMenu.playlistId);
+    if (selectedPlaylistId === contextMenu.playlistId) {
+      selectPlaylist(null);
+    }
+    setContextMenu(null);
+  };
+
+  const handleRenamePlaylist = () => {
+    if (!contextMenu) return;
+    setRenamePlaylistId(contextMenu.playlistId);
+    setRenameDialogOpen(true);
+    setContextMenu(null);
+  };
+
+  const closeRenameDialog = () => {
+    setRenameDialogOpen(false);
+    setRenamePlaylistId(null);
+  };
+
+  const handleAddPlaylistClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setCreateDialogOpen(true);
+  };
+
+  const closeCreateDialog = () => {
+    setCreateDialogOpen(false);
+  };
+
+  const handlePlaylistDragOver = (
+    e: React.DragEvent,
+    playlistId: string,
+    isSmart: boolean,
+  ) => {
+    if (
+      isSmart ||
+      !e.dataTransfer.types.includes('application/x-hihat-tracks')
+    ) {
+      e.dataTransfer.dropEffect = 'none';
+      return;
+    }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    setDragOverPlaylistId(playlistId);
+  };
+
+  const handlePlaylistDragLeave = (e: React.DragEvent) => {
+    const related = e.relatedTarget as Node | null;
+    if (related && (e.currentTarget as Node).contains(related)) {
+      return;
+    }
+    setDragOverPlaylistId(null);
+  };
+
+  const handlePlaylistDrop = async (
+    e: React.DragEvent,
+    playlistId: string,
+    isSmart: boolean,
+  ) => {
+    setDragOverPlaylistId(null);
+    if (isSmart) return;
+
+    const raw = e.dataTransfer.getData('application/x-hihat-tracks');
+    if (!raw) return;
+    e.preventDefault();
+
+    let trackIds: string[];
+    try {
+      trackIds = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    if (!Array.isArray(trackIds) || trackIds.length === 0) return;
+
+    const { showNotification } = useUIStore.getState();
+    const { addTrackToPlaylist } = useLibraryStore.getState();
+
+    if (trackIds.length === 1) {
+      await addTrackToPlaylist(trackIds[0], playlistId);
+      return;
+    }
+
+    const currentPlaylists = useLibraryStore.getState().playlists;
+    const playlist = currentPlaylists.find((p) => p.id === playlistId);
+    if (!playlist) return;
+
+    const existingSet = new Set(playlist.trackIds);
+    const newTrackIds = trackIds.filter((id) => !existingSet.has(id));
+    const dupeCount = trackIds.length - newTrackIds.length;
+
+    if (newTrackIds.length === 0) {
+      showNotification(
+        `All ${trackIds.length} tracks are already in "${playlist.name}"`,
+        'info',
+      );
+      return;
+    }
+
+    const updatedPlaylist = {
+      ...playlist,
+      trackIds: [...playlist.trackIds, ...newTrackIds],
+    };
+
+    await window.electron.playlists.update(updatedPlaylist);
+    useLibraryStore.setState((state) => ({
+      playlists: state.playlists.map((p) =>
+        p.id === playlistId ? updatedPlaylist : p,
+      ),
+    }));
+
+    const dupeMsg = dupeCount > 0 ? ` (${dupeCount} already in playlist)` : '';
+    showNotification(
+      `Added ${newTrackIds.length} track${newTrackIds.length > 1 ? 's' : ''} to "${playlist.name}"${dupeMsg}`,
+      'success',
+    );
+  };
+
+  useEffect(() => {
+    const handleDragEnd = () => setDragOverPlaylistId(null);
+    document.addEventListener('dragend', handleDragEnd);
+    return () => document.removeEventListener('dragend', handleDragEnd);
+  }, []);
+
+  return (
+    <>
+      <Drawer
+        anchor="left"
+        open={sidebarOpen}
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+            display: 'flex',
+            flexDirection: 'column',
+            height: 'calc(100vh - 100px)',
+            WebkitAppRegion: 'drag',
+            '& .MuiListItemButton-root, & .MuiIconButton-root, & .MuiListItemIcon-root, & .MuiListItemText-root':
+              {
+                WebkitAppRegion: 'no-drag',
+              },
+          },
+        }}
+        variant="persistent"
+      >
+        <Paper
+          elevation={0}
+          sx={{
+            borderRadius: '0px',
+            height: '100%',
+            backgroundColor: theme === 'dark' ? '#000000' : '#FFFFFF',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          {/* Window chrome row: traffic lights + settings/sidebar toggle */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              px: 1.5,
+              py: 0.5,
+              WebkitAppRegion: 'drag',
+              height: '44px',
+            }}
+          >
+            <WindowControls />
+            <Box sx={{ display: 'flex', gap: 1.5, WebkitAppRegion: 'no-drag' }}>
+              <Tooltip title="Settings">
+                <IconButton
+                  data-testid="nav-settings"
+                  onClick={() => setSettingsOpen(!settingsOpen)}
+                  size="small"
+                  sx={{
+                    ...mutedIconButtonSx,
+                    padding: 0,
+                  }}
+                >
+                  <SettingsIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={sidebarOpen ? 'Hide Sidebar' : 'Show Sidebar'}>
+                <IconButton
+                  data-testid="sidebar-toggle-close"
+                  onClick={toggleSidebar}
+                  size="small"
+                  sx={{
+                    ...mutedIconButtonSx,
+                    padding: 0,
+                  }}
+                >
+                  <ViewSidebarRoundedIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
+
+          <List
+            sx={{
+              flexGrow: 1,
+              paddingTop: 0,
+              px: 1,
+              overflow: 'auto',
+              minHeight: 0,
+            }}
+          >
+            {/* Library section */}
+            <Box sx={{ mb: 0.5 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  px: 1.5,
+                  py: 0.5,
+                  WebkitAppRegion: 'no-drag',
+                }}
+              >
+                <Typography
+                  sx={{
+                    flexGrow: 1,
+                    fontSize: '11px',
+                    fontWeight: 600,
+                    letterSpacing: '0.5px',
+                    textTransform: 'uppercase',
+                    color: (t) => t.palette.text.secondary,
+                    opacity: 0.7,
+                  }}
+                  variant="caption"
+                >
+                  Library
+                </Typography>
+              </Box>
+              <ListItemButton
+                data-testid="nav-library"
+                data-view="library"
+                onClick={() => handleViewChange('library')}
+                selected={currentView === 'library'}
+                sx={{
+                  py: 0.25,
+                  px: 1.5,
+                  WebkitAppRegion: 'no-drag',
+                  borderRadius: 1,
+                  mb: 0,
+                  '&.Mui-selected': {
+                    backgroundColor: (t) =>
+                      t.palette.mode === 'dark'
+                        ? 'rgba(255, 255, 255, 0.08)'
+                        : 'rgba(0, 0, 0, 0.08)',
+                    '& .MuiListItemText-primary': {
+                      fontWeight: 600,
+                    },
+                    '&:hover': {
+                      backgroundColor: (t) =>
+                        t.palette.mode === 'dark'
+                          ? 'rgba(255, 255, 255, 0.1)'
+                          : 'rgba(0, 0, 0, 0.1)',
+                    },
+                  },
+                  '&:hover': {
+                    backgroundColor: (t) =>
+                      t.palette.mode === 'dark'
+                        ? 'rgba(255, 255, 255, 0.04)'
+                        : 'rgba(0, 0, 0, 0.04)',
+                  },
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    minWidth: '24px',
+                    opacity: 0.7,
+                  }}
+                >
+                  <LibraryMusicIcon sx={{ fontSize: 16 }} />
+                </ListItemIcon>
+                <ListItemText
+                  primary="All"
+                  slotProps={{
+                    primary: {
+                      sx: {
+                        fontSize: '13px',
+                        fontWeight: currentView === 'library' ? 600 : 400,
+                      },
+                    },
+                  }}
+                />
+              </ListItemButton>
+            </Box>
+
+            {/* Playlists section */}
+            <Box sx={{ mt: 0.5, mb: 0.5 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  pl: 1.5,
+                  pr: 1,
+                  py: 0.5,
+                  WebkitAppRegion: 'no-drag',
+                }}
+              >
+                <Typography
+                  sx={{
+                    flexGrow: 1,
+                    fontSize: '11px',
+                    fontWeight: 600,
+                    letterSpacing: '0.5px',
+                    textTransform: 'uppercase',
+                    color: (t) => t.palette.text.secondary,
+                    opacity: 0.7,
+                  }}
+                  variant="caption"
+                >
+                  Playlists
+                </Typography>
+                <Tooltip title="Create Playlist">
+                  <IconButton
+                    data-testid="add-playlist-button"
+                    onClick={handleAddPlaylistClick}
+                    size="small"
+                    sx={{
+                      ...mutedIconButtonSx,
+                      p: 0,
+                      left: '2px',
+                      WebkitAppRegion: 'no-drag',
+                    }}
+                  >
+                    <AddIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+
+              <List component="div" disablePadding>
+                {playlists.map((playlist) => (
+                  <ListItemButton
+                    key={playlist.id}
+                    data-playlist-id={playlist.id}
+                    onClick={() => handlePlaylistSelect(playlist.id)}
+                    onContextMenu={(e) =>
+                      handlePlaylistContextMenu(e, playlist.id)
+                    }
+                    onDragLeave={handlePlaylistDragLeave}
+                    onDragOver={(e) =>
+                      handlePlaylistDragOver(e, playlist.id, !!playlist.isSmart)
+                    }
+                    onDrop={(e) =>
+                      handlePlaylistDrop(e, playlist.id, !!playlist.isSmart)
+                    }
+                    selected={
+                      currentView === 'playlists' &&
+                      selectedPlaylistId === playlist.id
+                    }
+                    sx={{
+                      py: 0.25,
+                      px: 1.5,
+                      WebkitAppRegion: 'no-drag',
+                      borderRadius: 1,
+                      mb: 0,
+                      transition: 'background-color 0.1s, outline 0.1s',
+                      ...(dragOverPlaylistId === playlist.id &&
+                        !playlist.isSmart && {
+                          backgroundColor: (t) =>
+                            t.palette.mode === 'dark'
+                              ? 'rgba(66, 165, 245, 0.15)'
+                              : 'rgba(33, 150, 243, 0.12)',
+                          outline: (t) =>
+                            `1px solid ${t.palette.mode === 'dark' ? 'rgba(66, 165, 245, 0.5)' : 'rgba(33, 150, 243, 0.5)'}`,
+                        }),
+                      '&.Mui-selected': {
+                        backgroundColor: (t) =>
+                          t.palette.mode === 'dark'
+                            ? 'rgba(255, 255, 255, 0.08)'
+                            : 'rgba(0, 0, 0, 0.08)',
+                        '& .MuiListItemText-primary': {
+                          fontWeight: 600,
+                        },
+                        '&:hover': {
+                          backgroundColor: (t) =>
+                            t.palette.mode === 'dark'
+                              ? 'rgba(255, 255, 255, 0.1)'
+                              : 'rgba(0, 0, 0, 0.1)',
+                        },
+                      },
+                      '&:hover': {
+                        backgroundColor: (t) =>
+                          t.palette.mode === 'dark'
+                            ? 'rgba(255, 255, 255, 0.04)'
+                            : 'rgba(0, 0, 0, 0.04)',
+                      },
+                    }}
+                  >
+                    <ListItemIcon
+                      sx={{
+                        minWidth: '24px',
+                        opacity: 0.7,
+                      }}
+                    >
+                      {playlist.isSmart ? (
+                        <AutoAwesomeIcon sx={{ fontSize: 16 }} />
+                      ) : (
+                        <QueueMusicIcon sx={{ fontSize: 16 }} />
+                      )}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={playlist.name}
+                      slotProps={{
+                        primary: {
+                          noWrap: true,
+                          title: playlist.name,
+                          sx: {
+                            fontSize: '13px',
+                            fontWeight:
+                              currentView === 'playlists' &&
+                              selectedPlaylistId === playlist.id
+                                ? 600
+                                : 400,
+                          },
+                        },
+                      }}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            </Box>
+          </List>
+        </Paper>
+      </Drawer>
+
+      <Menu
+        anchorPosition={
+          contextMenu !== null
+            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+            : undefined
+        }
+        anchorReference="anchorPosition"
+        onClose={handleContextMenuClose}
+        open={contextMenu !== null}
+      >
+        {contextMenu && !contextMenu.isSmart ? (
+          <>
+            <MenuItem
+              data-testid="rename-playlist-menu-item"
+              onClick={handleRenamePlaylist}
+            >
+              <ListItemIcon>
+                <EditIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Rename</ListItemText>
+            </MenuItem>
+            <MenuItem
+              data-testid="delete-playlist-menu-item"
+              onClick={handleDeletePlaylist}
+            >
+              <ListItemIcon>
+                <DeleteIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Delete Playlist</ListItemText>
+            </MenuItem>
+          </>
+        ) : (
+          <MenuItem onClick={() => {}}>
+            <ListItemText>No options available</ListItemText>
+          </MenuItem>
+        )}
+      </Menu>
+
+      <CreatePlaylistDialog
+        onClose={closeCreateDialog}
+        open={createDialogOpen}
+      />
+
+      <RenamePlaylistDialog
+        initialName={
+          playlists.find((p) => p.id === renamePlaylistId)?.name || ''
+        }
+        onClose={closeRenameDialog}
+        open={renameDialogOpen}
+        playlistId={renamePlaylistId}
+      />
+    </>
+  );
+}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -49,6 +49,7 @@ export default function Sidebar() {
   const setSettingsOpen = useUIStore((state) => state.setSettingsOpen);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
+  const showNotification = useUIStore((state) => state.showNotification);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [dragOverPlaylistId, setDragOverPlaylistId] = useState<string | null>(
@@ -94,9 +95,7 @@ export default function Sidebar() {
   const handleDeletePlaylist = async () => {
     if (!contextMenu) return;
     if (contextMenu.isSmart) {
-      useUIStore
-        .getState()
-        .showNotification('Smart playlists cannot be deleted', 'warning');
+      showNotification('Smart playlists cannot be deleted', 'warning');
       setContextMenu(null);
       return;
     }
@@ -174,7 +173,6 @@ export default function Sidebar() {
 
     if (!Array.isArray(trackIds) || trackIds.length === 0) return;
 
-    const { showNotification } = useUIStore.getState();
     const { addTrackToPlaylist } = useLibraryStore.getState();
 
     if (trackIds.length === 1) {

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import MinimizeIcon from '@mui/icons-material/Remove';
+import MaximizeIcon from '@mui/icons-material/CropSquare';
+import RestoreIcon from '@mui/icons-material/FilterNone';
+
+export default function WindowControls() {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  const checkMaximized = useCallback(async () => {
+    const maximized = await window.electron.window.isMaximized();
+    setIsMaximized(maximized);
+  }, []);
+
+  const handleMaximize = () => {
+    window.electron.window.maximize();
+    setTimeout(checkMaximized, 100);
+  };
+
+  useEffect(() => {
+    checkMaximized();
+    const unsubMaximizedChange = window.electron.window.onMaximizedChange(
+      (maximized) => {
+        setIsMaximized(maximized);
+      },
+    );
+    return () => {
+      unsubMaximizedChange();
+    };
+  }, [checkMaximized]);
+
+  return (
+    <Box sx={{ display: 'flex', gap: '8px', WebkitAppRegion: 'no-drag' }}>
+      <Tooltip title="Close">
+        <IconButton
+          onClick={() => window.electron.window.close()}
+          size="small"
+          sx={{
+            width: '12px',
+            height: '12px',
+            bgcolor: (t) => t.palette.grey[500],
+            '&:hover': {
+              bgcolor: '#ff5f57',
+              '& .MuiSvgIcon-root': {
+                opacity: 1,
+                color: 'black',
+              },
+            },
+            padding: 0,
+          }}
+        >
+          <CloseIcon
+            sx={{
+              fontSize: '8px',
+              opacity: 0,
+              transition: 'opacity 0.2s',
+            }}
+          />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Minimize">
+        <IconButton
+          onClick={() => window.electron.window.minimize()}
+          size="small"
+          sx={{
+            width: '12px',
+            height: '12px',
+            bgcolor: (t) => t.palette.grey[500],
+            '&:hover': {
+              bgcolor: '#ffbd2e',
+              '& .MuiSvgIcon-root': {
+                opacity: 1,
+                color: 'black',
+              },
+            },
+            padding: 0,
+          }}
+        >
+          <MinimizeIcon
+            sx={{
+              fontSize: '8px',
+              opacity: 0,
+              transition: 'opacity 0.2s',
+            }}
+          />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title={isMaximized ? 'Restore' : 'Maximize'}>
+        <IconButton
+          onClick={handleMaximize}
+          size="small"
+          sx={{
+            width: '12px',
+            height: '12px',
+            bgcolor: (t) => t.palette.grey[500],
+            '&:hover': {
+              bgcolor: '#28c940',
+              '& .MuiSvgIcon-root': {
+                opacity: 1,
+                color: 'black',
+              },
+            },
+            padding: 0,
+          }}
+        >
+          {isMaximized ? (
+            <RestoreIcon
+              sx={{
+                fontSize: '8px',
+                opacity: 0,
+                transition: 'opacity 0.2s',
+              }}
+            />
+          ) : (
+            <MaximizeIcon
+              sx={{
+                fontSize: '8px',
+                opacity: 0,
+                transition: 'opacity 0.2s',
+              }}
+            />
+          )}
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -161,6 +161,7 @@ export interface UIStore {
   currentView: 'library' | 'playlists';
   settingsOpen: boolean;
   browserOpen: boolean;
+  sidebarOpen: boolean;
   showNotification: (
     message: string,
     type: 'info' | 'success' | 'warning' | 'error',
@@ -172,6 +173,8 @@ export interface UIStore {
   setCurrentView: (view: 'library' | 'playlists') => void;
   setSettingsOpen: (open: boolean) => void;
   setBrowserOpen: (open: boolean) => void;
+  setSidebarOpen: (open: boolean) => void;
+  toggleSidebar: () => void;
 }
 
 // Combined Settings and Playback Store Types

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -8,6 +8,7 @@ const useUIStore = create<UIStore>((set) => ({
   currentView: 'library',
   settingsOpen: false,
   browserOpen: false,
+  sidebarOpen: true,
   notificationPanelOpen: false,
 
   // Actions
@@ -54,6 +55,9 @@ const useUIStore = create<UIStore>((set) => ({
     }
     set({ browserOpen: open });
   },
+
+  setSidebarOpen: (open: boolean) => set({ sidebarOpen: open }),
+  toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
 }));
 
 export default useUIStore;


### PR DESCRIPTION
## Summary

- **Decompose MainLayout** (~1050 → ~290 lines) into focused components: `WindowControls`, `Sidebar`, `MainContent`. Each owns the state it needs, so transient UI state changes (drag-over, context menu, isMaximized, dialogs) no longer re-render the entire shell.
- **Lift sidebar drawer state** into `uiStore` (`sidebarOpen` + `toggleSidebar`). `Library` and `Playlists` subscribe directly via selector instead of receiving `drawerOpen` / `onDrawerToggle` as props.
- **Drop `React.memo`** on `Library` and `Playlists`. With the parent no longer pushing renders for state these components don't care about, the memo wrappers and their justification comments are dead weight.

## Why

`MainLayout` was a god component owning window chrome, sidebar drag state, context menus, dialogs, view switching, and the settings drawer. Every transient UI state change re-rendered the whole shell — which is exactly why `Library` and `Playlists` each needed a `React.memo` defensive shield against the cascade. That memo was a symptom, not a fix. "Before You memo()" applies directly: move state down so the parent stops re-rendering, and the memo becomes obsolete by construction.

After the split, `Library` and `Playlists` re-render only when:
1. View switches mount them (unavoidable)
2. Their own store subscriptions fire (intended)
3. The user actually toggles the sidebar (rare, legitimate)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:e2e` — **121 passed, 1 skipped** (full suite, including drag-to-playlist, context menus, sidebar persistence, view switching, search persistence, sort persistence, scroll-to-song, settings drawer, theme toggle, UI visual verification)
- [x] Manual: drag a track from the library table onto a sidebar playlist, confirm drop highlight + add behavior
- [x] Manual: right-click a playlist, rename and delete flows
- [x] Manual: maximize/restore the window, settings drawer toggle, view switching

## Files

| File | Change |
|---|---|
| `MainLayout.tsx` | Thin shell (~290 lines): loading screen, IPC + custom-event listeners, `Main` margin animation, settings drawer, `Player`, `NotificationSystem` |
| `Sidebar.tsx` | **NEW** — owns drag/context/dialog state, playlist list, window-chrome row |
| `MainContent.tsx` | **NEW** — reads `currentView`, renders `<Library/>` or `<Playlists/>` |
| `WindowControls.tsx` | **NEW** — owns `isMaximized`, traffic-light buttons |
| `Library.tsx` | Drops `drawerOpen` prop, reads `sidebarOpen` from `uiStore`. Drops `React.memo` wrapper. |
| `Playlists.tsx` | Same as Library. |
| `uiStore.ts` + `types.ts` | Adds `sidebarOpen` state + `setSidebarOpen` / `toggleSidebar` actions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)