### PR TITLE
fix(notifications): wrap multi-line text instead of truncating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ npm-debug.log.*
 # Claude Code settings
 .claude
 
+# Ralph workflow (autonomous agent loop) — runner files, per-run state, and PRD drafts live locally only
+scripts/ralph/
+tasks/
+
 # E2E Testing
 e2e/screenshots/
 playwright-report/

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -60,39 +60,46 @@ test.describe('Notification System', () => {
   test('should stack multiple notifications', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Add a track to playlist-1 (first notification)
+    // Wait for renderer to fully boot so the e2e store hook is installed.
     await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-    const trackRow = page.locator('[data-track-id]').first();
-    await trackRow.click({ button: 'right' });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE !==
+        undefined,
+      undefined,
+      { timeout: 5000 },
+    );
 
-    // Verify first notification in the auto-expanded panel
+    // Seed two notifications directly via the store hook. The right-click +
+    // add-to-playlist trigger flow is already exercised by the surrounding
+    // single-notification specs (bell-icon, notification-text, dismiss,
+    // panel-toggle, panel-close); this test only needs two items present to
+    // exercise stacking UI. Driving the trigger twice in succession races
+    // with the auto-opened panel overlay (issue #98).
+    await page.evaluate(() => {
+      type UIStoreActions = {
+        clearAllNotifications: () => void;
+        showNotification: (
+          m: string,
+          t: 'info' | 'success' | 'warning' | 'error',
+        ) => void;
+        setNotificationPanelOpen: (open: boolean) => void;
+      };
+      const winRecord = window as unknown as Record<string, unknown>;
+      const store = (
+        winRecord.HIHAT_E2E_UI_STORE as { getState: () => UIStoreActions }
+      ).getState();
+      store.clearAllNotifications();
+      store.showNotification('First test notification', 'success');
+      store.showNotification('Second test notification', 'success');
+      store.setNotificationPanelOpen(true);
+    });
+
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
-    const itemsAfterFirst = panel.locator('[data-testid="notification-item"]');
-    expect(await itemsAfterFirst.count()).toBe(1);
 
-    // Add same track to playlist-2 (second notification) using force click
-    // since panel overlay is present. Panel stays expanded because it's already open.
-    await trackRow.click({ button: 'right', force: true });
-    await page.waitForSelector('[data-testid="add-to-playlist-menu-item"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForSelector('[data-testid="playlist-option-playlist-2"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="playlist-option-playlist-2"]');
-    await page.waitForTimeout(1000);
-
-    // Panel should still be open (no click-outside-to-close)
-    await panel.waitFor({ state: 'visible', timeout: 5000 });
     const items = panel.locator('[data-testid="notification-item"]');
-    const count = await items.count();
-    expect(count).toBeGreaterThanOrEqual(2);
+    await expect(items).toHaveCount(2);
 
     await TestHelpers.closeApp(app);
   });
@@ -131,32 +138,38 @@ test.describe('Notification System', () => {
   test('should clear all notifications', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Add a track to playlist-1 (first notification)
+    // Wait for renderer to fully boot so the e2e store hook is installed.
     await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-    const trackRow = page.locator('[data-track-id]').first();
-    await trackRow.click({ button: 'right' });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE !==
+        undefined,
+      undefined,
+      { timeout: 5000 },
+    );
 
-    // Verify first notification in the auto-expanded panel
+    // Seed two notifications directly via the store hook (see "should stack
+    // multiple notifications" for rationale — issue #98).
+    await page.evaluate(() => {
+      type UIStoreActions = {
+        clearAllNotifications: () => void;
+        showNotification: (
+          m: string,
+          t: 'info' | 'success' | 'warning' | 'error',
+        ) => void;
+        setNotificationPanelOpen: (open: boolean) => void;
+      };
+      const winRecord = window as unknown as Record<string, unknown>;
+      const store = (
+        winRecord.HIHAT_E2E_UI_STORE as { getState: () => UIStoreActions }
+      ).getState();
+      store.clearAllNotifications();
+      store.showNotification('First test notification', 'success');
+      store.showNotification('Second test notification', 'success');
+      store.setNotificationPanelOpen(true);
+    });
+
     const panel = page.locator('[data-testid="notification-panel"]');
-    await panel.waitFor({ state: 'visible', timeout: 5000 });
-
-    // Add same track to playlist-2 (second notification)
-    await trackRow.click({ button: 'right', force: true });
-    await page.waitForSelector('[data-testid="add-to-playlist-menu-item"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForSelector('[data-testid="playlist-option-playlist-2"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="playlist-option-playlist-2"]');
-    await page.waitForTimeout(1000);
-
-    // Panel should still be open (no click-outside-to-close)
     await panel.waitFor({ state: 'visible', timeout: 5000 });
 
     // Click Clear

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -214,7 +214,7 @@ test.describe('Notification System', () => {
     await TestHelpers.closeApp(app);
   });
 
-  test('should truncate long notification text with ellipsis', async () => {
+  test('should wrap long notification text instead of truncating', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
     // Trigger a notification via a real action
@@ -229,11 +229,11 @@ test.describe('Notification System', () => {
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
 
-    // Verify the notification text element has ellipsis overflow styles
+    // Verify the message Typography uses wrap styles (no ellipsis truncation)
     const item = panel.locator('[data-testid="notification-item"]').first();
     await expect(item).toBeVisible();
 
-    const textOverflow = await item
+    const textStyles = await item
       .locator('p')
       .first()
       .evaluate((el) => {
@@ -242,12 +242,140 @@ test.describe('Notification System', () => {
           whiteSpace: style.whiteSpace,
           overflow: style.overflow,
           textOverflow: style.textOverflow,
+          overflowWrap: style.overflowWrap,
         };
       });
 
-    expect(textOverflow.whiteSpace).toBe('nowrap');
-    expect(textOverflow.overflow).toBe('hidden');
-    expect(textOverflow.textOverflow).toBe('ellipsis');
+    // Wrapping must be enabled
+    expect(textStyles.whiteSpace).not.toBe('nowrap');
+    expect(textStyles.overflow).not.toBe('hidden');
+    expect(textStyles.textOverflow).not.toBe('ellipsis');
+    // overflowWrap must allow mid-token breaks for long unbroken paths/URLs
+    expect(textStyles.overflowWrap).toBe('anywhere');
+
+    // Native tooltip removed (full text now visible — title would duplicate)
+    const titleAttr = await item.locator('p').first().getAttribute('title');
+    expect(titleAttr).toBeNull();
+
+    await TestHelpers.closeApp(app);
+  });
+
+  test('should wrap multi-line and long-path notifications with X anchored top-right', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    // Wait for renderer to fully boot so the e2e store hook is installed
+    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE !==
+        undefined,
+      undefined,
+      { timeout: 5000 },
+    );
+
+    const SHORT_MSG = 'Saved.';
+    const LONG_MSG =
+      'Library scan complete. Imported 47 new tracks and updated 12 existing tracks. Some files were skipped because their metadata could not be read.';
+    const PATH_MSG =
+      'Failed to read /Users/somebody/Music/Library/Artists/Verylongartistnamethatdoesnotbreak/Album-Title-No-Breaks-Anywhere/01-very-long-track-filename-without-spaces-or-breaks.flac';
+
+    // Seed three notifications and force the panel open via the e2e hook.
+    await page.evaluate(
+      ({ shortMsg, longMsg, pathMsg }) => {
+        type UIStoreActions = {
+          clearAllNotifications: () => void;
+          showNotification: (
+            m: string,
+            t: 'info' | 'success' | 'warning' | 'error',
+          ) => void;
+          setNotificationPanelOpen: (open: boolean) => void;
+        };
+        const winRecord = window as unknown as Record<string, unknown>;
+        const store = (
+          winRecord.HIHAT_E2E_UI_STORE as { getState: () => UIStoreActions }
+        ).getState();
+        store.clearAllNotifications();
+        store.showNotification(shortMsg, 'success');
+        store.showNotification(longMsg, 'info');
+        store.showNotification(pathMsg, 'error');
+        store.setNotificationPanelOpen(true);
+      },
+      { shortMsg: SHORT_MSG, longMsg: LONG_MSG, pathMsg: PATH_MSG },
+    );
+
+    const panel = page.locator('[data-testid="notification-panel"]');
+    await panel.waitFor({ state: 'visible', timeout: 5000 });
+
+    const items = panel.locator('[data-testid="notification-item"]');
+    await expect(items).toHaveCount(3);
+
+    // Each row exposes its dismiss X (top-right anchor on multi-line rows)
+    const dismissButtons = panel.locator(
+      '[data-testid="notification-dismiss"]',
+    );
+    await expect(dismissButtons).toHaveCount(3);
+
+    // Capture full page + a panel-only screenshot for inspection
+    await TestHelpers.takeScreenshot(page, 'notif-wrap-panel-three-items');
+    await panel.screenshot({
+      path: 'e2e/screenshots/notif-wrap-panel-only.png',
+    });
+
+    // Per-row geometry checks: long rows must be taller than short row
+    // and the X must remain anchored to the top of each row.
+    const rowMetrics = await items.evaluateAll((els) =>
+      els.map((row) => {
+        const rect = (row as HTMLElement).getBoundingClientRect();
+        const dismiss = row.querySelector(
+          '[data-testid="notification-dismiss"]',
+        ) as HTMLElement | null;
+        const dismissRect = dismiss?.getBoundingClientRect();
+        const message = row.querySelector('p') as HTMLElement | null;
+        const messageRect = message?.getBoundingClientRect();
+        return {
+          rowText: (message?.textContent ?? '').slice(0, 40),
+          rowHeight: rect.height,
+          rowTop: rect.top,
+          rowRight: rect.right,
+          rowLeft: rect.left,
+          dismissTop: dismissRect?.top ?? null,
+          dismissRight: dismissRect?.right ?? null,
+          messageWidth: messageRect?.width ?? null,
+        };
+      }),
+    );
+
+    expect(rowMetrics).toHaveLength(3);
+    const [shortRow, longRow, pathRow] = rowMetrics;
+
+    // Long content rows must wrap to multiple lines (taller than the
+    // ~32px single-line floor)
+    expect(longRow.rowHeight).toBeGreaterThan(shortRow.rowHeight + 12);
+    expect(pathRow.rowHeight).toBeGreaterThan(shortRow.rowHeight + 12);
+
+    // X dismiss button anchored top-right on every row: its top edge
+    // sits near the row's top, not vertically centered in a tall row.
+    rowMetrics.forEach((m) => {
+      if (m.dismissTop != null) {
+        expect(m.dismissTop - m.rowTop).toBeLessThan(14);
+      }
+      if (m.dismissRight != null) {
+        expect(m.rowRight - m.dismissRight).toBeLessThan(14);
+      }
+    });
+
+    // Dismiss X visible for every row (including multi-line)
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(dismissButtons.nth(i)).toBeVisible();
+    }
+
+    // Long-path message wraps within the panel — message width must
+    // fit inside the panel's interior (no horizontal overflow).
+    const panelBox = await panel.boundingBox();
+    if (panelBox && pathRow.messageWidth != null) {
+      expect(pathRow.messageWidth).toBeLessThanOrEqual(panelBox.width);
+    }
 
     await TestHelpers.closeApp(app);
   });

--- a/src/renderer/components/NotificationSystem.tsx
+++ b/src/renderer/components/NotificationSystem.tsx
@@ -269,7 +269,7 @@ export default function NotificationSystem() {
               data-testid="notification-item"
               sx={{
                 display: 'flex',
-                alignItems: 'center',
+                alignItems: 'flex-start',
                 gap: '8px',
                 px: '8px',
                 py: '6px',
@@ -301,11 +301,8 @@ export default function NotificationSystem() {
                   fontSize: '13px',
                   color: 'text.primary',
                   flex: 1,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
+                  overflowWrap: 'anywhere',
                 }}
-                title={notification.message}
                 variant="body2"
               >
                 {notification.message}

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -60,4 +60,12 @@ const useUIStore = create<UIStore>((set) => ({
   toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
 }));
 
+// E2E diagnostic hook: lets Playwright specs seed notifications and
+// toggle the panel without driving real user actions. Mirrors the
+// `__hihat_e2e_getPlayerState` pattern in settingsAndPlaybackStore.
+if (typeof window !== 'undefined') {
+  (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE =
+    useUIStore;
+}
+
 export default useUIStore;


### PR DESCRIPTION
## Summary

Closes #95 and #98.

Two related fixes bundled into one PR:

### 1. Notification text wraps multi-line (closes #95)

Notification panel rows previously truncated long messages with an ellipsis, so the full text was only readable via a hover tooltip — long error messages and file paths got clipped on first read. Rows now wrap multi-line, the colored left accent border grows with the row, and the dismiss X stays anchored top-right.

- **`NotificationSystem.tsx`** — row Box switches `alignItems: 'center'` → `'flex-start'` so the X anchors top-right when text wraps. Message `Typography` drops `whiteSpace: nowrap`, `overflow: hidden`, `textOverflow: ellipsis`, and adds `overflowWrap: 'anywhere'` for long unbroken tokens (paths, URLs). Redundant `title` prop removed.
- **`uiStore.ts`** — adds an `HIHAT_E2E_UI_STORE` window hook (mirrors the `__hihat_e2e_getPlayerState` pattern in `settingsAndPlaybackStore`) so Playwright specs can seed notifications without driving real user actions.
- **`e2e/notifications.spec.ts`** — replaces the stale ellipsis assertion with a wrap-style assertion (computed styles, no `title` attr) and adds a three-fixture spec (short / multi-sentence / long unbroken path) verifying row-height delta, X position, and no horizontal overflow inside the panel.
- **`.gitignore`** — adds `scripts/ralph/` and `tasks/` so Ralph runner files and per-branch PRD drafts stay local.

### 2. De-flake the multi-notification specs (closes #98)

Two specs (`should stack multiple notifications` and `should clear all notifications`) flaked because they generated two notifications by right-clicking the same track row twice. After the first notification, the panel auto-opens and races with the second right-click + context menu + dialog sequence. The prior `force: true` only papered over part of it.

Replaces the two-trigger right-click chain in both specs with direct `showNotification` calls via the new `HIHAT_E2E_UI_STORE` hook (the same hook this PR introduces for fix #1). Tightens the stack assertion from `toBeGreaterThanOrEqual(2)` → `toHaveCount(2)` since seeding is deterministic.

- **`e2e/notifications.spec.ts`** — both formerly-flaky specs rewritten to seed via the store hook.

The `right-click → add-to-playlist → showNotification` integration remains covered by six other specs in this file (bell icon, single notification text, dismiss, panel toggle via bell, panel close via X, and the wrap test added above), so coverage is preserved.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npx playwright test e2e/notifications.spec.ts -g "should wrap"` — wrap specs green
- [x] `npx playwright test e2e/notifications.spec.ts -g "should stack multiple notifications|should clear all notifications" --repeat-each=5` — **10/10 green** (was previously ~50% flake rate)
- [x] `npx playwright test e2e/notifications.spec.ts` — **9/9 green** (full file, no regressions)
- [ ] **Reviewer:** spot-check `e2e/screenshots/notif-wrap-panel-only.png` after running the spec locally — short item single-line, multi-sentence wraps cleanly, long-path wraps mid-token, X top-right on every row, accent borders span full row height
- [ ] **Reviewer:** verify single-line notifications (existing flows: scan complete, playlist add success, etc.) still render visually identical — only multi-line behavior should change

## Notes for reviewer

- Webpack's `EnvironmentPlugin` only forwards `NODE_ENV` and `DEBUG_PROD` to the renderer, so `process.env.TEST_MODE` set at Electron launch does NOT reach renderer code. The `HIHAT_E2E_UI_STORE` hook is therefore installed unconditionally at module load time (matches the existing `__hihat_e2e_getPlayerState` pattern). Tracked as enhancement #99 — if gating it behind a build flag is desirable, that's a follow-up that should also gate the existing hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
