### PR TITLE
feat: optimistic next/prev playback controls

### DIFF
--- a/e2e/playback-rapid-skip.spec.ts
+++ b/e2e/playback-rapid-skip.spec.ts
@@ -3,6 +3,97 @@ import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
 test.describe('Rapid Skip Bug Regression', () => {
+  // The optimistic-next/prev feature (issue #72) requires that rapid clicks
+  // never get dropped. If a user clicks next 10 times quickly, they must land
+  // 10 songs forward — not 1 or 2.
+  test('rapid next x10 lands on the song 10 positions forward', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // Read the title of the song we expect to land on (start + 10 = index 10).
+    const expectedLandingTitle = await page
+      .locator('[data-track-id]')
+      .nth(10)
+      .locator('td')
+      .first()
+      .textContent();
+
+    // Double-click the first track to start playback.
+    await page.locator('[data-track-id]').first().dblclick();
+    await page.waitForTimeout(1000);
+
+    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
+    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+
+    // Fire 10 rapid clicks via DOM dispatching — tight synchronous loop so
+    // no React state update can settle between them.
+    await page.evaluate(() => {
+      const btn = document.querySelector('[data-testid="skip-next-button"]');
+      if (!btn) return;
+      for (let i = 0; i < 10; i++) {
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    });
+
+    // Give the final track time to load and autoplay.
+    await page.waitForTimeout(3000);
+
+    // Verify we landed on the expected track 10 positions ahead.
+    const pageContent = await page.content();
+    expect(pageContent).toContain(expectedLandingTitle!.trim());
+
+    // And that audio is actively advancing (not stuck at 0:00).
+    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('rapid previous x5 lands on the song 5 positions back', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // Expected landing: start from track index 10, go back 5 = index 5.
+    const expectedLandingTitle = await page
+      .locator('[data-track-id]')
+      .nth(5)
+      .locator('td')
+      .first()
+      .textContent();
+
+    // Start on the 11th track (index 10).
+    await page.locator('[data-track-id]').nth(10).dblclick();
+    await page.waitForTimeout(1000);
+
+    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
+    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+
+    // Fire 5 rapid prev clicks. Each one should walk back one index since
+    // position has just reset to 0 on each skip (position > 3 restart only
+    // applies on the very first click, and since we just started, position
+    // is ~0 anyway so every click walks back).
+    await page.evaluate(() => {
+      const btn = document.querySelector(
+        '[data-testid="skip-previous-button"]',
+      );
+      if (!btn) return;
+      for (let i = 0; i < 5; i++) {
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    });
+
+    await page.waitForTimeout(3000);
+
+    const pageContent = await page.content();
+    expect(pageContent).toContain(expectedLandingTitle!.trim());
+    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+
+    await TestHelpers.closeApp(app);
+  });
+
   test('rapid next clicks while playing — playback state stays in sync', async () => {
     const { app, page } = await TestHelpers.launchApp();
 

--- a/e2e/playback-rapid-skip.spec.ts
+++ b/e2e/playback-rapid-skip.spec.ts
@@ -37,12 +37,12 @@ test.describe('Rapid Skip Bug Regression', () => {
       }
     });
 
-    // Give the final track time to load and autoplay.
-    await page.waitForTimeout(3000);
-
-    // Verify we landed on the expected track 10 positions ahead.
-    const pageContent = await page.content();
-    expect(pageContent).toContain(expectedLandingTitle!.trim());
+    // Assert the player's now-playing title matches the expected landing
+    // track. Using a scoped locator (not pageContent) avoids false positives
+    // from the track list, which also renders the same title.
+    await expect(
+      page.locator('[data-testid="now-playing-title"]'),
+    ).toContainText(expectedLandingTitle!.trim(), { timeout: 5000 });
 
     // And that audio is actively advancing (not stuck at 0:00).
     await expect(pauseIcon).toBeVisible({ timeout: 5000 });
@@ -85,10 +85,9 @@ test.describe('Rapid Skip Bug Regression', () => {
       }
     });
 
-    await page.waitForTimeout(3000);
-
-    const pageContent = await page.content();
-    expect(pageContent).toContain(expectedLandingTitle!.trim());
+    await expect(
+      page.locator('[data-testid="now-playing-title"]'),
+    ).toContainText(expectedLandingTitle!.trim(), { timeout: 5000 });
     await expect(pauseIcon).toBeVisible({ timeout: 5000 });
 
     await TestHelpers.closeApp(app);

--- a/e2e/playback-skip-disable.spec.ts
+++ b/e2e/playback-skip-disable.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { TestHelpers } from './helpers/test-helpers';
+
+test.describe('Skip Button Disable States (issue #72)', () => {
+  test('previous is disabled at the first track with position 0 and no repeat', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // Start playing the first track, then pause immediately so position stays near 0.
+    await page.locator('[data-track-id]').first().dblclick();
+    await page.waitForTimeout(500);
+    await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
+    await page.waitForTimeout(300);
+
+    // With repeat=off (default), shuffle=off, position ~0, and on track 1,
+    // previous should now be disabled.
+    const prevBtn = page.locator('[data-testid="skip-previous-button"]');
+    await expect(prevBtn).toBeDisabled({ timeout: 3000 });
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('previous re-enables after playback advances past 3 seconds', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // Play the first track.
+    await page.locator('[data-track-id]').first().dblclick();
+    await page.waitForTimeout(500);
+
+    const prevBtn = page.locator('[data-testid="skip-previous-button"]');
+
+    // Immediately after starting, we're near 0 — prev should be disabled.
+    await expect(prevBtn).toBeDisabled({ timeout: 3000 });
+
+    // Let playback advance past 3 seconds; the restart escape hatch enables prev.
+    await page.waitForTimeout(4000);
+    await expect(prevBtn).toBeEnabled({ timeout: 3000 });
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('next stays enabled with 200+ tracks ahead', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // Play the first track — plenty of songs available ahead.
+    await page.locator('[data-track-id]').first().dblclick();
+    await page.waitForTimeout(500);
+
+    const nextBtn = page.locator('[data-testid="skip-next-button"]');
+    await expect(nextBtn).toBeEnabled({ timeout: 3000 });
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('tooltip does not render when previous button is disabled', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    // First track, position ~0, paused → prev disabled.
+    await page.locator('[data-track-id]').first().dblclick();
+    await page.waitForTimeout(500);
+    await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
+    await page.waitForTimeout(300);
+
+    const prevBtn = page.locator('[data-testid="skip-previous-button"]');
+    await expect(prevBtn).toBeDisabled({ timeout: 3000 });
+
+    // Hover over the wrapping span (the Tooltip attaches listeners there since
+    // the disabled button doesn't emit pointer events) and confirm no tooltip
+    // popover appears.
+    const prevWrapper = page
+      .locator('span:has([data-testid="skip-previous-button"])')
+      .first();
+    await prevWrapper.hover();
+    await page.waitForTimeout(1000);
+
+    const tooltip = page.locator('[role="tooltip"]');
+    await expect(tooltip).toHaveCount(0);
+
+    await TestHelpers.closeApp(app);
+  });
+});

--- a/src/main/miniPlayer.ts
+++ b/src/main/miniPlayer.ts
@@ -35,6 +35,8 @@ let playbackState = {
   volume: 1,
   repeatMode: 'off' as 'off' | 'track' | 'all',
   shuffleMode: false,
+  canGoNext: false,
+  canGoPrev: false,
 };
 
 // Store window position

--- a/src/main/miniPlayer.ts
+++ b/src/main/miniPlayer.ts
@@ -36,7 +36,7 @@ let playbackState = {
   repeatMode: 'off' as 'off' | 'track' | 'all',
   shuffleMode: false,
   canGoNext: false,
-  canGoPrev: false,
+  canGoPrevOrRestart: false,
 };
 
 // Store window position

--- a/src/renderer/components/MiniPlayer.tsx
+++ b/src/renderer/components/MiniPlayer.tsx
@@ -85,6 +85,8 @@ export default function MiniPlayer() {
   const [volume, setVolume] = useState(1);
   const [repeatMode, setRepeatMode] = useState<'off' | 'track' | 'all'>('off');
   const [shuffleMode, setShuffleMode] = useState(false);
+  const [canGoNext, setCanGoNext] = useState(false);
+  const [canGoPrev, setCanGoPrev] = useState(false);
   const [albumArt, setAlbumArt] = useState<string | null>(null);
   // Add error state for debugging
   const [error, setError] = useState<string | null>(null);
@@ -114,6 +116,8 @@ export default function MiniPlayer() {
             setVolume(state.volume);
             setRepeatMode(state.repeatMode);
             setShuffleMode(state.shuffleMode);
+            setCanGoNext(Boolean(state.canGoNext));
+            setCanGoPrev(Boolean(state.canGoPrev));
           } catch (err) {
             console.error('Error updating state:', err);
             setError(`State update error: ${err}`);
@@ -538,10 +542,10 @@ export default function MiniPlayer() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip title="Previous">
+            <Tooltip title={canGoPrev ? 'Previous' : ''}>
               <span>
                 <IconButton
-                  disabled={!currentTrack}
+                  disabled={!canGoPrev}
                   onClick={handlePreviousTrack}
                   size="medium"
                   sx={{ color: 'white', padding: '4px' }}
@@ -575,10 +579,10 @@ export default function MiniPlayer() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip title="Next">
+            <Tooltip title={canGoNext ? 'Next' : ''}>
               <span>
                 <IconButton
-                  disabled={!currentTrack}
+                  disabled={!canGoNext}
                   onClick={handleNextTrack}
                   size="medium"
                   sx={{ color: 'white', padding: '4px' }}

--- a/src/renderer/components/MiniPlayer.tsx
+++ b/src/renderer/components/MiniPlayer.tsx
@@ -27,6 +27,7 @@ import {
 } from '@mui/icons-material';
 import MaterialSymbolIcon from './MaterialSymbolIcon';
 
+import type { PlayerPlaybackState } from '../../types/ipc';
 import { formatDuration } from '../utils/formatters';
 
 // Album art placeholder component
@@ -86,7 +87,7 @@ export default function MiniPlayer() {
   const [repeatMode, setRepeatMode] = useState<'off' | 'track' | 'all'>('off');
   const [shuffleMode, setShuffleMode] = useState(false);
   const [canGoNext, setCanGoNext] = useState(false);
-  const [canGoPrev, setCanGoPrev] = useState(false);
+  const [canGoPrevOrRestart, setCanGoPrevOrRestart] = useState(false);
   const [albumArt, setAlbumArt] = useState<string | null>(null);
   // Add error state for debugging
   const [error, setError] = useState<string | null>(null);
@@ -109,15 +110,15 @@ export default function MiniPlayer() {
       );
 
       const unsubscribeState = window.electron.miniPlayer.onStateChange(
-        (state: any) => {
+        (state: PlayerPlaybackState) => {
           try {
             setPaused(state.paused);
             setDuration(state.duration);
             setVolume(state.volume);
             setRepeatMode(state.repeatMode);
             setShuffleMode(state.shuffleMode);
-            setCanGoNext(Boolean(state.canGoNext));
-            setCanGoPrev(Boolean(state.canGoPrev));
+            setCanGoNext(state.canGoNext);
+            setCanGoPrevOrRestart(state.canGoPrevOrRestart);
           } catch (err) {
             console.error('Error updating state:', err);
             setError(`State update error: ${err}`);
@@ -542,10 +543,10 @@ export default function MiniPlayer() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip title={canGoPrev ? 'Previous' : ''}>
+            <Tooltip title={canGoPrevOrRestart ? 'Previous' : ''}>
               <span>
                 <IconButton
-                  disabled={!canGoPrev}
+                  disabled={!canGoPrevOrRestart}
                   onClick={handlePreviousTrack}
                   size="medium"
                   sx={{ color: 'white', padding: '4px' }}

--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -31,10 +31,6 @@ import {
   toggleIconButtonSx,
 } from '../styles/iconButtonStyles';
 import { playerSliderSx } from '../styles/sliderStyles';
-import {
-  computeCanGoNext,
-  computeCanGoPrev,
-} from '../utils/trackSelectionUtils';
 
 // Album art placeholder component
 function AlbumArtPlaceholder() {
@@ -97,8 +93,10 @@ export default function Player() {
   );
   const repeatMode = useSettingsAndPlaybackStore((state) => state.repeatMode);
   const shuffleMode = useSettingsAndPlaybackStore((state) => state.shuffleMode);
-  const canGoNext = useSettingsAndPlaybackStore(computeCanGoNext);
-  const canGoPrev = useSettingsAndPlaybackStore(computeCanGoPrev);
+  const canGoNext = useSettingsAndPlaybackStore((state) => state.canGoNext);
+  const canGoPrevOrRestart = useSettingsAndPlaybackStore(
+    (state) => state.canGoPrevOrRestart,
+  );
 
   // Get actions from the store
   const setPaused = useSettingsAndPlaybackStore((state) => state.setPaused);
@@ -197,7 +195,7 @@ export default function Player() {
       shuffleMode,
       position,
       canGoNext,
-      canGoPrev,
+      canGoPrevOrRestart,
     });
   }, [
     paused,
@@ -207,7 +205,7 @@ export default function Player() {
     repeatMode,
     shuffleMode,
     canGoNext,
-    canGoPrev,
+    canGoPrevOrRestart,
   ]);
 
   // Position-related formatting moved to PositionDisplay component to isolate updates
@@ -747,6 +745,7 @@ export default function Player() {
                 >
                   <Typography
                     component="div"
+                    data-testid="now-playing-title"
                     onClick={handleTrackTitleClick}
                     sx={{
                       cursor: playbackSource ? 'pointer' : 'default',
@@ -859,11 +858,15 @@ export default function Player() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip arrow placement="top" title={canGoPrev ? 'Previous' : ''}>
+            <Tooltip
+              arrow
+              placement="top"
+              title={canGoPrevOrRestart ? 'Previous' : ''}
+            >
               <span>
                 <IconButton
                   data-testid="skip-previous-button"
-                  disabled={!canGoPrev}
+                  disabled={!canGoPrevOrRestart}
                   onClick={skipToPreviousTrack}
                   size="medium"
                   sx={{

--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -31,6 +31,10 @@ import {
   toggleIconButtonSx,
 } from '../styles/iconButtonStyles';
 import { playerSliderSx } from '../styles/sliderStyles';
+import {
+  computeCanGoNext,
+  computeCanGoPrev,
+} from '../utils/trackSelectionUtils';
 
 // Album art placeholder component
 function AlbumArtPlaceholder() {
@@ -93,9 +97,8 @@ export default function Player() {
   );
   const repeatMode = useSettingsAndPlaybackStore((state) => state.repeatMode);
   const shuffleMode = useSettingsAndPlaybackStore((state) => state.shuffleMode);
-  const skipInProgress = useSettingsAndPlaybackStore(
-    (state) => state.skipInProgress,
-  );
+  const canGoNext = useSettingsAndPlaybackStore(computeCanGoNext);
+  const canGoPrev = useSettingsAndPlaybackStore(computeCanGoPrev);
 
   // Get actions from the store
   const setPaused = useSettingsAndPlaybackStore((state) => state.setPaused);
@@ -193,8 +196,19 @@ export default function Player() {
       repeatMode,
       shuffleMode,
       position,
+      canGoNext,
+      canGoPrev,
     });
-  }, [paused, duration, position, volume, repeatMode, shuffleMode]);
+  }, [
+    paused,
+    duration,
+    position,
+    volume,
+    repeatMode,
+    shuffleMode,
+    canGoNext,
+    canGoPrev,
+  ]);
 
   // Position-related formatting moved to PositionDisplay component to isolate updates
 
@@ -845,11 +859,11 @@ export default function Player() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip arrow placement="top" title="Previous">
+            <Tooltip arrow placement="top" title={canGoPrev ? 'Previous' : ''}>
               <span>
                 <IconButton
                   data-testid="skip-previous-button"
-                  disabled={!currentTrack || skipInProgress}
+                  disabled={!canGoPrev}
                   onClick={skipToPreviousTrack}
                   size="medium"
                   sx={{
@@ -900,11 +914,11 @@ export default function Player() {
                 </IconButton>
               </span>
             </Tooltip>
-            <Tooltip arrow placement="top" title="Next">
+            <Tooltip arrow placement="top" title={canGoNext ? 'Next' : ''}>
               <span>
                 <IconButton
                   data-testid="skip-next-button"
-                  disabled={!currentTrack || skipInProgress}
+                  disabled={!canGoNext}
                   onClick={skipToNextTrack}
                   size="medium"
                   sx={{

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -74,7 +74,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     shuffleMode: false, // shuffle mode
     shuffleHistory: [], // history of shuffled tracks
     shuffleHistoryPosition: -1, // current position in shuffle history (-1 means at the tip)
-    canGoNext: false, // stored boundary — refreshed by refreshBoundaries after mutations
+    canGoNext: false, // stored boundary — refreshed by refreshPrevNextBoundaries after mutations
     canGoPrevOrRestart: false, // true when prev click would navigate OR restart the song
 
     // Internal state (from playbackStore)
@@ -399,7 +399,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
      * these as stored fields avoids running the filter/sort in getFiltered...
      * on every store-update tick, which matters for large libraries.
      */
-    refreshBoundaries: () => {
+    refreshPrevNextBoundaries: () => {
       set((state) => {
         const canGoNext = computeCanGoNext(state);
         const canGoPrevOrRestart = computeCanGoPrevOrRestart(state);
@@ -550,7 +550,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           playbackContextBrowserFilter: browserFilter, // Store the browser filter context
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     skipToNextTrack: () => {
@@ -857,7 +857,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           duration: nextSong.duration,
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     skipToPreviousTrack: () => {
@@ -1006,7 +1006,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: Date.now(),
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     toggleRepeatMode: () => {
@@ -1034,7 +1034,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
         return { repeatMode, player: state.player };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     toggleShuffleMode: () => {
@@ -1045,7 +1045,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           shuffleHistoryPosition: -1,
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     setPaused: (paused: boolean) => {
@@ -1183,7 +1183,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             // current track" escape hatch). Only refresh on a crossing so we
             // don't pay for findPreviousSong's sort on every tick.
             if (prevPosition <= 3 !== currentPosition <= 3) {
-              get().refreshBoundaries();
+              get().refreshPrevNextBoundaries();
             }
 
             // Handle tracking actual playback time for play count
@@ -1264,7 +1264,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: Date.now(),
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
 
     autoPlayNextTrack: async () => {
@@ -1515,7 +1515,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: timeUpdateDelay,
         };
       });
-      get().refreshBoundaries();
+      get().refreshPrevNextBoundaries();
     },
   }),
 );

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -63,7 +63,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     // Playback state (from playbackStore)
     currentTrack: null, // the current track playing
     paused: true, // play pause state
-    skipInProgress: false, // true while a skip operation is in-flight
     position: 0, // current position of the playing track in seconds
     duration: 0, // duration of the playing track in seconds
     playbackSource: 'library', // the source of the playback (library or playlist)
@@ -534,11 +533,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           throw new Error('No player found while skipping to next song');
         }
 
-        // Guard against rapid skip clicks while a skip is still loading
-        if (state.skipInProgress) {
-          return {};
-        }
-
         if (state.repeatMode === 'track') {
           // For repeat track mode, start from the beginning
           state.player.setPosition(0);
@@ -608,7 +602,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 lastPlaybackTimeUpdateRef: Date.now(),
                 duration: nextSong.duration,
                 shuffleHistoryPosition: newPosition,
-                skipInProgress: !state.paused,
               };
             }
           }
@@ -746,7 +739,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             duration: nextSong.duration,
             shuffleHistory,
             shuffleHistoryPosition: shuffleHistory.length - 1, // Now at the new tip
-            skipInProgress: !state.paused,
           };
         }
 
@@ -837,7 +829,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPosition: 0,
           lastPlaybackTimeUpdateRef: Date.now(),
           duration: nextSong.duration,
-          skipInProgress: !state.paused,
         };
       });
     },
@@ -846,11 +837,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
       return set((state) => {
         if (!state.player) {
           throw new Error('No player found while skipping to previous song');
-        }
-
-        // Guard against rapid skip clicks while a skip is still loading
-        if (state.skipInProgress) {
-          return {};
         }
 
         // If we're less than 3 seconds into the song, go to previous track
@@ -907,7 +893,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 lastPlaybackTimeUpdateRef: Date.now(),
                 duration: previousSong.duration,
                 shuffleHistoryPosition: newPosition,
-                skipInProgress: !state.paused,
               };
             }
           }
@@ -978,7 +963,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             lastPosition: 0,
             lastPlaybackTimeUpdateRef: Date.now(),
             duration: previousSong.duration,
-            skipInProgress: !state.paused,
           };
         }
         // Restart the current track
@@ -1119,7 +1103,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         player.onplay = () => {
           set({
             paused: false,
-            skipInProgress: false,
             lastPlaybackTimeUpdateRef: Date.now(),
             lastPosition: get().position,
           });

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -5,6 +5,8 @@ import { SettingsAndPlaybackStore } from './types';
 import useLibraryStore from './libraryStore';
 import useUIStore from './uiStore';
 import {
+  computeCanGoNext,
+  computeCanGoPrevOrRestart,
   findNextSong,
   findPreviousSong,
   getFilePathFromTrackUrl,
@@ -72,6 +74,8 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     shuffleMode: false, // shuffle mode
     shuffleHistory: [], // history of shuffled tracks
     shuffleHistoryPosition: -1, // current position in shuffle history (-1 means at the tip)
+    canGoNext: false, // stored boundary — refreshed by refreshBoundaries after mutations
+    canGoPrevOrRestart: false, // true when prev click would navigate OR restart the song
 
     // Internal state (from playbackStore)
     player: null, // the gapless 5 player instance
@@ -388,6 +392,27 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
       return set({ silentAudioRef: ref });
     },
 
+    /**
+     * Recompute canGoNext / canGoPrevOrRestart from current state. Call this
+     * after any mutation that might change the answer (new currentTrack,
+     * repeat/shuffle toggle, library change, position crossing 3s). Holding
+     * these as stored fields avoids running the filter/sort in getFiltered...
+     * on every store-update tick, which matters for large libraries.
+     */
+    refreshBoundaries: () => {
+      return set((state) => {
+        const canGoNext = computeCanGoNext(state);
+        const canGoPrevOrRestart = computeCanGoPrevOrRestart(state);
+        if (
+          canGoNext === state.canGoNext &&
+          canGoPrevOrRestart === state.canGoPrevOrRestart
+        ) {
+          return {};
+        }
+        return { canGoNext, canGoPrevOrRestart };
+      });
+    },
+
     setVolume: (volume) => {
       return set((state) => {
         if (state.player) {
@@ -417,7 +442,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     },
 
     selectSpecificSong: (trackId, playbackSource, playlistId = null) => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while selecting specific song');
         }
@@ -525,10 +550,11 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           playbackContextBrowserFilter: browserFilter, // Store the browser filter context
         };
       });
+      get().refreshBoundaries();
     },
 
     skipToNextTrack: () => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while skipping to next song');
         }
@@ -831,10 +857,11 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           duration: nextSong.duration,
         };
       });
+      get().refreshBoundaries();
     },
 
     skipToPreviousTrack: () => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while skipping to previous song');
         }
@@ -979,10 +1006,11 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: Date.now(),
         };
       });
