### PR TITLE
fix(table): restore pointer cursor on library/playlist rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {

--- a/src/renderer/styles/virtualTable.css
+++ b/src/renderer/styles/virtualTable.css
@@ -177,11 +177,6 @@
   cursor: grab;
 }
 
-/* Draggable rows — grab cursor */
-tr[draggable="true"] {
-  cursor: grab;
-}
-
 /* While dragging — reduced opacity */
 .vt-th.vt-th-dragging {
   opacity: 0.5;


### PR DESCRIPTION
## Summary
- Drops the `tr[draggable="true"] { cursor: grab }` rule that was overriding `.vt-row { cursor: pointer }` and making every row in the library and playlist tables render the grab hand on hover.
- Row drag-and-drop behavior (preview, MIME payload, sidebar drop targets) is untouched — only cursor styling moved. Header drag still uses `cursor: grab` as the column-reorder affordance.
- Patch version bump to 2.2.1.

Closes #88.

## Test plan
- [x] `npm run build`
- [x] `npx playwright test e2e/drag-to-playlist.spec.ts` — 5/5 pass (single + multi-track drag, smart-playlist reject, dedup, playlist→playlist)
- [x] `npx playwright test e2e/column-reorder.spec.ts` — 3/3 pass (header drag affordance unaffected)
- [x] Manual hover in dev: library and playlist views render `pointer` on row hover; drag-to-sidebar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)