### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Bump version from 2.0.1 to 2.0.2 across package.json, package-lock.json, and release/app equivalents

## Test plan
- [ ] Verify version shows 2.0.2 in packaged app

🤖 Generated with [Claude Code](https://claude.com/claude-code)