### PR TITLE
fix(backup): smooth progress bar + ETA

### DIFF
--- a/src/__tests__/formatters.test.ts
+++ b/src/__tests__/formatters.test.ts
@@ -5,6 +5,7 @@
 import {
   calculateTotalHours,
   formatDuration,
+  formatEta,
 } from '../renderer/utils/formatters';
 
 describe('formatDuration', () => {
@@ -88,5 +89,47 @@ describe('calculateTotalHours', () => {
     expect(calculateTotalHours([{ duration: 86399 }])).toMatch(/h$/);
     // 24h 0m 1s -> days
     expect(calculateTotalHours([{ duration: 86401 }])).toMatch(/d$/);
+  });
+});
+
+describe('formatEta', () => {
+  test('volatility guard: too few samples and too soon → empty', () => {
+    // 1 file in 500ms is not enough signal to estimate.
+    expect(formatEta(500, 1, 1000)).toBe('');
+    expect(formatEta(1999, 4, 1000)).toBe('');
+  });
+
+  test('emits an estimate once we have either enough files or enough time', () => {
+    // 5 files unlocks an estimate even if elapsed is small.
+    expect(formatEta(500, 5, 1000)).not.toBe('');
+    // 2s elapsed unlocks an estimate even with 1 file.
+    expect(formatEta(2000, 1, 1000)).not.toBe('');
+  });
+
+  test('returns empty when there is nothing left to do', () => {
+    expect(formatEta(10_000, 100, 100)).toBe('');
+    expect(formatEta(10_000, 100, 50)).toBe('');
+    expect(formatEta(10_000, 0, 100)).toBe('');
+  });
+
+  test('formats sub-minute estimates as seconds', () => {
+    // 10 files in 1s → 100ms/file → 50 files remaining = 5s
+    expect(formatEta(1000, 10, 60)).toBe('5 seconds');
+  });
+
+  test('formats sub-hour estimates as minutes', () => {
+    // 10 files in 1s → 100ms/file → 6000 files remaining = 600s = 10min
+    expect(formatEta(1000, 10, 6010)).toBe('10 minutes');
+  });
+
+  test('formats hour-plus estimates as hours and minutes', () => {
+    // 1 file/s → 7200s remaining = 2h
+    const out = formatEta(10_000, 10, 7210);
+    expect(out).toMatch(/^\d+ hours? \d+ minutes?$/);
+  });
+
+  test('uses singular nouns for 1-hour estimates', () => {
+    // 1 file/s → 3660s remaining = 1h 1m
+    expect(formatEta(10_000, 10, 3670)).toBe('1 hour 1 minute');
   });
 });

--- a/src/main/ipc/backupHandlers.ts
+++ b/src/main/ipc/backupHandlers.ts
@@ -6,154 +6,96 @@
  *   - registers via `ipcMain.on('menu-backup-library', …)`, not
  *     `ipcMain.handle`
  *   - streams progress to the renderer via `event.reply()` repeatedly
- *     over the lifetime of the rsync subprocess (counting → scanning →
- *     transferring → success/error), rather than returning a single
- *     typed response
- *   - parses rsync's stdout (~250 lines below) to derive structured
- *     progress events, which has nothing to do with the typed
- *     invoke-handler registry in `handlers.ts`
+ *     over the lifetime of the rsync subprocess (planning → transferring
+ *     → success/error), rather than returning a single typed response
+ *
+ * Two phases:
+ *   1. Plan — walk source and destination to count files that need to
+ *      transfer (matches --ignore-existing semantics). Knowing the
+ *      denominator up front is what lets the renderer show smooth
+ *      progress in phase 2.
+ *   2. Transfer — run rsync with `--out-format='%i %n'` so each
+ *      transferred entry is one stable, version-independent line on
+ *      stdout. The `%i` itemize-changes string lets us tell files apart
+ *      from directories that rsync creates along the way (rsync emits a
+ *      line for each created directory too — counting those would blow
+ *      past the file-count denominator we computed in phase 1). Emit
+ *      progress events throttled to 250ms. This avoids parsing rsync's
+ *      verbose-mode output, whose format differs across rsync 2.x,
+ *      rsync 3.x, and OpenRsync (the macOS Sequoia default).
  *
  * Anything else that needs the same long-running, progress-streaming
  * shape belongs in its own similar file/module — not in `handlers.ts`.
  */
 
 import path from 'path';
