### PR TITLE
fix: add exact packageManager field for Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": ">=24.0.0",
     "npm": ">=11.1.0"
   },
+  "packageManager": "npm@11.14.1",
   "scripts": {
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:dll": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",


### PR DESCRIPTION
## Problem

Dependabot's automatic **security updates** (currently upgrading `electron` 35.7.5 → 42.1.0 for multiple CVEs) fail on every run:

```
Invalid package manager specification in package.json (npm@>=11.1.0); expected a semver version
```

[Failing run](https://github.com/johnnyshankman/hihat/actions/runs/25981479148/job/76370907624)

## Root cause

Dependabot runs npm through **Corepack**. Corepack reads the top-level `packageManager` field and requires an **exact** version — it rejects ranges. `package.json` had no `packageManager` field, so Dependabot synthesized a Corepack spec from `engines.npm` (`">=11.1.0"`), producing the invalid `npm@>=11.1.0`.

Confirmed by reproducing the exact error locally with `corepack` and by checking Dependabot's `npm_and_yarn/package_manager.rb` — it reads `packageManager` and `engines`, **not `devEngines`**.

## Fix

Add an exact-version top-level `packageManager` field:

```diff
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=11.1.0"
   },
+  "packageManager": "npm@11.14.1",
```

With a valid `packageManager` present, Dependabot uses it directly (skipping `engines`) and hands Corepack a valid spec.

- `npm@11.14.1` satisfies `engines.npm >=11.1.0`; no `package-lock.json` change (the lockfile does not record `packageManager`).

Once merged to `main`, the next Dependabot security-update run will pick up the fix.

## Relationship to #115

This PR fixes what #115 set out to fix — the failing Dependabot security-update job. #115 changed `devEngines`, which is **not** on Dependabot's npm code path (it reads `packageManager` and `engines`), so the job kept failing afterward.

**#115 is still a valid change and should not be reverted.** It corrected `devEngines.runtime` / `devEngines.packageManager` from `>=22.x` / `>=10.x` (which mix a comparator with an x-range and aren't valid semver) to proper ranges aligned with `engines`. That's a genuine, independent fix — it just wasn't the cause of the Dependabot failure. The two PRs are complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
