### PR TITLE
fix(playlists): show name (not id) in delete notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {

--- a/src/renderer/queries/playlists.ts
+++ b/src/renderer/queries/playlists.ts
@@ -109,10 +109,8 @@ export function useDeletePlaylist() {
       );
       return { prev };
     },
-    onSuccess: (_data, id) => {
-      const name = qc
-        .getQueryData<Playlist[]>(queryKeys.playlists)
-        ?.find((p) => p.id === id)?.name;
+    onSuccess: (_data, id, ctx) => {
+      const name = ctx?.prev?.find((p) => p.id === id)?.name;
       useUIStore
         .getState()
         .showNotification(`Playlist "${name ?? id}" deleted`, 'success');


### PR DESCRIPTION
## Summary
- Deleting a user-created playlist surfaced `Playlist "43f98fa1-3931-4b6c-baf7-c544860003b8" deleted` instead of the playlist's name.
- `useDeletePlaylist`'s `onMutate` optimistically removed the row from the `queryKeys.playlists` cache, then `onSuccess` looked the name up in that (post-delete) cache and the `name ?? id` fallback fired.
- Read the name from `ctx.prev` (the snapshot already captured by `onMutate`) instead — same pattern used by `useAddTrackToPlaylist`'s `onSuccess`. Two-line change in `src/renderer/queries/playlists.ts`.
- Patch version bump 2.3.0 → 2.3.1 (root + `release/app/`).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Manual: `npm run start`, create a playlist (e.g. "Test Delete Me"), delete via sidebar context menu, confirm the notification reads `Playlist "Test Delete Me" deleted` (not the UUID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)