+import { promises as fsp } from 'fs';
 import type { IpcMainEvent } from 'electron';
 import Rsync from 'rsync';
 import * as db from '../db';
 
-// Define interfaces for parsed output types
-interface BaseOutput {
-  type: string;
-}
-
-interface FileOutput extends BaseOutput {
-  type: 'file';
-  currentFile: string;
-}
-
-interface PreparingOutput extends BaseOutput {
-  type: 'preparing';
-  status: string;
-}
-
-interface FilesCountOutput extends BaseOutput {
-  type: 'filesCount';
-  totalFiles: number;
-}
-
-interface ScanningOutput extends BaseOutput {
-  type: 'scanning';
-  filesProcessed: number;
-}
-
-interface ProgressOutput extends BaseOutput {
-  type: 'progress';
-  percent: number;
-  currentTransfer?: number;
-  remaining?: number;
-  total?: number;
-}
-
-interface SpeedOutput extends BaseOutput {
-  type: 'speed';
-  speed: string;
-}
-
-type ParsedOutput =
-  | FileOutput
-  | PreparingOutput
-  | FilesCountOutput
-  | ScanningOutput
-  | ProgressOutput
-  | SpeedOutput
-  | null;
+const PLANNING_EMIT_EVERY_N_FILES = 100;
+const TRANSFER_EMIT_INTERVAL_MS = 250;
 
 /**
- * Parses rsync output to extract useful information
- * @param output - The stdout from rsync
- * @returns Parsed information object or null if not relevant
+ * Walk the source library tree, counting files that don't yet exist at
+ * the destination. Mirrors rsync `--ignore-existing` semantics: presence
+ * of the destination path means "skip", regardless of size or mtime.
+ *
+ * `onChecked` fires every {@link PLANNING_EMIT_EVERY_N_FILES} files so
+ * the renderer can keep the indeterminate progress bar lively rather
+ * than appearing frozen on large libraries.
  */
