### PR TITLE
docs(readme): add SQLite to the Built With section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ See the [open issues](https://github.com/johnnyshankman/hihat/issues) for a full
 * [![zustand][zustand.js]][zustand-url]
 * [![TanStack Query][TanStackQuery.js]][TanStackQuery-url]
 * [![TanStack Table][TanStackTable.js]][TanStackTable-url]
+* [![SQLite][SQLite.js]][SQLite-url]
 * [![Music Metadata][MusicMetadata.js]][MusicMetadata-url]
 * [![Gapless 5][Gapless5.js]][Gapless5-url]
 
@@ -295,3 +296,5 @@ Project Link: [https://github.com/johnnyshankman/hihat](https://github.com/johnn
 [TanStackTable-url]: https://tanstack.com/table
 [Gapless5.js]: https://img.shields.io/badge/Gapless5-20232A?style=for-the-badge&logo=javascript&logoColor=007ACC
 [Gapless5-url]: https://github.com/regosen/Gapless-5
+[SQLite.js]: https://img.shields.io/badge/SQLite-20232A?style=for-the-badge&logo=sqlite&logoColor=007ACC
+[SQLite-url]: https://sql.js.org


### PR DESCRIPTION
## What

Adds a **SQLite** badge to the **Built With** section of the README, linking to [sql.js](https://sql.js.org).

## Why

The Built With section already lists functional infrastructure libraries — Gapless 5 (audio engine) and Music Metadata (tag parser) — not just headline frameworks. hihat's database layer is equally fundamental, so leaving it out was an inconsistency.

The badge is labelled **SQLite** because that is what it genuinely is (and what readers recognize), and links to **sql.js.org** — the WebAssembly SQLite build the app actually depends on (no native bindings).

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)