### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Bump app version 2.1.0 → 2.2.0 in root and release/app package.json
- Re-sync both lockfiles via `npm install --package-lock-only` under node 22 (no dependency changes)

## Test plan
- [x] CI: typecheck / lint / build / playwright pass
- [x] Confirm 2.2.0 appears in About dialog after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)