### PR TITLE
fix: use valid semver ranges in devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,12 +249,12 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=22.x",
+      "version": ">=24.0.0",
       "onFail": "error"
     },
     "packageManager": {
       "name": "npm",
-      "version": ">=10.x",
+      "version": ">=11.1.0",
       "onFail": "error"
     }
   },


### PR DESCRIPTION
## Problem

Dependabot refused to run on this repo with:

> Invalid package manager specification in package.json. The packageManager field must specify a valid semver version

## Cause

`devEngines.runtime.version` and `devEngines.packageManager.version` were set to `">=22.x"` and `">=10.x"`. Combining a comparator operator (`>=`) with an x-range wildcard (`22.x`) is **not valid semver**, so Dependabot rejected the manifest.

## Fix

Replace with proper semver ranges, aligned with the existing `engines` field:

- runtime (node): `>=22.x` → `>=24.0.0`
- packageManager (npm): `>=10.x` → `>=11.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)