### PR TITLE
fix(e2e): stop notifications spec flake by seeding via store hook

### DIFF
--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -60,39 +60,46 @@ test.describe('Notification System', () => {
   test('should stack multiple notifications', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Add a track to playlist-1 (first notification)
+    // Wait for renderer to fully boot so the e2e store hook is installed.
     await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-    const trackRow = page.locator('[data-track-id]').first();
-    await trackRow.click({ button: 'right' });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE !==
+        undefined,
+      undefined,
+      { timeout: 5000 },
+    );
 
-    // Verify first notification in the auto-expanded panel
+    // Seed two notifications directly via the store hook. The right-click +
+    // add-to-playlist trigger flow is already exercised by the surrounding
+    // single-notification specs (bell-icon, notification-text, dismiss,
+    // panel-toggle, panel-close); this test only needs two items present to
+    // exercise stacking UI. Driving the trigger twice in succession races
+    // with the auto-opened panel overlay (issue #98).
+    await page.evaluate(() => {
+      type UIStoreActions = {
+        clearAllNotifications: () => void;
+        showNotification: (
+          m: string,
+          t: 'info' | 'success' | 'warning' | 'error',
+        ) => void;
+        setNotificationPanelOpen: (open: boolean) => void;
+      };
+      const winRecord = window as unknown as Record<string, unknown>;
+      const store = (
+        winRecord.HIHAT_E2E_UI_STORE as { getState: () => UIStoreActions }
+      ).getState();
+      store.clearAllNotifications();
+      store.showNotification('First test notification', 'success');
+      store.showNotification('Second test notification', 'success');
+      store.setNotificationPanelOpen(true);
+    });
+
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
-    const itemsAfterFirst = panel.locator('[data-testid="notification-item"]');
-    expect(await itemsAfterFirst.count()).toBe(1);
 
-    // Add same track to playlist-2 (second notification) using force click
-    // since panel overlay is present. Panel stays expanded because it's already open.
-    await trackRow.click({ button: 'right', force: true });
-    await page.waitForSelector('[data-testid="add-to-playlist-menu-item"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForSelector('[data-testid="playlist-option-playlist-2"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="playlist-option-playlist-2"]');
-    await page.waitForTimeout(1000);
-
-    // Panel should still be open (no click-outside-to-close)
-    await panel.waitFor({ state: 'visible', timeout: 5000 });
     const items = panel.locator('[data-testid="notification-item"]');
-    const count = await items.count();
-    expect(count).toBeGreaterThanOrEqual(2);
+    await expect(items).toHaveCount(2);
 
     await TestHelpers.closeApp(app);
   });
@@ -131,32 +138,38 @@ test.describe('Notification System', () => {
   test('should clear all notifications', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Add a track to playlist-1 (first notification)
+    // Wait for renderer to fully boot so the e2e store hook is installed.
     await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-    const trackRow = page.locator('[data-track-id]').first();
-    await trackRow.click({ button: 'right' });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).HIHAT_E2E_UI_STORE !==
+        undefined,
+      undefined,
+      { timeout: 5000 },
+    );
 
-    // Verify first notification in the auto-expanded panel
+    // Seed two notifications directly via the store hook (see "should stack
+    // multiple notifications" for rationale — issue #98).
+    await page.evaluate(() => {
+      type UIStoreActions = {
+        clearAllNotifications: () => void;
+        showNotification: (
+          m: string,
+          t: 'info' | 'success' | 'warning' | 'error',
+        ) => void;
+        setNotificationPanelOpen: (open: boolean) => void;
+      };
+      const winRecord = window as unknown as Record<string, unknown>;
+      const store = (
+        winRecord.HIHAT_E2E_UI_STORE as { getState: () => UIStoreActions }
+      ).getState();
+      store.clearAllNotifications();
+      store.showNotification('First test notification', 'success');
+      store.showNotification('Second test notification', 'success');
+      store.setNotificationPanelOpen(true);
+    });
+
     const panel = page.locator('[data-testid="notification-panel"]');
-    await panel.waitFor({ state: 'visible', timeout: 5000 });
-
-    // Add same track to playlist-2 (second notification)
-    await trackRow.click({ button: 'right', force: true });
-    await page.waitForSelector('[data-testid="add-to-playlist-menu-item"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForSelector('[data-testid="playlist-option-playlist-2"]', {
-      timeout: 5000,
-    });
-    await page.click('[data-testid="playlist-option-playlist-2"]');
-    await page.waitForTimeout(1000);
-
-    // Panel should still be open (no click-outside-to-close)
     await panel.waitFor({ state: 'visible', timeout: 5000 });
 
     // Click Clear


### PR DESCRIPTION
## Summary

Closes #98.

Two specs in `e2e/notifications.spec.ts` flaked because they generated two notifications by right-clicking the same track row twice (and adding it to two playlists). After the first notification, the panel auto-opens and races with the second right-click + context-menu + dialog sequence; the prior `force: true` click only papered over part of it.

Replace the two-trigger right-click chain in both specs with direct `showNotification` calls via the `HIHAT_E2E_UI_STORE` window hook (already shipping in #97, already in use by the wrap test in this same file).

- **`should stack multiple notifications`** — seeds 2 notifications, asserts panel has exactly 2 items (`toHaveCount(2)` instead of `toBeGreaterThanOrEqual(2)` since seeding is deterministic).
- **`should clear all notifications`** — seeds 2 notifications, clicks Clear, asserts panel hidden.

## Why this is a coverage-preserving change

The `right-click → add-to-playlist → showNotification` integration is already exercised by six other specs in this file, all using a single notification (no second-right-click flake):

- `should always show notification bell icon`
- `should show notification when adding a track to a playlist`
- `should dismiss a single notification`
- `should toggle panel open and closed via bell icon`
- `should close panel with close button`
- `should wrap long notification text instead of truncating` (from #97)

Removing the right-click trigger from the two flaky specs preserves their actual purpose (stacking + clear-all UI) and doesn't reduce the integration coverage matrix.

## Dependency on #97

This PR is branched off `main`, but the test code references `window.HIHAT_E2E_UI_STORE`, which is added by #97. CI on this PR will fail until #97 merges, at which point this PR auto-resolves and can merge. No code conflict between the two PRs — only a temporal dependency.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` (e2e/notifications.spec.ts) clean
- [x] `npm run build` clean
- [x] `npx playwright test e2e/notifications.spec.ts -g "should stack multiple notifications|should clear all notifications" --repeat-each=5` — **10/10 green** (5 reruns of each, was previously ~50% flake rate)
- [x] `npx playwright test e2e/notifications.spec.ts` — **9/9 green** (no regression in the other 7 specs)
- [ ] **CI:** will go red until #97 merges. After that it should pass without changes.

Verification was performed by stashing the test edits, applying them on top of #97's branch (which has the hook), running the specs there, then bringing the edits back to this branch. Diff applied cleanly both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)