### PR TITLE
refactor: schedule stale track cleanup past crossfade window

### DIFF
--- a/e2e/playback-autoplay-skip.spec.ts
+++ b/e2e/playback-autoplay-skip.spec.ts
@@ -60,6 +60,10 @@ test.describe('Autoplay → Skip regression', () => {
     // Gapless-5 should actually be playing track 2 (the store's view)
     expect(stateAfterAutoplay.playerCurrentFilePath).toBe(track2FilePath);
 
+    // The scheduled cleanup (50ms) has long since fired — queue settles
+    // to exactly 2 entries (current + preloaded) rather than 3.
+    expect(stateAfterAutoplay.playerQueueLength).toBe(2);
+
     // The preloaded track is track 3 — record it so we can compare after skip
     const track3FilePath = stateAfterAutoplay.storePreloadedTrackFilePath;
     expect(track3FilePath).toBeTruthy();
@@ -76,6 +80,8 @@ test.describe('Autoplay → Skip regression', () => {
     // THIS is the bug-catching assertion: the player must actually be
     // playing track 3, not a restarted track 2.
     expect(stateAfterSkip.playerCurrentFilePath).toBe(track3FilePath);
+    // Post-skip queue is clean (no accumulated stale).
+    expect(stateAfterSkip.playerQueueLength).toBe(2);
 
     await TestHelpers.closeApp(app);
   });
@@ -100,6 +106,9 @@ test.describe('Autoplay → Skip regression', () => {
 
     // Store and player should agree on track 3
     expect(stateAfterAutoplay.playerCurrentFilePath).toBe(track3FilePath);
+    // Queue stays bounded at 2 even after repeated auto-advances —
+    // each scheduled cleanup fires before the next auto-advance.
+    expect(stateAfterAutoplay.playerQueueLength).toBe(2);
 
     // Skip — Gapless-5 should now play track 4.
     await page.locator('[data-testid="skip-next-button"]').click();
@@ -109,6 +118,28 @@ test.describe('Autoplay → Skip regression', () => {
     expect(stateAfterSkip.storeCurrentTrackFilePath).toBe(track4FilePath);
     // Bug-catching assertion:
     expect(stateAfterSkip.playerCurrentFilePath).toBe(track4FilePath);
+    expect(stateAfterSkip.playerQueueLength).toBe(2);
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('queue settles to 2 within 200ms after auto-advance', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await page.waitForTimeout(3000);
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+    await page.locator('[data-track-id]').nth(0).dblclick();
+    await page.waitForTimeout(1000);
+
+    // Let track 1 auto-advance to track 2 (~10s fixtures) then wait just
+    // past the 50ms scheduled cleanup.
+    await page.waitForTimeout(11000);
+    await page.waitForTimeout(200);
+
+    const state = await readPlayerState(page);
+    expect(state.playerQueueLength).toBe(2);
+    expect(state.storeCurrentTrackFilePath).toBe(state.playerCurrentFilePath);
 
     await TestHelpers.closeApp(app);
   });

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -12,7 +12,12 @@ import {
   updateMediaSession,
 } from '../utils/trackSelectionUtils';
 import { playbackTracker, updatePlayCount } from '../utils/playbackTracker';
-import { preloadNextInQueue, syncPlayerQueue } from '../utils/playerQueue';
+import {
+  flushStaleCleanup,
+  preloadNextInQueue,
+  scheduleStaleCleanup,
+  syncPlayerQueue,
+} from '../utils/playerQueue';
 
 /**
  * Derive Gapless-5's singleMode from our repeatMode. The store's
@@ -98,7 +103,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     silentAudioRef: null, // reference to the silent audio element for MediaSession support
     preloadedTrack: null, // track sitting at Gapless-5 queue index 1 (store-owned)
     preloadReady: false, // true once the preloaded track is decoded and ready
-    queueLeadingStaleCount: 0, // stale finished tracks at the front of Gapless-5's queue
+    pendingStaleCleanupTimeout: null, // timer that drops the stale finished track after auto-advance
 
     // Settings actions
     setLibraryPath: async (libraryPath: Settings['libraryPath']) => {
@@ -459,6 +464,10 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           throw new Error('No player found while selecting specific song');
         }
 
+        // Run any pending post-crossfade stale cleanup now. Safe here
+        // because we're about to rebuild the queue from scratch anyway.
+        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
+
         const library = useLibraryStore.getState().tracks;
 
         const selectedTrack = library.find((t) => t.id === trackId);
@@ -561,7 +570,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           playbackContextBrowserFilter: browserFilter, // Store the browser filter context
           preloadedTrack: nextSong ?? null,
           preloadReady: false,
-          queueLeadingStaleCount: 0,
+          pendingStaleCleanupTimeout: null,
         };
       });
       get().refreshCanGoNext();
@@ -593,6 +602,13 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         if (!state.currentTrack) {
           throw new Error('No current track found while skipping to next song');
         }
+
+        // Flush any pending post-crossfade cleanup so the queue is
+        // [current, preloaded] before we hit the fast path. Human
+        // reaction time (~200ms) is well past the 50ms scheduler, so
+        // in practice this is a no-op; it's defensive against the
+        // edge case where a user clicks skip within the window.
+        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
 
         // If in shuffle mode
         if (state.shuffleMode) {
@@ -639,7 +655,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                queueLeadingStaleCount: 0,
+                pendingStaleCleanupTimeout: null,
               };
             }
           }
@@ -773,7 +789,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             shuffleHistoryPosition: shuffleHistory.length - 1, // Now at the new tip
             preloadedTrack: futureNextSong ?? null,
             preloadReady: false,
-            queueLeadingStaleCount: 0,
+            pendingStaleCleanupTimeout: null,
           };
         }
 
@@ -818,23 +834,10 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           state.preloadedTrack?.id === nextSong.id && state.preloadReady;
 
         if (isFastPathEligible) {
-          // FAST PATH: switch to the already-buffered preloaded track.
-          //
-          // Jump by URL (not by index) so we're robust to the known leak
-          // where Gapless-5's queue accumulates stale finished tracks at
-          // the front after each auto-advance. `gotoTrack(1)` would land
-          // on whatever sits at index 1, which after N auto-advances is
-          // NOT the preloaded track — it's one of the stale leaders.
-          //
-          // After jumping, remove every track ahead of the new current:
-          // one for each stale leading entry (queueLeadingStaleCount) plus
-          // one for the prior current that's now the old index 0 slot.
-          const nextSongUrl = getTrackUrl(nextSong.filePath);
-          state.player.gotoTrack(nextSongUrl);
-          const removalsBeforeCurrent = state.queueLeadingStaleCount + 1;
-          for (let i = 0; i < removalsBeforeCurrent; i += 1) {
-            state.player.removeTrack(0);
-          }
+          // FAST PATH: queue is [current, preloaded] after the flush
+          // above, so a plain index jump + drop is correct.
+          state.player.gotoTrack(1);
+          state.player.removeTrack(0);
           if (futureNextSong) {
             preloadNextInQueue(state.player, futureNextSong);
           }
@@ -869,7 +872,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           duration: nextSong.duration,
           preloadedTrack: futureNextSong ?? null,
           preloadReady: false,
-          queueLeadingStaleCount: 0,
+          pendingStaleCleanupTimeout: null,
         };
       });
       get().refreshCanGoNext();
@@ -880,6 +883,11 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         if (!state.player) {
           throw new Error('No player found while skipping to previous song');
         }
+
+        // Flush any pending post-crossfade cleanup before we mutate the
+        // queue. Every branch below either rebuilds the queue or just
+        // seeks, so it's safe to run the deferred removeTrack now.
+        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
 
         // If we're less than 3 seconds into the song, go to previous track
         // Otherwise, restart the current track
@@ -931,7 +939,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                queueLeadingStaleCount: 0,
+                pendingStaleCleanupTimeout: null,
               };
             }
           }
@@ -1001,7 +1009,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             duration: previousSong.duration,
             preloadedTrack: futureNextSong,
             preloadReady: false,
-            queueLeadingStaleCount: 0,
+            pendingStaleCleanupTimeout: null,
           };
         }
         // Restart the current track
@@ -1166,8 +1174,18 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         };
 
         player.onpause = () => {
-          // When pausing, update playback tracking
           const currentState = get();
+
+          // Drop the stale track left behind by a recent auto-advance now
+          // that we're safely out of any crossfade transition.
+          if (currentState.player) {
+            flushStaleCleanup(
+              currentState.player,
+              currentState.pendingStaleCleanupTimeout,
+            );
+          }
+
+          // When pausing, update playback tracking
           if (!currentState.paused && currentState.currentTrack) {
             const now = Date.now();
             const lastUpdate = currentState.lastPlaybackTimeUpdateRef;
@@ -1188,7 +1206,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             }
           }
 
-          set({ paused: true });
+          set({ paused: true, pendingStaleCleanupTimeout: null });
         };
 
         player.ontimeupdate = (time) => {
@@ -1378,7 +1396,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                queueLeadingStaleCount: state.queueLeadingStaleCount + 1,
+                pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
               };
             }
           }
@@ -1494,7 +1512,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             shuffleHistoryPosition: shuffleHistory.length - 1, // At the new tip
             preloadedTrack: nextSong,
             preloadReady: false,
-            queueLeadingStaleCount: state.queueLeadingStaleCount + 1,
+            pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
           };
         }
 
@@ -1543,7 +1561,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: timeUpdateDelay,
           preloadedTrack: nextSong,
           preloadReady: false,
-          queueLeadingStaleCount: state.queueLeadingStaleCount + 1,
+          pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
         };
       });
       get().refreshCanGoNext();

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/trackSelectionUtils';
 import { playbackTracker, updatePlayCount } from '../utils/playbackTracker';
 import {
+  GAPLESS5_CROSSFADE_MS,
   flushStaleCleanup,
   preloadNextInQueue,
   scheduleStaleCleanup,
@@ -103,7 +104,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
     silentAudioRef: null, // reference to the silent audio element for MediaSession support
     preloadedTrack: null, // track sitting at Gapless-5 queue index 1 (store-owned)
     preloadReady: false, // true once the preloaded track is decoded and ready
-    pendingStaleCleanupTimeout: null, // timer that drops the stale finished track after auto-advance
 
     // Settings actions
     setLibraryPath: async (libraryPath: Settings['libraryPath']) => {
@@ -466,7 +466,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
         // Run any pending post-crossfade stale cleanup now. Safe here
         // because we're about to rebuild the queue from scratch anyway.
-        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
+        flushStaleCleanup(state.player);
 
         const library = useLibraryStore.getState().tracks;
 
@@ -570,7 +570,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           playbackContextBrowserFilter: browserFilter, // Store the browser filter context
           preloadedTrack: nextSong ?? null,
           preloadReady: false,
-          pendingStaleCleanupTimeout: null,
         };
       });
       get().refreshCanGoNext();
@@ -608,7 +607,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         // reaction time (~200ms) is well past the 50ms scheduler, so
         // in practice this is a no-op; it's defensive against the
         // edge case where a user clicks skip within the window.
-        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
+        flushStaleCleanup(state.player);
 
         // If in shuffle mode
         if (state.shuffleMode) {
@@ -655,7 +654,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                pendingStaleCleanupTimeout: null,
               };
             }
           }
@@ -789,7 +787,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             shuffleHistoryPosition: shuffleHistory.length - 1, // Now at the new tip
             preloadedTrack: futureNextSong ?? null,
             preloadReady: false,
-            pendingStaleCleanupTimeout: null,
           };
         }
 
@@ -872,7 +869,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           duration: nextSong.duration,
           preloadedTrack: futureNextSong ?? null,
           preloadReady: false,
-          pendingStaleCleanupTimeout: null,
         };
       });
       get().refreshCanGoNext();
@@ -887,7 +883,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         // Flush any pending post-crossfade cleanup before we mutate the
         // queue. Every branch below either rebuilds the queue or just
         // seeks, so it's safe to run the deferred removeTrack now.
-        flushStaleCleanup(state.player, state.pendingStaleCleanupTimeout);
+        flushStaleCleanup(state.player);
 
         // If we're less than 3 seconds into the song, go to previous track
         // Otherwise, restart the current track
@@ -939,7 +935,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                pendingStaleCleanupTimeout: null,
               };
             }
           }
@@ -1009,7 +1004,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             duration: previousSong.duration,
             preloadedTrack: futureNextSong,
             preloadReady: false,
-            pendingStaleCleanupTimeout: null,
           };
         }
         // Restart the current track
@@ -1127,7 +1121,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
       if (!state.player) {
         const player = new Gapless5({
           useHTML5Audio: false,
-          crossfade: 25, // 25ms crossfade between tracks
+          crossfade: GAPLESS5_CROSSFADE_MS,
           exclusive: true, // Only one track can play at a time
           loadLimit: 3, // Load up to 3 tracks at a time
           volume: state.volume,
@@ -1179,10 +1173,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           // Drop the stale track left behind by a recent auto-advance now
           // that we're safely out of any crossfade transition.
           if (currentState.player) {
-            flushStaleCleanup(
-              currentState.player,
-              currentState.pendingStaleCleanupTimeout,
-            );
+            flushStaleCleanup(currentState.player);
           }
 
           // When pausing, update playback tracking
@@ -1206,7 +1197,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             }
           }
 
-          set({ paused: true, pendingStaleCleanupTimeout: null });
+          set({ paused: true });
         };
 
         player.ontimeupdate = (time) => {
@@ -1374,6 +1365,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
               if (futureNextSong) {
                 preloadNextInQueue(state.player, futureNextSong);
               }
+              scheduleStaleCleanup(state.player);
 
               // Update media session
               updateMediaSession(currentTrackThatIsAudiblyPlaying);
@@ -1396,7 +1388,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
                 shuffleHistoryPosition: newPosition,
                 preloadedTrack: futureNextSong ?? null,
                 preloadReady: false,
-                pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
               };
             }
           }
@@ -1489,6 +1480,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
           // Add the FUTURE next song to the player queue
           preloadNextInQueue(state.player, nextSong);
+          scheduleStaleCleanup(state.player);
 
           // Update media session
           updateMediaSession(currentTrackThatIsAudiblyPlaying);
@@ -1512,7 +1504,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
             shuffleHistoryPosition: shuffleHistory.length - 1, // At the new tip
             preloadedTrack: nextSong,
             preloadReady: false,
-            pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
           };
         }
 
@@ -1537,6 +1528,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
 
         // Add the FUTURE next song to the player queue
         preloadNextInQueue(state.player, nextSong);
+        scheduleStaleCleanup(state.player);
 
         // Update media session
         updateMediaSession(currentTrackThatIsAudiblyPlaying);
@@ -1561,7 +1553,6 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           lastPlaybackTimeUpdateRef: timeUpdateDelay,
           preloadedTrack: nextSong,
           preloadReady: false,
-          pendingStaleCleanupTimeout: scheduleStaleCleanup(state.player),
         };
       });
       get().refreshCanGoNext();

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -225,14 +225,13 @@ export interface SettingsAndPlaybackStore {
   // fully decoded and ready for a gapless transition. Reset to false any
   // time preloadedTrack changes.
   preloadReady: boolean;
-  // Count of stale finished tracks sitting at the front of Gapless-5's
-  // queue from prior auto-advances. See the leak note in playerQueue.ts.
-  // Incremented once per auto-advance, reset to 0 on any full rebuild
-  // (syncPlayerQueue) or on the fast-path cleanup in skipToNextTrack.
-  // Used only to tell the fast path how many removeTrack(0) calls it
-  // needs to execute after gotoTrack — never read as authoritative
-  // playback state.
-  queueLeadingStaleCount: number;
+  // Timer handle for the post-crossfade cleanup that drops the stale
+  // finished track at Gapless-5 queue index 0 after an auto-advance.
+  // Non-null between an auto-advance firing preloadNextInQueue and
+  // either the timer firing (~50ms later) or any action flushing it
+  // (pause, skipToNextTrack, skipToPreviousTrack, selectSpecificSong).
+  // See the leak note in playerQueue.ts for why we defer.
+  pendingStaleCleanupTimeout: ReturnType<typeof setTimeout> | null;
 
   // Combined actions
   // Settings actions

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -225,13 +225,6 @@ export interface SettingsAndPlaybackStore {
   // fully decoded and ready for a gapless transition. Reset to false any
   // time preloadedTrack changes.
   preloadReady: boolean;
-  // Timer handle for the post-crossfade cleanup that drops the stale
-  // finished track at Gapless-5 queue index 0 after an auto-advance.
-  // Non-null between an auto-advance firing preloadNextInQueue and
-  // either the timer firing (~50ms later) or any action flushing it
-  // (pause, skipToNextTrack, skipToPreviousTrack, selectSpecificSong).
-  // See the leak note in playerQueue.ts for why we defer.
-  pendingStaleCleanupTimeout: ReturnType<typeof setTimeout> | null;
 
   // Combined actions
   // Settings actions

--- a/src/renderer/utils/playerQueue.ts
+++ b/src/renderer/utils/playerQueue.ts
@@ -2,6 +2,29 @@ import { Gapless5 } from '@regosen/gapless-5';
 import { Track } from '../../types/dbTypes';
 import { getTrackUrl } from './trackSelectionUtils';
 
+/**
+ * Queue invariant (temporal):
+ *   Steady state — Gapless-5's queue holds at most two tracks:
+ *     [current, preloaded-next]
+ *   Transient state — between an `autoPlayNextTrack` call and its
+ *   scheduled cleanup firing (~50ms later, past the 25ms crossfade)
+ *   the queue momentarily holds three tracks:
+ *     [finished (stale), current, preloaded-next]
+ *
+ * The stale entry is removed by either:
+ *   - `scheduleStaleCleanup` firing ~50ms after the auto-advance, OR
+ *   - `flushStaleCleanup` running synchronously on pause or on any
+ *     user-initiated queue mutation (skip next/prev, selectSpecificSong).
+ *
+ * We intentionally do NOT assert length <= 2 synchronously: the
+ * transient 3-track window is expected after every auto-advance, so a
+ * sync assertion would spam the console without signal. The scheduled
+ * cleanup's own `length > 2` guard is the only runtime check; beyond
+ * that we rely on the regression spec
+ * (`e2e/playback-autoplay-skip.spec.ts`) to verify that queue length
+ * returns to 2 after an autoplay settles.
+ */
+
 export interface SyncPlayerQueueOptions {
   current: Track;
   next: Track | null | undefined;
@@ -10,29 +33,9 @@ export interface SyncPlayerQueueOptions {
 }
 
 /**
- * Dev-only sanity check that the Gapless-5 queue hasn't grown past
- * the two-slot invariant (current + preloaded-next).
- *
- * Brief length-3 window: after an `autoPlayNextTrack` the queue momentarily
- * holds [finished, current, preloaded]. `scheduleStaleCleanup` drops the
- * finished entry ~50ms later (safely past Gapless-5's 25ms crossfade) or
- * immediately on pause, whichever comes first. If this assertion trips at
- * steady state rather than in that transient window, it means a cleanup
- * was missed somewhere.
- */
-function assertQueueInvariant(player: Gapless5): void {
-  if (process.env.NODE_ENV === 'production') return;
-  const { length } = player.getTracks();
-  if (length > 2) {
-    console.error(
-      `[playerQueue] invariant violation: Gapless-5 holds ${length} tracks, expected <= 2`,
-    );
-  }
-}
-
-/**
  * Rebuild Gapless-5's internal queue to hold the current track (index 0)
- * and optionally a preloaded next track (index 1).
+ * and optionally a preloaded next track (index 1). Post-state is
+ * length 1 or 2.
  *
  * Gapless-5 is a controlled component: this helper is the single place
  * allowed to call removeAllTracks + addTrack in sequence. The Zustand
@@ -54,7 +57,6 @@ export function syncPlayerQueue(
   if (shouldPlay) {
     player.play();
   }
-  assertQueueInvariant(player);
 }
 
 /**
@@ -65,10 +67,12 @@ export function syncPlayerQueue(
  * so the finished track still lingers at index 0 and the queue
  * momentarily has length 3. `scheduleStaleCleanup` is the companion
  * call that drops that finished entry past the crossfade window.
+ *
+ * In `skipToNextTrack`'s fast path, cleanup is already flushed before
+ * this runs, so post-state is length 2.
  */
 export function preloadNextInQueue(player: Gapless5, next: Track): void {
   player.addTrack(getTrackUrl(next.filePath));
-  assertQueueInvariant(player);
 }
 
 /**

--- a/src/renderer/utils/playerQueue.ts
+++ b/src/renderer/utils/playerQueue.ts
@@ -13,17 +13,12 @@ export interface SyncPlayerQueueOptions {
  * Dev-only sanity check that the Gapless-5 queue hasn't grown past
  * the two-slot invariant (current + preloaded-next).
  *
- * KNOWN LEAK: after each `autoPlayNextTrack` the queue actually holds
- * three entries — the finished track at index 0, the now-playing
- * track at index 1, and the new preload at index 2. The obvious fix
- * (remove index 0 after Gapless-5 auto-advances) was attempted and
- * reverted in 45f4dab / d931896: removing a track mid-transition
- * triggers a Gapless-5 bug where the player pauses instead of
- * continuing auto-play. Until the upstream library is patched we
- * accept the leak. Functional impact is nil — Gapless-5 tracks its
- * own index and plays the right song — but this assertion will spam
- * the console in dev. loadLimit:3 caps actually-decoded audio memory;
- * only the URL list grows unbounded.
+ * Brief length-3 window: after an `autoPlayNextTrack` the queue momentarily
+ * holds [finished, current, preloaded]. `scheduleStaleCleanup` drops the
+ * finished entry ~50ms later (safely past Gapless-5's 25ms crossfade) or
+ * immediately on pause, whichever comes first. If this assertion trips at
+ * steady state rather than in that transient window, it means a cleanup
+ * was missed somewhere.
  */
 function assertQueueInvariant(player: Gapless5): void {
   if (process.env.NODE_ENV === 'production') return;
@@ -66,14 +61,50 @@ export function syncPlayerQueue(
  * Preload a single next track into Gapless-5 at queue index 1.
  * Assumes index 0 already holds a currently-playing track.
  *
- * In `autoPlayNextTrack` this helper is invoked after Gapless-5 has
- * already auto-advanced past a finished track, so the finished track
- * still lingers at index 0 and we end up at length 3. See the leak
- * note on `assertQueueInvariant` — we intentionally leave the stale
- * track in place because removing it during a transition breaks
- * Gapless-5's auto-play.
+ * In `autoPlayNextTrack` this runs right after Gapless-5 auto-advanced,
+ * so the finished track still lingers at index 0 and the queue
+ * momentarily has length 3. `scheduleStaleCleanup` is the companion
+ * call that drops that finished entry past the crossfade window.
  */
 export function preloadNextInQueue(player: Gapless5, next: Track): void {
   player.addTrack(getTrackUrl(next.filePath));
   assertQueueInvariant(player);
+}
+
+/**
+ * Schedule removal of the stale finished track that Gapless-5 leaves at
+ * queue index 0 after an auto-advance. Deferred past the 25ms crossfade
+ * window because removing the track mid-transition breaks Gapless-5's
+ * internal state and causes the player to pause (see 45f4dab → d931896).
+ *
+ * Length-guarded at fire time so scheduling this without a stale track
+ * pending is safe. Callers must store the returned handle in
+ * `pendingStaleCleanupTimeout` and flush it via `flushStaleCleanup` on
+ * pause or any queue-mutating user action.
+ */
+export function scheduleStaleCleanup(
+  player: Gapless5,
+): ReturnType<typeof setTimeout> {
+  return setTimeout(() => {
+    if (player.getTracks().length > 2) {
+      player.removeTrack(0);
+    }
+  }, 50);
+}
+
+/**
+ * Synchronously run the pending stale cleanup (if any) and cancel the
+ * timer. Safe to call at any time once we're out of the auto-advance
+ * crossfade window — pause and user-initiated queue mutations both
+ * qualify.
+ */
+export function flushStaleCleanup(
+  player: Gapless5,
+  handle: ReturnType<typeof setTimeout> | null,
+): void {
+  if (handle === null) return;
+  clearTimeout(handle);
+  if (player.getTracks().length > 2) {
+    player.removeTrack(0);
+  }
 }

--- a/src/renderer/utils/playerQueue.ts
+++ b/src/renderer/utils/playerQueue.ts
@@ -3,16 +3,32 @@ import { Track } from '../../types/dbTypes';
 import { getTrackUrl } from './trackSelectionUtils';
 
 /**
+ * Gapless-5's crossfade duration (milliseconds). Passed to the
+ * `Gapless5` constructor as the `crossfade` option. During this window
+ * the library is mid-transition between tracks and `removeTrack(0)`
+ * causes the player to pause instead of continuing (see 45f4dab →
+ * d931896). Any deferred cleanup must wait past this window.
+ */
+export const GAPLESS5_CROSSFADE_MS = 25;
+
+/**
+ * How long to wait after an auto-advance before removing the finished
+ * track at queue index 0. Two crossfade durations is a comfortable
+ * margin — the library's internal transition has fully settled.
+ */
+export const STALE_CLEANUP_DELAY_MS = GAPLESS5_CROSSFADE_MS * 2;
+
+/**
  * Queue invariant (temporal):
  *   Steady state — Gapless-5's queue holds at most two tracks:
  *     [current, preloaded-next]
  *   Transient state — between an `autoPlayNextTrack` call and its
- *   scheduled cleanup firing (~50ms later, past the 25ms crossfade)
- *   the queue momentarily holds three tracks:
+ *   scheduled cleanup firing (~STALE_CLEANUP_DELAY_MS later, past the
+ *   GAPLESS5_CROSSFADE_MS crossfade) the queue momentarily holds three:
  *     [finished (stale), current, preloaded-next]
  *
  * The stale entry is removed by either:
- *   - `scheduleStaleCleanup` firing ~50ms after the auto-advance, OR
+ *   - the scheduled cleanup firing, OR
  *   - `flushStaleCleanup` running synchronously on pause or on any
  *     user-initiated queue mutation (skip next/prev, selectSpecificSong).
  *
@@ -24,6 +40,14 @@ import { getTrackUrl } from './trackSelectionUtils';
  * (`e2e/playback-autoplay-skip.spec.ts`) to verify that queue length
  * returns to 2 after an autoplay settles.
  */
+
+// Module-private timer handle for the pending post-crossfade cleanup.
+// Lives here (not in Zustand) because it's a mutable side-effectful
+// resource, not plain data. The module acts as a singleton manager:
+// there is exactly one Gapless-5 player per renderer, so one handle
+// suffices. Callers schedule/flush via the exported functions and
+// never touch this directly.
+let pendingCleanupHandle: ReturnType<typeof setTimeout> | null = null;
 
 export interface SyncPlayerQueueOptions {
   current: Track;
@@ -77,23 +101,23 @@ export function preloadNextInQueue(player: Gapless5, next: Track): void {
 
 /**
  * Schedule removal of the stale finished track that Gapless-5 leaves at
- * queue index 0 after an auto-advance. Deferred past the 25ms crossfade
+ * queue index 0 after an auto-advance. Deferred past the crossfade
  * window because removing the track mid-transition breaks Gapless-5's
- * internal state and causes the player to pause (see 45f4dab → d931896).
+ * internal state and causes the player to pause.
  *
- * Length-guarded at fire time so scheduling this without a stale track
- * pending is safe. Callers must store the returned handle in
- * `pendingStaleCleanupTimeout` and flush it via `flushStaleCleanup` on
- * pause or any queue-mutating user action.
+ * Replaces any previously scheduled cleanup. Length-guarded at fire
+ * time so scheduling this without a stale track pending is safe.
  */
-export function scheduleStaleCleanup(
-  player: Gapless5,
-): ReturnType<typeof setTimeout> {
-  return setTimeout(() => {
+export function scheduleStaleCleanup(player: Gapless5): void {
+  if (pendingCleanupHandle !== null) {
+    clearTimeout(pendingCleanupHandle);
+  }
+  pendingCleanupHandle = setTimeout(() => {
+    pendingCleanupHandle = null;
     if (player.getTracks().length > 2) {
       player.removeTrack(0);
     }
-  }, 50);
+  }, STALE_CLEANUP_DELAY_MS);
 }
 
 /**
@@ -102,12 +126,10 @@ export function scheduleStaleCleanup(
  * crossfade window — pause and user-initiated queue mutations both
  * qualify.
  */
-export function flushStaleCleanup(
-  player: Gapless5,
-  handle: ReturnType<typeof setTimeout> | null,
-): void {
-  if (handle === null) return;
-  clearTimeout(handle);
+export function flushStaleCleanup(player: Gapless5): void {
+  if (pendingCleanupHandle === null) return;
+  clearTimeout(pendingCleanupHandle);
+  pendingCleanupHandle = null;
   if (player.getTracks().length > 2) {
     player.removeTrack(0);
   }


### PR DESCRIPTION
## Summary

Replace the `queueLeadingStaleCount` counter from #77 with a scheduled `setTimeout` that drops the stale finished track from Gapless-5's queue ~50ms after each auto-advance — safely past the 25ms crossfade window where synchronous `removeTrack(0)` breaks the library's internal state.

Cleanup also runs synchronously on pause and on any user-initiated queue mutation (skip next/prev, selectSpecificSong). With cleanup guaranteed before any subsequent queue mutation, the fast path simplifies back to the classic `gotoTrack(1) + removeTrack(0) + preloadNextInQueue`.

## Commits

| | |
|---|---|
| `e895656` | Scheduled cleanup + fast-path simplification |
| `9416819` | Drop the now-obsolete sync invariant assert |
| `1e3e40c` | Extract timer from Zustand; link delay to Gapless-5 crossfade config |

## Design after the follow-up commit

- **Timer is no longer in Zustand.** `playerQueue.ts` owns a module-private `pendingCleanupHandle`. Actions call `scheduleStaleCleanup(player)` / `flushStaleCleanup(player)` with no handle threaded through state patches.
- **Magic number is gone.** Two named constants in `playerQueue.ts`:

  ```ts
  export const GAPLESS5_CROSSFADE_MS = 25;
  export const STALE_CLEANUP_DELAY_MS = GAPLESS5_CROSSFADE_MS * 2;
  ```

  The `Gapless5` constructor uses `crossfade: GAPLESS5_CROSSFADE_MS`; `scheduleStaleCleanup` uses `STALE_CLEANUP_DELAY_MS`. Any change to the crossfade duration updates both sites in lockstep.

## How it works

| Event | Action |
|---|---|
| Auto-advance in `autoPlayNextTrack` | `scheduleStaleCleanup(player)` arms the module-level timer |
| Timer fires (still playing) | Drops index 0 if queue has grown past 2 |
| User pauses | `onpause` calls `flushStaleCleanup(player)` synchronously |
| User skips / selects | `flushStaleCleanup(player)` runs at top of the action |

At most one stale track can exist at a time because real music tracks are orders of magnitude longer than 50ms.

## Files

- `src/renderer/stores/types.ts` — removed `queueLeadingStaleCount`. No `pendingStaleCleanupTimeout` field (lives in `playerQueue.ts` module state instead).
- `src/renderer/stores/settingsAndPlaybackStore.ts` — schedule on three `autoPlayNextTrack` preload branches, flush on pause / skip / select. Fast path back to classic. `Gapless5` constructor uses `GAPLESS5_CROSSFADE_MS`.
- `src/renderer/utils/playerQueue.ts` — `scheduleStaleCleanup` / `flushStaleCleanup` with module-private handle, named constants, doc comments describing the temporal invariant.
- `e2e/playback-autoplay-skip.spec.ts` — `playerQueueLength === 2` assertions at existing checkpoints, plus a new case asserting queue settles to 2 within 200ms.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] All 22 playback-related e2e specs pass
- [x] Manual: play a track, let it auto-advance. Dev console `window.__hihat_e2e_getPlayerState()` should report `playerQueueLength === 2`.
- [x] Manual: repeat through 5+ auto-advances without pausing — player stays playing (regression check for the `45f4dab` pause bug).
- [x] Manual: skip right after an auto-advance — plays the preloaded track, no delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)