+      get().refreshBoundaries();
     },
 
     toggleRepeatMode: () => {
-      return set((state) => {
+      set((state) => {
         // Cycle through repeat modes: off -> track -> all -> off
         const modes: ('off' | 'track' | 'all')[] = ['off', 'track', 'all'];
         const currentIndex = modes.indexOf(state.repeatMode);
@@ -1006,16 +1034,18 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
         return { repeatMode, player: state.player };
       });
+      get().refreshBoundaries();
     },
 
     toggleShuffleMode: () => {
-      return set((state) => {
+      set((state) => {
         return {
           shuffleMode: !state.shuffleMode,
           shuffleHistory: [],
           shuffleHistoryPosition: -1,
         };
       });
+      get().refreshBoundaries();
     },
 
     setPaused: (paused: boolean) => {
@@ -1141,12 +1171,20 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           const currentPosition = Math.floor(time / 1000);
 
           if (now - lastUpdate >= 1000) {
-            // Update position
+            // Update position (capture prev for threshold detection below)
+            const prevPosition = get().position;
             set({
               lastPositionUpdateRef: now,
               // Convert from milliseconds to seconds
               position: currentPosition,
             });
+
+            // canGoPrevOrRestart flips when position crosses 3s (the "restart
+            // current track" escape hatch). Only refresh on a crossing so we
+            // don't pay for findPreviousSong's sort on every tick.
+            if (prevPosition <= 3 !== currentPosition <= 3) {
+              get().refreshBoundaries();
+            }
 
             // Handle tracking actual playback time for play count
             const currentState = get();
@@ -1190,7 +1228,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     },
 
     seekToPosition: (position: number) => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while seeking to position');
         }
@@ -1226,10 +1264,11 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: Date.now(),
         };
       });
+      get().refreshBoundaries();
     },
 
     autoPlayNextTrack: async () => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while auto playing next track');
         }