-const parseRsyncOutput = (output: string): ParsedOutput => {
-  const trimmedOutput = output.trim();
+async function planBackup(
+  libraryPath: string,
+  backupPath: string,
+  onChecked: (totalChecked: number) => void,
+): Promise<{ totalFiles: number; totalChecked: number }> {
+  const state = { totalFiles: 0, totalChecked: 0 };
 
-  // Check if this is a file transfer line with a path
-  if (trimmedOutput.includes('.m4a') || trimmedOutput.includes('.mp3')) {
-    return {
-      type: 'file',
-      currentFile: trimmedOutput,
-    };
-  }
-
-  // Check if this is a file list building line
-  if (trimmedOutput.includes('building file list')) {
-    return {
-      type: 'preparing',
-      status: 'Building file list...',
-    };
-  }
-
-  // Check if this shows number of files to process
-  const filesMatch = trimmedOutput.match(/(\d+) files to consider/);
-  if (filesMatch) {
-    return {
-      type: 'filesCount',
-      totalFiles: parseInt(filesMatch[1], 10),
-    };
-  }
-
-  // Check if this is a progress percentage line
-  const progressMatch = trimmedOutput.match(/(\d+)%/);
-  if (progressMatch) {
-    // Also try to get transfer info if available
-    const transferMatch = trimmedOutput.match(
-      /\(xfer#(\d+), to-check=(\d+)\/(\d+)\)/,
-    );
-    if (transferMatch) {
-      return {
-        type: 'progress',
-        percent: parseInt(progressMatch[1], 10),
-        currentTransfer: parseInt(transferMatch[1], 10),
-        remaining: parseInt(transferMatch[2], 10),
-        total: parseInt(transferMatch[3], 10),
-      };
+  const walk = async (dir: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
     }
+    await Promise.all(
+      entries.map(async (entry) => {
+        const sourcePath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(sourcePath);
+          return;
+        }
+        if (!entry.isFile()) return;
+        const rel = path.relative(libraryPath, sourcePath);
+        const destPath = path.join(backupPath, rel);
+        try {
+          await fsp.access(destPath);
+          // Exists at destination — rsync will skip it.
+        } catch {
+          state.totalFiles += 1;
+        }
+        state.totalChecked += 1;
+        if (state.totalChecked % PLANNING_EMIT_EVERY_N_FILES === 0) {
+          onChecked(state.totalChecked);
+        }
+      }),
+    );
+  };
 
-    return {
-      type: 'progress',
-      percent: parseInt(progressMatch[1], 10),
-    };
-  }
-
-  // Check if this is a speed line
-  const speedMatch = trimmedOutput.match(/(\d+\.\d+)(M|K|G)B\/s/);
-  if (speedMatch) {
-    return {
-      type: 'speed',
-      speed: `${speedMatch[1]} ${speedMatch[2]}B/s`,
-    };
-  }
-
-  // Check if showing X files processed
-  const filesProcessedMatch = trimmedOutput.match(/(\d+) files\.\.\./);
-  if (filesProcessedMatch) {
-    return {
-      type: 'scanning',
-      filesProcessed: parseInt(filesProcessedMatch[1], 10),
-    };
-  }
-
-  return null;
-};
+  await walk(libraryPath);
+  return state;
+}
 
 /**
- * Backup the user's library to the specified directory using rsync
+ * Backup the user's library to the specified directory using rsync.
+ *
  * @param backupPath - Path to backup the library to
  * @param event - IPC event to reply with progress or completion
  */
 const backupLibrary = async (backupPath: string, event: IpcMainEvent) => {
   try {
-    // Get user settings for library path
     const settings = await db.getSettings();
     const { libraryPath } = settings;
 
@@ -162,7 +104,6 @@ const backupLibrary = async (backupPath: string, event: IpcMainEvent) => {
       return;
     }
 
-    // Validate that backup path is not the same as library path
     if (
       backupPath === libraryPath ||
       backupPath.startsWith(libraryPath + path.sep)
@@ -174,25 +115,88 @@ const backupLibrary = async (backupPath: string, event: IpcMainEvent) => {
       return;
     }
 
-    console.warn('backupLibrary called');
+    // Phase 1: Plan
+    event.reply('backup-library-progress', {
+      phase: 'planning',
+      status: 'Checking files...',
+    });
 
-    // Set up rsync
+    const { totalFiles } = await planBackup(
+      libraryPath,
+      backupPath,
+      (checked) => {
+        event.reply('backup-library-progress', {
+          phase: 'planning',
+          status: `Checking ${checked.toLocaleString()} files...`,
+        });
+      },
+    );
+
+    event.reply('backup-library-progress', {
+      phase: 'planning',
+      totalFiles,
+      status:
+        totalFiles === 0
+          ? 'Already up to date'
+          : `Found ${totalFiles.toLocaleString()} new file${
+              totalFiles === 1 ? '' : 's'
+            } to back up`,
+    });
+
+    if (totalFiles === 0) {
+      event.reply('backup-library-success');
+      return;
+    }
+
+    // Phase 2: Transfer
+    let filesCopied = 0;
+    let lastEmit = 0;
+    let stdoutBuf = '';
+
+    const emitProgress = (currentFile: string, force: boolean) => {
+      const now = Date.now();
+      if (!force && now - lastEmit < TRANSFER_EMIT_INTERVAL_MS) return;
+      lastEmit = now;
+      const progress = Math.min(
+        100,
+        Math.round((filesCopied / totalFiles) * 100),
+      );
+      event.reply('backup-library-progress', {
+        phase: 'transferring',
+        progress,
+        currentFile,
+        currentTransfer: filesCopied,
+        total: totalFiles,
+        remaining: Math.max(0, totalFiles - filesCopied),
+        status: `Copying: ${path.basename(currentFile)}`,
+      });
+    };
+
+    const handleLine = (rawLine: string) => {
+      const line = rawLine.trim();
+      // rsync emits one line per transferred *entry* — files AND
+      // directory creations. Format with --out-format='%i %n' is:
+      // 11 itemize chars + ' ' + path. Position 1 of %i is the entry
+      // type: 'f' (regular file), 'd' (directory), 'L' (symlink), etc.
+      // Only count regular files so the numerator can't overshoot the
+      // file-count denominator from planBackup. Lines too short or with
+      // a non-file type byte are skipped silently.
+      if (line.length < 13 || line.charAt(1) !== 'f') return;
+      const fileName = line.substring(12);
+      filesCopied += 1;
+      const isFirst = filesCopied === 1;
+      const isLast = filesCopied >= totalFiles;
+      emitProgress(fileName, isFirst || isLast);
+    };
+
     const rsync = new Rsync();
-
-    // Track current state
-    let currentFile = '';
-    let filesProcessed = 0;
-    let totalFiles = 0;
-    let phase = 'preparing';
-    let transferSpeed = '';
-
     rsync
-      .set('ignore-existing') // Don't overwrite existing files
-      .flags(['v', 'P', 'r', 'h']) // Verbose, Progress, Recursive, Human-readable
-      .source(libraryPath + path.sep) // Ensure trailing slash to copy contents
+      .set('ignore-existing')
+      .set('out-format', '%i %n')
+      .flags(['r'])
+      .source(libraryPath + path.sep)
       .destination(backupPath);
 
-    // Execute the command
     rsync.execute(
       (error, _code, cmd) => {
         console.warn('rsync command:', cmd);
@@ -203,99 +207,36 @@ const backupLibrary = async (backupPath: string, event: IpcMainEvent) => {
           return;
         }
 
-        // Backup successful
+        // Flush any buffered partial line that didn't get a trailing newline.
+        if (stdoutBuf.trim()) handleLine(stdoutBuf);
+
+        // Final 100% — guarantees the bar lands at full even if the file
+        // count drifted (e.g. rsync copied directory entries we didn't
+        // count in planBackup).
+        event.reply('backup-library-progress', {
+          phase: 'transferring',
+          progress: 100,
+          currentFile: '',
+          currentTransfer: totalFiles,
+          total: totalFiles,
+          remaining: 0,
+          status: 'Finishing up…',
+        });
+
         event.reply('backup-library-success');
       },
       (stdout) => {
-        const output = stdout.toString();
-
-        console.warn('rsync stdout:', output);
-
-        // Parse output
-        const parsedOutput = parseRsyncOutput(output);
-
-        if (parsedOutput) {
-          switch (parsedOutput.type) {
-            case 'preparing':
-              phase = 'preparing';
-              event.reply('backup-library-progress', {
-                phase,
-                status: 'Preparing backup...',
-              });
-              break;
-
-            case 'filesCount':
-              totalFiles = parsedOutput.totalFiles;
-              event.reply('backup-library-progress', {
-                phase: 'counting',
-                totalFiles,
-                status: `Found ${totalFiles} files to backup`,
-              });
-              break;
-
-            case 'scanning':
-              filesProcessed = parsedOutput.filesProcessed;
-              event.reply('backup-library-progress', {
-                phase: 'scanning',
-                filesProcessed,
-                status: `Scanning files: ${filesProcessed} processed`,
-              });
-              break;
-
-            case 'file':
-              currentFile = parsedOutput.currentFile;
-              phase = 'transferring';
-              event.reply('backup-library-progress', {
-                phase,
-                currentFile,
-                status: `Copying: ${currentFile}`,
-              });
-              break;
-
-            case 'progress':
-              if (
-                'total' in parsedOutput &&
-                parsedOutput.total !== undefined &&
-                'remaining' in parsedOutput &&
-                parsedOutput.remaining !== undefined &&
-                'currentTransfer' in parsedOutput &&
-                parsedOutput.currentTransfer !== undefined
-              ) {
-                const progress = Math.round(
-                  ((parsedOutput.total - parsedOutput.remaining) /
-                    parsedOutput.total) *
-                    100,
-                );
-                event.reply('backup-library-progress', {
-                  phase: 'transferring',
-                  progress,
-                  currentFile,
-                  currentTransfer: parsedOutput.currentTransfer,
-                  remaining: parsedOutput.remaining,
-                  total: parsedOutput.total,
-                  transferSpeed,
-                  status: `Copying: ${currentFile} (${parsedOutput.currentTransfer}/${parsedOutput.total})`,
-                });
-              }
-              break;
-
-            case 'speed':
-              transferSpeed = parsedOutput.speed;
-              break;
-
-            default:
-              // Unhandled output type
-              break;
-          }
-        }
+        stdoutBuf += stdout.toString();
+        const lines = stdoutBuf.split('\n');
+        stdoutBuf = lines.pop() ?? '';
+        lines.forEach(handleLine);
       },
       (stderr) => {
+        // rsync writes warnings (e.g. "skipping non-regular file") to
+        // stderr without exiting non-zero. Log them but don't surface as
+        // a backup error or progress-phase change — only the exit-code
+        // callback above triggers the error path.
         console.warn('rsync stderr:', stderr.toString());
-        // Send error information to renderer if needed
-        event.reply('backup-library-progress', {
-          phase: 'error',
-          status: `Error: ${stderr.toString()}`,
-        });
       },
     );
   } catch (error: unknown) {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -35,6 +35,7 @@ import {
   getSettingsSnapshot,
   DEFAULT_COLUMNS,
 } from '../queries';
+import { formatEta } from '../utils/formatters';
 import ConfirmationDialog from './ConfirmationDialog';
 
 // Define the props for the Settings component
@@ -85,7 +86,7 @@ export default function Settings({ onClose }: SettingsProps) {
   const scanProcessedFilesRef = useRef<string[]>([]);
   const scanStartTime = useRef<number>(0);
 
-  const [_backupStatus, setBackupStatus] = useState('');
+  const [backupStatus, setBackupStatus] = useState('');
   // Add backup progress state
   const [backupProgress, setBackupProgress] = useState(0);
   const [backupCurrentFile, setBackupCurrentFile] = useState('');
@@ -94,8 +95,11 @@ export default function Settings({ onClose }: SettingsProps) {
     current: number;
     total: number;
     remaining: number;
-    speed: string;
+    estimatedTimeRemaining: string;
   } | null>(null);
+  // Wall-clock anchor for ETA. Set when the first file finishes copying
+  // (transfer phase, currentTransfer === 1). Reset to 0 between runs.
+  const backupStartTime = useRef<number>(0);
   // Track the last processed file for display in the completed log
   const [_processedFiles, setProcessedFiles] = useState<string[]>([]);
   const processedFilesRef = useRef<string[]>([]);
@@ -146,34 +150,17 @@ export default function Settings({ onClose }: SettingsProps) {
           setScanProcessedFiles(updatedFiles);
         }
 
-        // Calculate ETA
         if (data.processed > 0 && scanStartTime.current > 0) {
-          const elapsedTime = now - scanStartTime.current;
-          const filesPerMs = data.processed / elapsedTime;
-          const remainingFiles = data.total - data.processed;
-          const estimatedRemainingMs = remainingFiles / filesPerMs;
-
-          // Format estimated time remaining
-          let estimatedTimeRemaining = '';
-          if (estimatedRemainingMs < 60000) {
-            // Less than a minute
-            estimatedTimeRemaining = `${Math.ceil(estimatedRemainingMs / 1000)} seconds`;
-          } else if (estimatedRemainingMs < 3600000) {
-            // Less than an hour
-            estimatedTimeRemaining = `${Math.ceil(estimatedRemainingMs / 60000)} minutes`;
-          } else {
-            // Hours or more
-            const hours = Math.floor(estimatedRemainingMs / 3600000);
-            const minutes = Math.ceil((estimatedRemainingMs % 3600000) / 60000);
-            estimatedTimeRemaining = `${hours} hour${hours !== 1 ? 's' : ''} ${minutes} minute${minutes !== 1 ? 's' : ''}`;
-          }
-
-          // Update transfer info
+          const elapsedMs = now - scanStartTime.current;
           setScanTransferInfo({
             current: data.processed,
             total: data.total,
-            remaining: remainingFiles,
-            estimatedTimeRemaining,
+            remaining: data.total - data.processed,
+            estimatedTimeRemaining: formatEta(
+              elapsedMs,
+              data.processed,
+              data.total,
+            ),
           });
         }
 
@@ -246,17 +233,24 @@ export default function Settings({ onClose }: SettingsProps) {
           data.total !== undefined &&
           data.remaining !== undefined
         ) {
+          if (backupStartTime.current === 0 && data.currentTransfer >= 1) {
+            backupStartTime.current = Date.now();
+          }
+          const elapsedMs =
+            backupStartTime.current === 0
+              ? 0
+              : Date.now() - backupStartTime.current;
           setBackupTransferInfo({
             current: data.currentTransfer,
             total: data.total,
             remaining: data.remaining,
-            speed: data.transferSpeed || '',
+            estimatedTimeRemaining: formatEta(
+              elapsedMs,
+              data.currentTransfer,
+              data.total,
+            ),
           });
         }
-      } else if (data.phase === 'counting' && data.totalFiles) {
-        setBackupStatus(`Found ${data.totalFiles} files to backup`);
-      } else if (data.phase === 'scanning' && data.filesProcessed) {
-        setBackupStatus(`Scanning files: ${data.filesProcessed} processed`);
       }
     });
 
@@ -376,10 +370,16 @@ export default function Settings({ onClose }: SettingsProps) {
         return;
       }
 
-      // Show backup dialog
+      // Reset run-scoped state so a second backup in the same session
+      // doesn't show stale counts/ETA from the previous run.
       setBackupDialogOpen(true);
       setIsBackupInProgress(true);
       setBackupStatus('Backing up library...');
+      setBackupPhase('preparing');
+      setBackupProgress(0);
+      setBackupCurrentFile('');
+      setBackupTransferInfo(null);
+      backupStartTime.current = 0;
 
       // Trigger the backup; progress / success / error arrive via the
       // backup.on* subscriptions above.
@@ -528,10 +528,8 @@ export default function Settings({ onClose }: SettingsProps) {
     switch (backupPhase) {
       case 'preparing':
         return 'Preparing...';
-      case 'counting':
-        return 'Counting files...';
-      case 'scanning':
-        return 'Scanning files...';
+      case 'planning':
+        return 'Checking files...';
       case 'transferring':
         return 'Copying files...';
       case 'error':
@@ -958,12 +956,25 @@ export default function Settings({ onClose }: SettingsProps) {
               variant={getProgressVariant()}
             />
 
+            {backupPhase === 'planning' && backupStatus && (
+              <Typography color="text.secondary" variant="body2">
+                {backupStatus}
+              </Typography>
+            )}
+
             {backupPhase === 'transferring' && backupTransferInfo && (
               <Typography color="text.secondary" variant="body2">
                 {backupTransferInfo.current.toLocaleString()} of{' '}
                 {backupTransferInfo.total.toLocaleString()} files
               </Typography>
             )}
+
+            {backupPhase === 'transferring' &&
+              backupTransferInfo?.estimatedTimeRemaining && (
+                <Typography color="text.secondary" variant="body2">
+                  About {backupTransferInfo.estimatedTimeRemaining} remaining
+                </Typography>
+              )}
 
             {backupPhase === 'transferring' && backupCurrentFile && (
               <Typography

--- a/src/renderer/utils/formatters.ts
+++ b/src/renderer/utils/formatters.ts
@@ -56,3 +56,44 @@ export function calculateTotalHours(
   const days = totalDays.toFixed(1);
   return `${days}${days === '1.0' ? 'd' : 'd'}`;
 }
+
+/**
+ * Format a "time remaining" estimate from elapsed wall-clock time and
+ * file counts. Returns an empty string when the estimate would be too
+ * volatile to be useful (very small samples / very recent start).
+ *
+ * Used by both the library scan and library backup progress dialogs so
+ * their wording stays consistent.
+ *
+ * @param elapsedMs - Milliseconds since the operation started
+ * @param processed - Files processed so far
+ * @param total - Total files expected
+ * @returns Human-readable estimate (e.g. "3 minutes", "1 hour 5 minutes")
+ *          or an empty string when no estimate should be shown yet.
+ */
+export function formatEta(
+  elapsedMs: number,
+  processed: number,
+  total: number,
+): string {
+  // Volatility guard: with only a handful of samples the estimate
+  // bounces wildly. Suppress until we have either enough files OR
+  // enough wall-clock time to smooth it out.
+  if (processed < 5 && elapsedMs < 2000) return '';
+  if (processed === 0) return '';
+  const remaining = total - processed;
+  if (remaining <= 0) return '';
+
+  const msPerFile = elapsedMs / processed;
+  const etaMs = remaining * msPerFile;
+
+  if (etaMs < 60_000) {
+    return `${Math.ceil(etaMs / 1000)} seconds`;
+  }
+  if (etaMs < 3_600_000) {
+    return `${Math.ceil(etaMs / 60_000)} minutes`;
+  }
+  const hours = Math.floor(etaMs / 3_600_000);
+  const minutes = Math.ceil((etaMs % 3_600_000) / 60_000);
+  return `${hours} hour${hours !== 1 ? 's' : ''} ${minutes} minute${minutes !== 1 ? 's' : ''}`;
+}


### PR DESCRIPTION
## Summary
- Backup library progress bar was stuck at 0% — `backupHandlers` parsed an rsync 2.x stdout format (`xfer#N, to-check=N/Total`) that neither macOS OpenRsync nor modern rsync 3.x emit. Replaced parsing with a two-phase, version-independent flow: a Node-side `planBackup` walk that counts files-to-transfer (matching `--ignore-existing` semantics) and an rsync run with `--out-format='%i %n'` that emits one stable line per transferred entry.
- The transfer counter filters on the `%i` itemize-changes type byte so newly-created directories don't overshoot the file-count denominator. Stdout is line-buffered, emissions throttled to 250ms, and a final 100% is guaranteed in the rsync exit callback.
- Backup and library-scan modals now share a new `formatEta` helper in `formatters.ts` with a volatility guard for the first ~2s / ~5 files. Seven unit tests pin its boundaries.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` — 170 passing (adds 7 cases for `formatEta`)
- [x] Manual smoke against a large library: planning phase shows indeterminate bar with live "Checking N files…" updates, transfer bar fills smoothly 0→100%, "X of Y files" counter ends at the denominator, ETA appears after a couple seconds and decreases monotonically
- [x] Manual smoke against a same-destination re-run: hits the `totalFiles === 0` path and shows the standard success toast immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)