### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Bumps `package.json`, `release/app/package.json`, and both lockfiles from 2.0.2 → 2.1.0
- Minor bump rationale: two `feat:` commits landed since 2.0.2

## Changes since 2.0.2
- f2e1a87 feat: prev button restarts song when no previous target (#75)
- 0858eee feat: optimistic next/prev playback controls (#73)
- eebac9d ui: Settings drawer polish, non-selectable chrome, pill alignment (#71)

Per semver + Conventional Commits, two `feat:` commits → MINOR. No breaking API changes, so not MAJOR. Patch (2.0.3) would also be defensible since none of the changes add new surface area, but the behavior changes in #73 and #75 are user-visible enough to warrant minor.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] Verify About / title bar reflects 2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)