### PR TITLE
fix: eliminate theme FOUC on app boot

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -243,17 +243,45 @@ const createWindow = async () => {
 
   mainWindow.loadURL(resolveHtmlPath('index.html'));
 
+  // ── Deferred window show ──────────────────────────────────────────
+  // The window is created with `show: false` (see BrowserWindow options
+  // above) to prevent a flash of incorrectly-themed content. Two
+  // conditions must be met before the window is shown:
+  //
+  //   1. ready-to-show  — Electron has painted the first frame
+  //   2. app:settingsLoaded — the renderer has loaded the user's theme
+  //      preference from the database (sent from loadSettings() in
+  //      settingsAndPlaybackStore.ts)
+  //
+  // Without this, the renderer's initial Zustand state (theme: 'dark')
+  // is painted before the async IPC round-trip to fetch the real
+  // preference completes, causing a visible theme flash for light-mode
+  // users. By holding the window hidden until both events fire, the
+  // first frame the user sees always has the correct theme applied.
+  // ────────────────────────────────────────────────────────────────────
   let windowReadyToShow = false;
-  mainWindow.on('ready-to-show', () => {
-    if (!mainWindow) {
-      throw new Error('"mainWindow" is not defined');
-    }
-    windowReadyToShow = true;
+  let rendererSettingsLoaded = false;
+
+  const showWindowIfReady = () => {
+    if (!mainWindow || !windowReadyToShow || !rendererSettingsLoaded) return;
     if (process.env.START_MINIMIZED) {
       mainWindow.minimize();
     } else if (!isTestHidden) {
       mainWindow.show();
     }
+  };
+
+  mainWindow.on('ready-to-show', () => {
+    if (!mainWindow) {
+      throw new Error('"mainWindow" is not defined');
+    }
+    windowReadyToShow = true;
+    showWindowIfReady();
+  });
+
+  ipcMain.once('app:settingsLoaded', () => {
+    rendererSettingsLoaded = true;
+    showWindowIfReady();
   });
 
   mainWindow.on('closed', () => {

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -42,7 +42,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     // Settings state (from settingsStore)
     id: 'app-settings', // db record name never changes
     libraryPath: '',
-    theme: 'light',
+    theme: 'dark',
     lastPlayedSongId: null,
     volume: 1.0,
     columns: {
@@ -146,15 +146,25 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           player.setVolume(volumeValue);
         }
 
+        // Signal the main process that settings are loaded so the window
+        // can be shown with the correct theme. See the "Deferred window
+        // show" comment in main.ts for the full pattern.
+        window.electron.ipcRenderer.sendMessage('app:settingsLoaded');
+
         return appSettings;
       } catch (error) {
         console.error('Error loading settings:', error);
         useUIStore
           .getState()
           .showNotification('Failed to load settings', 'error');
+
+        // Signal even on failure — the window must still show. The store
+        // defaults to 'dark' so the fallback theme is reasonable.
+        window.electron.ipcRenderer.sendMessage('app:settingsLoaded');
+
         return {
           libraryPath: '',
-          theme: 'light',
+          theme: 'dark',
           lastPlayedSongId: null,
           volume: 1.0,
           columns: {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -54,6 +54,7 @@ export type Channels =
   | 'app:restart'
   | 'app:open-in-browser'
   | 'app:getLogFilePath'
+  | 'app:settingsLoaded'
 
   // UI operations
   | 'ui:toggleSidebar'
@@ -164,6 +165,7 @@ export interface IPCRequests {
   'app:restart': void;
   'app:open-in-browser': { link: string };
   'app:getLogFilePath': void;
+  'app:settingsLoaded': void;
 
   // UI operations
   'ui:toggleSidebar': void;
@@ -320,6 +322,7 @@ export interface IPCResponses {
   'app:restart': boolean;
   'app:open-in-browser': { success: boolean; message?: string };
   'app:getLogFilePath': { path: string | null; exists: boolean };
+  'app:settingsLoaded': void;
 
   // UI operations
   'ui:toggleSidebar': boolean;


### PR DESCRIPTION
Closes #61

## Summary
- **Default theme → dark**: Zustand store initial state and `loadSettings()` error fallback now default to `'dark'`, matching the database default. Previously defaulted to `'light'`, causing a flash of light-themed content for dark-mode users.
- **Deferred window show**: The main window already used `show: false`, but showed on `ready-to-show` (first paint) — before the async settings IPC resolved. Now the window waits for **both** `ready-to-show` AND an `app:settingsLoaded` IPC signal from the renderer, so the first visible frame always has the correct theme.
- **New IPC channel**: `app:settingsLoaded` — fire-and-forget signal sent by `loadSettings()` in `settingsAndPlaybackStore.ts` after settings are applied (or on error, so the window never gets stuck hidden).

### Files changed
| File | Change |
|------|--------|
| `src/main/main.ts` | Two-condition gate before `window.show()` with documentation |
| `src/renderer/stores/settingsAndPlaybackStore.ts` | Default theme `'dark'`, sends `app:settingsLoaded` IPC |
| `src/types/ipc.ts` | `app:settingsLoaded` added to `Channels`, `IPCRequests`, `IPCResponses` |

## Test plan
- [x] Launch app with dark theme preference → no flash, window appears dark immediately
- [x] Launch app with light theme preference → no flash, window appears light immediately
- [x] Force `loadSettings()` error (e.g. corrupt DB) → window still shows with dark fallback
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build && npm run test:e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)