@@ -1476,6 +1515,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: timeUpdateDelay,
         };
       });
+      get().refreshBoundaries();
     },
   }),
 );

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -389,7 +389,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
     // Playback actions
     setSilentAudioRef: (ref) => {
-      return set({ silentAudioRef: ref });
+      set({ silentAudioRef: ref });
     },
 
     /**
@@ -400,7 +400,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
      * on every store-update tick, which matters for large libraries.
      */
     refreshBoundaries: () => {
-      return set((state) => {
+      set((state) => {
         const canGoNext = computeCanGoNext(state);
         const canGoPrevOrRestart = computeCanGoPrevOrRestart(state);
         if (
@@ -414,7 +414,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     },
 
     setVolume: (volume) => {
-      return set((state) => {
+      set((state) => {
         if (state.player) {
           state.player.setVolume(volume);
         }
@@ -1049,7 +1049,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     },
 
     setPaused: (paused: boolean) => {
-      return set((state) => {
+      set((state) => {
         if (!state.player) {
           throw new Error('No player found while setting paused');
         }

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -206,7 +206,7 @@ export interface SettingsAndPlaybackStore {
   // Derived boundary state: true when the matching skip button should be
   // enabled. Maintained as stored fields (rather than computed per-render
   // selectors) so large libraries don't pay O(n log n) filter/sort on
-  // every store update — see refreshBoundaries / withBoundaries.
+  // every store update — see refreshPrevNextBoundaries / withBoundaries.
   canGoNext: boolean;
   canGoPrevOrRestart: boolean;
 
@@ -248,5 +248,5 @@ export interface SettingsAndPlaybackStore {
   toggleShuffleMode: () => void;
   setSilentAudioRef: (ref: HTMLAudioElement | null) => void;
   autoPlayNextTrack: () => Promise<void>;
-  refreshBoundaries: () => void;
+  refreshPrevNextBoundaries: () => void;
 }

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -203,6 +203,13 @@ export interface SettingsAndPlaybackStore {
   shuffleHistory: Track[];
   shuffleHistoryPosition: number;
 
+  // Derived boundary state: true when the matching skip button should be
+  // enabled. Maintained as stored fields (rather than computed per-render
+  // selectors) so large libraries don't pay O(n log n) filter/sort on
+  // every store update — see refreshBoundaries / withBoundaries.
+  canGoNext: boolean;
+  canGoPrevOrRestart: boolean;
+
   // Internal state
   player: Gapless5 | null;
   lastPositionUpdateRef: number;
@@ -241,4 +248,5 @@ export interface SettingsAndPlaybackStore {
   toggleShuffleMode: () => void;
   setSilentAudioRef: (ref: HTMLAudioElement | null) => void;
   autoPlayNextTrack: () => Promise<void>;
+  refreshBoundaries: () => void;
 }

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -205,7 +205,6 @@ export interface SettingsAndPlaybackStore {
 
   // Internal state
   player: Gapless5 | null;
-  skipInProgress: boolean;
   lastPositionUpdateRef: number;
   lastPlaybackTimeUpdateRef: number;
   lastPosition: number;

--- a/src/renderer/utils/trackSelectionUtils.ts
+++ b/src/renderer/utils/trackSelectionUtils.ts
@@ -310,7 +310,7 @@ export const findPreviousSong = (
   return tracks.find((t) => t.id === previousTrackId);
 };
 
-type BoundaryStateSlice = Pick<
+export type CanGoInputs = Pick<
   SettingsAndPlaybackStore,
   | 'currentTrack'
   | 'position'
@@ -323,13 +323,15 @@ type BoundaryStateSlice = Pick<
 >;
 
 /**
- * Derives whether the Next button should be enabled for the given playback
- * state. Returns false only when we are genuinely at the end of the current
- * view with no repeat and no more shuffle candidates. See findNextSong for the
- * underlying filter/sort/history logic — this wraps it with the repeat/shuffle
- * short-circuits so the UI can bind a boolean directly.
+ * Returns true when the Next button should be enabled. False only when the
+ * click would truly be a no-op — at the end of the filtered view with no
+ * repeat, or with shuffle history exhausted and no repeat='all' to recycle.
+ *
+ * When `repeatMode === 'track'`, clicking Next restarts the current song
+ * (see skipToNextTrack's repeat-track branch), so this returns true — the
+ * click always does something.
  */
-export const computeCanGoNext = (s: BoundaryStateSlice): boolean => {
+export const computeCanGoNext = (s: CanGoInputs): boolean => {
   if (!s.currentTrack) return false;
   if (s.repeatMode !== 'off') return true;
 
@@ -357,13 +359,18 @@ export const computeCanGoNext = (s: BoundaryStateSlice): boolean => {
 };
 
 /**
- * Derives whether the Previous button should be enabled. Mirrors
- * computeCanGoNext. Also returns true when position > 3s, since prev in that
- * case restarts the current song rather than navigating — keeping the button
- * enabled preserves the existing "back to start" affordance even at the first
- * song of the view.
+ * Returns true when the Previous button should be enabled. The button
+ * handles two mutually exclusive actions depending on playback position:
+ *
+ *   - position > 3s: clicking restarts the current track (in-place rewind).
+ *   - position <= 3s: clicking navigates to the previous track, if one
+ *     exists under the current filter/shuffle/repeat context.
+ *
+ * The name reflects that `true` may mean either "restart" or "navigate back"
+ * — consumers should not assume a previous track exists just because this
+ * boolean is true.
  */
-export const computeCanGoPrev = (s: BoundaryStateSlice): boolean => {
+export const computeCanGoPrevOrRestart = (s: CanGoInputs): boolean => {
   if (!s.currentTrack) return false;
   if (s.position > 3) return true;
   if (s.repeatMode !== 'off') return true;

--- a/src/renderer/utils/trackSelectionUtils.ts
+++ b/src/renderer/utils/trackSelectionUtils.ts
@@ -1,5 +1,6 @@
 import { Track } from '../../types/dbTypes';
 import useLibraryStore from '../stores/libraryStore';
+import type { SettingsAndPlaybackStore } from '../stores/types';
 import { getSortingFunction } from './sortingFunctions';
 
 // Define MediaImage interface for TypeScript
@@ -307,4 +308,82 @@ export const findPreviousSong = (
   // return the previous track
   const previousTrackId = trackIds[currentIndex - 1];
   return tracks.find((t) => t.id === previousTrackId);
+};
+
+type BoundaryStateSlice = Pick<
+  SettingsAndPlaybackStore,
+  | 'currentTrack'
+  | 'position'
+  | 'repeatMode'
+  | 'shuffleMode'
+  | 'shuffleHistory'
+  | 'shuffleHistoryPosition'
+  | 'playbackSource'
+  | 'playbackContextBrowserFilter'
+>;
+
+/**
+ * Derives whether the Next button should be enabled for the given playback
+ * state. Returns false only when we are genuinely at the end of the current
+ * view with no repeat and no more shuffle candidates. See findNextSong for the
+ * underlying filter/sort/history logic — this wraps it with the repeat/shuffle
+ * short-circuits so the UI can bind a boolean directly.
+ */
+export const computeCanGoNext = (s: BoundaryStateSlice): boolean => {
+  if (!s.currentTrack) return false;
+  if (s.repeatMode !== 'off') return true;
+
+  const artistFilter = s.playbackContextBrowserFilter?.artist || null;
+  const albumFilter = s.playbackContextBrowserFilter?.album || null;
+
+  if (s.shuffleMode) {
+    const forwardInHistory =
+      s.shuffleHistoryPosition >= 0 &&
+      s.shuffleHistoryPosition < s.shuffleHistory.length - 1;
+    if (forwardInHistory) return true;
+  }
+
+  return (
+    findNextSong(
+      s.currentTrack.id,
+      s.shuffleMode,
+      s.playbackSource,
+      s.repeatMode,
+      artistFilter,
+      s.shuffleHistory,
+      albumFilter,
+    ) !== undefined
+  );
+};
+
+/**
+ * Derives whether the Previous button should be enabled. Mirrors
+ * computeCanGoNext. Also returns true when position > 3s, since prev in that
+ * case restarts the current song rather than navigating — keeping the button
+ * enabled preserves the existing "back to start" affordance even at the first
+ * song of the view.
+ */
+export const computeCanGoPrev = (s: BoundaryStateSlice): boolean => {
+  if (!s.currentTrack) return false;
+  if (s.position > 3) return true;
+  if (s.repeatMode !== 'off') return true;
+
+  if (s.shuffleMode) {
+    return s.shuffleHistoryPosition > 0;
+  }
+
+  const artistFilter = s.playbackContextBrowserFilter?.artist || null;
+  const albumFilter = s.playbackContextBrowserFilter?.album || null;
+
+  return (
+    findPreviousSong(
+      s.currentTrack.id,
+      false,
+      s.playbackSource,
+      s.repeatMode,
+      [],
+      artistFilter,
+      albumFilter,
+    ) !== undefined
+  );
 };

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -209,6 +209,8 @@ export interface IPCRequests {
     volume: number;
     repeatMode: 'off' | 'track' | 'all';
     shuffleMode: boolean;
+    canGoNext: boolean;
+    canGoPrev: boolean;
   };
   'miniPlayer:positionChanged': number;
   'miniPlayer:albumArtChanged': string | null;
@@ -220,6 +222,8 @@ export interface IPCRequests {
     volume: number;
     repeatMode: 'off' | 'track' | 'all';
     shuffleMode: boolean;
+    canGoNext: boolean;
+    canGoPrev: boolean;
   };
   'player:trackUpdate': Track | null;
   'player:positionUpdate': number;

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -8,6 +8,26 @@
 import { Track, Playlist, Settings, MetadataToWrite } from './dbTypes';
 
 /**
+ * Playback state shared between the main player and the mini player.
+ * Emitted from the renderer as `player:stateUpdate` and relayed to the
+ * mini player renderer as `miniPlayer:stateChanged`.
+ *
+ * `canGoPrevOrRestart` is true when a click on the previous button would
+ * either navigate to a previous track OR restart the current track (the
+ * button handler picks based on `position > 3`).
+ */
+export interface PlayerPlaybackState {
+  paused: boolean;
+  duration: number;
+  volume: number;
+  position: number;
+  repeatMode: 'off' | 'track' | 'all';
+  shuffleMode: boolean;
+  canGoNext: boolean;
+  canGoPrevOrRestart: boolean;
+}
+
+/**
  * All available IPC channels for the application
  */
 export type Channels =
@@ -203,28 +223,12 @@ export interface IPCRequests {
   'miniPlayer:toggleRepeat': void;
   'miniPlayer:toggleShuffle': void;
   'miniPlayer:trackChanged': Track | null;
-  'miniPlayer:stateChanged': {
-    isPlaying: boolean;
-    duration: number;
-    volume: number;
-    repeatMode: 'off' | 'track' | 'all';
-    shuffleMode: boolean;
-    canGoNext: boolean;
-    canGoPrev: boolean;
-  };
+  'miniPlayer:stateChanged': PlayerPlaybackState;
   'miniPlayer:positionChanged': number;
   'miniPlayer:albumArtChanged': string | null;
 
   // Player-MiniPlayer sync operations
-  'player:stateUpdate': {
-    isPlaying: boolean;
-    duration: number;
-    volume: number;
-    repeatMode: 'off' | 'track' | 'all';
-    shuffleMode: boolean;
-    canGoNext: boolean;
-    canGoPrev: boolean;
-  };
+  'player:stateUpdate': PlayerPlaybackState;
   'player:trackUpdate': Track | null;
   'player:positionUpdate': number;
   'player:pausePlayback': void;


### PR DESCRIPTION
Closes #72

## Summary
- Remove the `skipInProgress` drop guards on `skipToNextTrack` / `skipToPreviousTrack`, and delete the field entirely. Each click now synchronously advances `currentTrack`, `shuffleHistory`, and MediaSession metadata; Gapless-5's `removeAllTracks()` aborts any prior in-flight XHR (`request.abort()`), so rapid clicks naturally coalesce and only the final target ever reaches `Play` state. No debouncer needed.
- Maintain `canGoNext` / `canGoPrevOrRestart` as stored boolean fields on the playback store (refreshed via `refreshBoundaries()` at mutation points and on 3s-threshold crossings). Drives visual disable on next/prev without re-running `findNextSong` / `findPreviousSong` on every position tick. Shared `PlayerPlaybackState` IPC type keeps main window and MiniPlayer in sync. Prev preserves the "restart at position > 3s" escape hatch — only disabled at the first song when `position <= 3s`.
- Suppress the MUI Tooltip on disabled next/prev by gating the `title` prop on the `canGo*` fields.

The gapless autoplay path (`onfinishedtrack` → `autoPlayNextTrack`) is unchanged; it reads Gapless-5's internal index, not the store's `currentTrack`, so optimistic updates don't interfere with natural track completion.

## Side-effect bug also fixed by removing `skipInProgress`
Before this PR, the `skipInProgress` flag was set after every skip and cleared only by Gapless-5's `onplay` callback. If a skip ever threw (e.g. a `findNextSong` edge case) before audio loaded, `skipInProgress` stayed `true` **forever** and silently blocked all subsequent next/prev clicks for the rest of the session — including OS media keys and the mini player. Deleting the field removes that stuck-state class of bug entirely; a failed skip just bubbles and the next click works.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] E2E: `playback-rapid-skip.spec.ts` — **new** asserts against the `now-playing-title` testid that 10 rapid next clicks land on the song 10 positions forward (and 5 prev clicks land 5 back). Scoped locator instead of page-wide substring match so it can't be fooled by the track list rendering the same title.
- [x] E2E: `playback-skip-disable.spec.ts` — **new** covers prev disabled at first track/position 0, prev re-enables after 3s, next stays enabled with a full library ahead, and tooltip suppression on the disabled button.
- [x] E2E: `playback-skip.spec.ts`, `playback-autoplay.spec.ts`, `miniplayer-sync.spec.ts`, `playback-modes.spec.ts`, `playback.spec.ts` — all pass, no regression (23 tests total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)