### PR TITLE
fix(security): scope hihat-audio:// protocol to the library path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -181,22 +181,22 @@ const createWindow = async () => {
   }
 
   /**
-   * Register a custom protocol to handle audio file requests from the renderer process
-   * This allows the renderer to access audio files through a custom URL scheme
+   * Register a custom protocol to handle audio file requests from the renderer process.
+   * This allows the renderer to access audio files through a custom URL scheme.
+   * Confined to the library directory so a compromised renderer can't
+   * read arbitrary files, mirroring the fileSystem:deleteFile guard.
    */
   protocol.registerFileProtocol('hihat-audio', (request, callback) => {
     try {
       const url = request.url.replace('hihat-audio://getfile/', '');
       const decodedUrl = decodeURIComponent(url);
 
-      // Confine to the library directory so a compromised renderer can't
-      // read arbitrary files. Mirrors the fileSystem:deleteFile guard.
       const { libraryPath } = getSettings();
       if (!libraryPath) {
         console.error('Refusing audio request: library path is not set');
         return callback({ error: 404 });
       }
-
+      
       const resolvedTarget = path.resolve(decodedUrl);
       const resolvedRoot = path.resolve(libraryPath);
       if (

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -189,18 +189,14 @@ const createWindow = async () => {
       const url = request.url.replace('hihat-audio://getfile/', '');
       const decodedUrl = decodeURIComponent(url);
 
-      // Constrain audio requests to files inside the configured library
-      // path. The renderer only builds these URLs from track file paths,
-      // and the scanner copies every imported file into libraryPath, so a
-      // legitimate request always resolves inside it. Without this check a
-      // compromised renderer could request any path on disk (such as
-      // hihat-audio://getfile/%2Fetc%2Fpasswd) and read it. Mirrors the
-      // prefix check in the fileSystem:deleteFile IPC handler.
+      // Confine to the library directory so a compromised renderer can't
+      // read arbitrary files. Mirrors the fileSystem:deleteFile guard.
       const { libraryPath } = getSettings();
       if (!libraryPath) {
         console.error('Refusing audio request: library path is not set');
         return callback({ error: 404 });
       }
+
       const resolvedTarget = path.resolve(decodedUrl);
       const resolvedRoot = path.resolve(libraryPath);
       if (

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -196,7 +196,7 @@ const createWindow = async () => {
         console.error('Refusing audio request: library path is not set');
         return callback({ error: 404 });
       }
-      
+
       const resolvedTarget = path.resolve(decodedUrl);
       const resolvedRoot = path.resolve(libraryPath);
       if (

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -185,10 +185,33 @@ const createWindow = async () => {
    * This allows the renderer to access audio files through a custom URL scheme
    */
   protocol.registerFileProtocol('hihat-audio', (request, callback) => {
-    const url = request.url.replace('hihat-audio://getfile/', '');
-    const decodedUrl = decodeURIComponent(url);
     try {
-      return callback(decodedUrl);
+      const url = request.url.replace('hihat-audio://getfile/', '');
+      const decodedUrl = decodeURIComponent(url);
+
+      // Constrain audio requests to files inside the configured library
+      // path. The renderer only builds these URLs from track file paths,
+      // and the scanner copies every imported file into libraryPath, so a
+      // legitimate request always resolves inside it. Without this check a
+      // compromised renderer could request any path on disk (such as
+      // hihat-audio://getfile/%2Fetc%2Fpasswd) and read it. Mirrors the
+      // prefix check in the fileSystem:deleteFile IPC handler.
+      const { libraryPath } = getSettings();
+      if (!libraryPath) {
+        console.error('Refusing audio request: library path is not set');
+        return callback({ error: 404 });
+      }
+      const resolvedTarget = path.resolve(decodedUrl);
+      const resolvedRoot = path.resolve(libraryPath);
+      if (
+        resolvedTarget !== resolvedRoot &&
+        !resolvedTarget.startsWith(resolvedRoot + path.sep)
+      ) {
+        console.error('Refusing audio request outside the library path');
+        return callback({ error: 404 });
+      }
+
+      return callback(resolvedTarget);
     } catch (error) {
       console.error('Error handling audio file request:', error);
       return callback({ error: 404 });


### PR DESCRIPTION
## Summary

The `hihat-audio://` custom protocol handler (`src/main/main.ts`) passed the decoded request path straight to the file callback with **no validation**. Since the renderer can construct any `hihat-audio://` URL, a compromised renderer (XSS / malicious content) could request **any file on disk** — e.g. `hihat-audio://getfile/%2Fetc%2Fpasswd` — turning a renderer foothold into an arbitrary local file read (SSH keys, browser cookies, `~/Library`, …).

## Fix

Confine every request to the configured `libraryPath`:

- Resolve the decoded path against the library root and reject anything outside it (`!== root && !startsWith(root + path.sep)`).
- The scanner copies every imported file into `libraryPath` (`copyFileToLibrary`), so every legitimate audio request already resolves inside it — **playback is unaffected**.
- Mirrors the existing prefix check in the `fileSystem:deleteFile` IPC handler, for consistency.
- Also moves URL decoding inside the `try` so malformed `decodeURIComponent` input fails closed (404) instead of throwing.

`registerFileProtocol` is intentionally kept (deprecated but still supported in Electron 35) — migrating to `protocol.handle` is a separate concern, left out of this security fix to avoid playback/seeking regressions.

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run lint` ✓
- Targeted e2e (`playback`, `playback-autoplay`, `audio-formats`) — **15/15 passed**: FLAC/WAV/OGG/AAC all play, autoplay-to-completion and play/pause all work; confinement does not break audio loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
