### PR TITLE
fix(player): correct marquee overflow measurement and reduce shimmer

### DIFF
--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -530,15 +530,15 @@ export default function Player() {
         return;
       }
 
-      // If marquee is showing, measure the text width against the Typography container
-      if (titleRef2.current) {
-        const container =
-          titleRef2.current.parentElement?.parentElement?.parentElement;
-        if (container) {
-          const textWidth = titleRef2.current.scrollWidth;
-          const containerWidth = container.clientWidth;
-          setIsTitleScrolling(textWidth > containerWidth);
-        }
+      // If marquee is showing, measure the text width against the track-info
+      // container directly. (The previous parentElement.parentElement.parentElement
+      // chain landed inside react-fast-marquee's internal `.rfm-marquee` flex
+      // wrapper, which is at least 2x the single-child width — so the check
+      // was effectively always false.)
+      if (titleRef2.current && trackInfoRef.current) {
+        const textWidth = titleRef2.current.scrollWidth;
+        const containerWidth = trackInfoRef.current.clientWidth;
+        setIsTitleScrolling(textWidth > containerWidth);
       }
     };
 
@@ -572,27 +572,24 @@ export default function Player() {
         return;
       }
 
-      // If marquee is showing, measure the text width against the Typography container
-      if (artistAlbumRef2.current) {
-        const container =
-          artistAlbumRef2.current.parentElement?.parentElement?.parentElement;
-        if (container) {
-          const textWidth = artistAlbumRef2.current.scrollWidth;
-          const containerWidth = container.clientWidth;
-          setIsArtistAlbumScrolling(textWidth > containerWidth);
-        }
+      // If marquee is showing, measure against the track-info container
+      // directly. See note in the title effect for why the previous
+      // parentElement traversal was wrong.
+      if (artistAlbumRef2.current && trackInfoRef.current) {
+        const textWidth = artistAlbumRef2.current.scrollWidth;
+        const containerWidth = trackInfoRef.current.clientWidth;
+        setIsArtistAlbumScrolling(textWidth > containerWidth);
       }
     };
 
     checkArtistAlbumOverflow();
 
-    // Create a ResizeObserver to watch for size changes on the Typography parent container
+    // Observe the Track Info Box which always resizes with the window.
+    // (Previously this resolved to a different element depending on which
+    // ref was populated at effect-mount time, leaving a stale observer
+    // target after state flips.)
     const resizeObserver = new ResizeObserver(checkArtistAlbumOverflow);
-
-    // Observe the Typography component that's always present
-    const typographyContainer =
-      artistAlbumRef.current?.parentElement ||
-      artistAlbumRef2.current?.parentElement?.parentElement?.parentElement;
+    const typographyContainer = trackInfoRef.current;
     if (typographyContainer) {
       resizeObserver.observe(typographyContainer);
     }
@@ -755,7 +752,7 @@ export default function Player() {
                         gradient
                         gradientColor={theme.palette.background.default}
                         gradientWidth={10}
-                        speed={10}
+                        speed={30}
                       >
                         <div ref={titleRef2}>
                           {currentTrack.title}&nbsp;&nbsp;•&nbsp;&nbsp;
@@ -783,7 +780,7 @@ export default function Player() {
                       gradient
                       gradientColor={theme.palette.background.default}
                       gradientWidth={10}
-                      speed={10}
+                      speed={30}
                     >
                       <div ref={artistAlbumRef2}>
                         {currentTrack.artist} • {currentTrack.album}


### PR DESCRIPTION
## Summary

- Fix marquee-branch overflow check that landed on `.rfm-marquee` (an internal flex wrapper holding duplicated children) instead of the track-info container, so the comparison was effectively always false.
- Fix artist+album `ResizeObserver` target which previously resolved to a different element depending on which ref was populated at effect-mount time, leaving a stale observer target after state flips.
- Bump marquee `speed` from `10` to `30` to mask GPU bilinear-sampling shimmer visible on light-on-dark text at very slow translate speeds.

## Why

The original check rarely fired (the observer watches the outer track-info Box, whose size doesn't change when children toggle), but on window resize during marquee playback it caused a visible snap to the static branch and back. Both effects now consistently measure against — and observe — `trackInfoRef.current`.

The shimmer at low speeds isn't a layout bug, it's the compositor sampling the cached glyph texture at sub-pixel offsets each frame; faster motion masks it via persistence of vision.

## Test plan

- [x] Play a track with a long title and a long artist+album, confirm both marquees scroll smoothly with no perceptible flicker
- [x] Drag-resize the window during marquee playback; confirm marquee stays marquee'd and doesn't snap to static
- [x] Switch to a track with a short title; confirm static (ellipsis-truncated) text renders, no marquee
- [x] Resize window narrower until short title overflows; confirm transition into marquee

🤖 Generated with [Claude Code](https://claude.com/claude-code)