### PR TITLE
ui: Settings drawer polish, non-selectable chrome, pill alignment

### DIFF
--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -733,7 +733,7 @@ export default function Library() {
                 ? theme.palette.grey[800]
                 : theme.palette.grey[200],
             px: 1.5,
-            py: 0.5,
+            height: 22,
             justifyContent: 'center',
             userSelect: 'none',
             flexShrink: 0,
@@ -743,11 +743,25 @@ export default function Library() {
             sx={{
               color: (theme) => theme.palette.text.secondary,
               lineHeight: 1,
+              fontSize: '13px',
             }}
             variant="body2"
           >
-            {data.length.toLocaleString()}&nbsp;&#9835;
+            {data.length.toLocaleString()}&nbsp;
           </Typography>
+          <Box
+            component="span"
+            sx={{
+              color: (theme) => theme.palette.text.secondary,
+              display: 'inline-flex',
+            }}
+          >
+            <MaterialSymbolIcon
+              fontSize={16}
+              icon="music_note_2"
+              weight={100}
+            />
+          </Box>
         </Box>
         <Box
           sx={{
@@ -759,7 +773,7 @@ export default function Library() {
                 ? theme.palette.grey[800]
                 : theme.palette.grey[200],
             px: 1.5,
-            py: 0.5,
+            height: 22,
             justifyContent: 'center',
             userSelect: 'none',
             flexShrink: 0,
@@ -769,6 +783,7 @@ export default function Library() {
             sx={{
               color: (theme) => theme.palette.text.secondary,
               lineHeight: 1,
+              fontSize: '13px',
             }}
             variant="body2"
           >

--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -272,14 +272,14 @@ export default function MainLayout() {
       </Box>
 
       <Drawer
-        anchor="right"
+        anchor="left"
         onClose={() => setSettingsOpen(false)}
         open={settingsOpen}
         sx={{
           '& .MuiDrawer-paper': {
             width: 'min(480px, calc(100vw - 60px))',
             boxSizing: 'border-box',
-            borderLeft: '1px solid',
+            borderRight: '1px solid',
             borderColor: (t) => t.palette.divider,
             WebkitAppRegion: 'no-drag',
           },

--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -746,6 +746,7 @@ export default function Player() {
                       textOverflow: 'ellipsis',
                       width: 'fit-content',
                       maxWidth: '100%',
+                      userSelect: 'none',
                     }}
                     variant="body1"
                   >
@@ -773,6 +774,7 @@ export default function Player() {
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     fontWeight: '500',
+                    userSelect: 'none',
                   }}
                   variant="body2"
                 >

--- a/src/renderer/components/Playlists.tsx
+++ b/src/renderer/components/Playlists.tsx
@@ -741,7 +741,7 @@ export default function Playlists() {
                 ? theme.palette.grey[800]
                 : theme.palette.grey[200],
             px: 1.5,
-            py: 0.5,
+            height: 22,
             justifyContent: 'center',
             userSelect: 'none',
             flexShrink: 0,
@@ -751,11 +751,25 @@ export default function Playlists() {
             sx={{
               color: (theme) => theme.palette.text.secondary,
               lineHeight: 1,
+              fontSize: '13px',
             }}
             variant="body2"
           >
-            {playlistTracks.length.toLocaleString()}&nbsp;&#9835;
+            {playlistTracks.length.toLocaleString()}&nbsp;
           </Typography>
+          <Box
+            component="span"
+            sx={{
+              color: (theme) => theme.palette.text.secondary,
+              display: 'inline-flex',
+            }}
+          >
+            <MaterialSymbolIcon
+              fontSize={16}
+              icon="music_note_2"
+              weight={100}
+            />
+          </Box>
         </Box>
         <Box
           sx={{
@@ -767,7 +781,7 @@ export default function Playlists() {
                 ? theme.palette.grey[800]
                 : theme.palette.grey[200],
             px: 1.5,
-            py: 0.5,
+            height: 22,
             justifyContent: 'center',
             userSelect: 'none',
             flexShrink: 0,
@@ -777,6 +791,7 @@ export default function Playlists() {
             sx={{
               color: (theme) => theme.palette.text.secondary,
               lineHeight: 1,
+              fontSize: '13px',
             }}
             variant="body2"
           >

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -651,12 +651,21 @@ export default function Settings({ onClose }: SettingsProps) {
           top: 0,
           backgroundColor: (t) => t.palette.background.paper,
           zIndex: 1,
+          WebkitAppRegion: 'drag',
         }}
       >
-        <Typography color="text.primary" variant="h1">
+        <Typography
+          color="text.primary"
+          sx={{ userSelect: 'none' }}
+          variant="h1"
+        >
           Settings
         </Typography>
-        <IconButton onClick={onClose} size="small">
+        <IconButton
+          onClick={onClose}
+          size="small"
+          sx={{ WebkitAppRegion: 'no-drag' }}
+        >
           <CloseIcon />
         </IconButton>
       </Box>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -327,6 +327,7 @@ export default function Sidebar() {
                     textTransform: 'uppercase',
                     color: (t) => t.palette.text.secondary,
                     opacity: 0.7,
+                    userSelect: 'none',
                   }}
                   variant="caption"
                 >
@@ -410,6 +411,7 @@ export default function Sidebar() {
                     textTransform: 'uppercase',
                     color: (t) => t.palette.text.secondary,
                     opacity: 0.7,
+                    userSelect: 'none',
                   }}
                   variant="caption"
                 >


### PR DESCRIPTION
## Summary
- Anchor the Settings drawer to the left edge so all sidebar-level surfaces open from the same side
- Make the Settings header a webkit drag region so the dead space next to the title can move the window
- Mark chrome-like text as non-selectable across the Settings header, sidebar section headers, and player track info
- Align the toolbar count and duration pills in Library and Playlists so they render at identical heights and share a symmetric structure

## Design decision: left-anchored Settings
The app's sidebar lives on the left and is the home for all high-level navigation UI — library, playlists, and the settings gear. Previously, clicking the gear on the left caused a panel to fly in from the right, creating a mental split where high-level navigation opened in two opposite directions depending on the action.

Anchoring Settings on the left means the whole class of "sidebar-level" surfaces — library navigation, playlist selection, and settings — consistently lives on and opens from the left edge. The right side stays reserved for track-level concerns (track list, player, toolbar actions).

**Rule going forward:** anything tied to sidebar-level concerns opens from the left.

## Settings header drag + non-selectable title
The Settings header now matches the drag behavior of the main sidebar/title bar:
- Header Box gets \`WebkitAppRegion: 'drag'\` so the gap between "Settings" and the X button can be used to move the app window
- Close \`IconButton\` opts out with \`WebkitAppRegion: 'no-drag'\` so clicking it still closes the drawer
- "Settings" Typography gets \`userSelect: 'none'\` to stop accidental text selection on what should feel like chrome, not content

## Non-selectable chrome text (sidebar + player)
Applied the same \`userSelect: 'none'\` treatment to four more pieces of UI text that behave like chrome, not content:
- Sidebar "Library" section header
- Sidebar "Playlists" section header
- Player track title (also has a click handler for scroll-to-track, so drag-selecting was an easy footgun)
- Player artist + album line

## Toolbar pill alignment (Library + Playlists)
The count and duration pills in the table toolbars previously rendered at slightly different heights because one pill wrapped a unicode \`♫\` glyph in \`Typography\` while the neighbouring duration pill wrapped an \`AccessTimeIcon\` SVG — different intrinsic content heights drove different pill heights despite identical padding.

Fix:
- Both pills are now locked to \`height: 22\` instead of relying on \`py\` + content height
- Count pill swaps the \`♫\` glyph for a \`music_note_2\` Material Symbol (\`fontSize={16}\`, \`weight={100}\`) wrapped in a color-inheriting span, mirroring the duration pill's icon structure
- All four pill \`Typography\` instances (count + duration, across Library and Playlists) unified at \`fontSize: '13px'\` + \`lineHeight: 1\`
- Library and Playlists pill JSX now identical except for the data-source variables

## Test plan
- [x] \`npm run start\` — open Settings via gear icon, confirm it slides in from the left
- [x] Confirm the divider renders on the right edge of the drawer (against the content area)
- [x] Confirm drawer still closes on overlay click and covers correctly at narrow widths (\`min(480px, calc(100vw - 60px))\`)
- [x] Drag the Settings header dead space and confirm the window moves
- [x] Click the X button in the Settings header and confirm the drawer closes
- [x] Try to select the "Settings" title text and confirm it can't be selected
- [x] Try to select the "Library" and "Playlists" sidebar headers and confirm they can't be selected
- [x] Try to select the track title and artist/album line in the player bar and confirm they can't be selected
- [x] Inspect the Library toolbar — count and duration pills render at identical 22px heights
- [x] Inspect a Playlist toolbar — same pill heights, same structure as Library

🤖 Generated with [Claude Code](https://claude.com/claude-code)