### PR TITLE
fix: refine Settings panel header, layout, and type hierarchy

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -616,7 +616,7 @@ export default function Settings({ onClose }: SettingsProps) {
         <Typography
           color="text.primary"
           sx={{ userSelect: 'none' }}
-          variant="h1"
+          variant="h2"
         >
           Settings
         </Typography>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_COLUMNS,
 } from '../queries';
 import { formatEta } from '../utils/formatters';
+import { mutedIconButtonSx } from '../styles/iconButtonStyles';
 import ConfirmationDialog from './ConfirmationDialog';
 
 // Define the props for the Settings component
@@ -621,7 +622,7 @@ export default function Settings({ onClose }: SettingsProps) {
         <IconButton
           onClick={onClose}
           size="small"
-          sx={{ WebkitAppRegion: 'no-drag' }}
+          sx={{ ...mutedIconButtonSx, WebkitAppRegion: 'no-drag' }}
         >
           <CloseIcon />
         </IconButton>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -15,9 +15,7 @@ import {
   DialogTitle,
   DialogContent,
   LinearProgress,
-  Divider,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
 import FolderIcon from '@mui/icons-material/Folder';
 import WarningIcon from '@mui/icons-material/Warning';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -631,140 +629,116 @@ export default function Settings({ onClose }: SettingsProps) {
 
       <Paper elevation={1} sx={{ WebkitAppRegion: 'no-drag', p: 2 }}>
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
-          <Grid container spacing={3}>
-            {/* Library Path Section */}
-            <Grid size={12}>
-              <Typography gutterBottom variant="h2">
-                Music Folder
-              </Typography>
-              <Typography
-                color="text.secondary"
-                sx={{ display: 'block', mb: 2 }}
-                variant="caption"
-              >
-                The folder on your computer where your music files live. hihat
-                scans this folder and all its subfolders.
-              </Typography>
-              <FormControl fullWidth sx={{ mt: 1 }}>
-                <TextField
-                  label="Folder"
-                  onChange={handleSelectLibraryPath}
-                  slotProps={{
-                    input: {
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            edge="end"
-                            onClick={handleSelectLibraryPath}
-                          >
-                            <FolderIcon />
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                  value={libraryPath}
-                />
-              </FormControl>
-            </Grid>
-
-            <Grid size={12}>
-              <Divider sx={{ my: 2 }} />
-            </Grid>
-
-            <Grid size={12}>
-              <Typography gutterBottom variant="h2">
-                Import Music
-              </Typography>
-
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <Typography
-                  color="text.secondary"
-                  sx={{ display: 'block', fontSize: '0.75rem' }}
-                >
-                  Add new songs or entire folders to your library. Files are
-                  copied into your Music Folder, so the originals stay right
-                  where they are. Duplicates are skipped automatically.
-                </Typography>
-                <Button
-                  color="primary"
-                  disabled={!libraryPath || isScanning}
-                  fullWidth
-                  onClick={handleAddSongs}
-                  startIcon={<AddIcon />}
-                  variant="contained"
-                >
-                  Add Songs
-                </Button>
-              </Box>
-            </Grid>
-
-            <Grid size={12}>
-              <Divider sx={{ my: 2 }} />
-            </Grid>
-
-            {/* Library Operations Section */}
-            <Grid size={12}>
-              <Typography gutterBottom variant="h2">
-                Rescan Library
-              </Typography>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <Typography
-                  color="text.secondary"
-                  sx={{ display: 'block', fontSize: '0.75rem' }}
-                >
-                  Check your music folder for any new, changed, or removed files
-                  and update your library to match.
-                </Typography>
-                <Button
-                  color="primary"
-                  disabled={!libraryPath || isScanning}
-                  fullWidth
-                  onClick={handleRescanLibrary}
-                  startIcon={<RefreshIcon />}
-                  variant="contained"
-                >
-                  {isScanning ? 'Scanning...' : 'Rescan Library'}
-                </Button>
-              </Box>
-            </Grid>
-
-            <Grid size={12}>
-              <Divider sx={{ my: 2 }} />
-            </Grid>
-
-            {/* Backup Section */}
-            <Grid size={12}>
-              <Typography gutterBottom variant="h2">
-                Backup Library
-              </Typography>
-              <Typography
-                color="text.secondary"
-                sx={{ display: 'block', mb: 2 }}
-                variant="caption"
-              >
-                Copy your music library to an external drive or another folder.
-                Only new and changed files are copied each time, so backups
-                after the first one are fast. Your existing backup files are
-                never removed.
-              </Typography>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <Button
-                  color="primary"
-                  disabled={!libraryPath || isScanning || isBackupInProgress}
-                  onClick={handleBackupLibrary}
-                  startIcon={<BackupIcon />}
-                  variant="contained"
-                >
-                  {isBackupInProgress ? 'Backing Up...' : 'Backup Library'}
-                </Button>
-              </Box>
-            </Grid>
-          </Grid>
+          <Typography gutterBottom variant="h3">
+            Music Folder
+          </Typography>
+          <Typography
+            color="text.secondary"
+            sx={{ display: 'block', mb: 2 }}
+            variant="caption"
+          >
+            The folder on your computer where your music files live. hihat scans
+            this folder and all its subfolders.
+          </Typography>
+          <FormControl fullWidth sx={{ mt: 1 }}>
+            <TextField
+              label="Folder"
+              onChange={handleSelectLibraryPath}
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton edge="end" onClick={handleSelectLibraryPath}>
+                        <FolderIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              value={libraryPath}
+            />
+          </FormControl>
         </Paper>
 
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
-          <Typography gutterBottom variant="h2">
+          <Typography gutterBottom variant="h3">
+            Import Music
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Typography
+              color="text.secondary"
+              sx={{ display: 'block', fontSize: '0.75rem' }}
+            >
+              Add new songs or entire folders to your library. Files are copied
+              into your Music Folder, so the originals stay right where they
+              are. Duplicates are skipped automatically.
+            </Typography>
+            <Button
+              color="primary"
+              disabled={!libraryPath || isScanning}
+              fullWidth
+              onClick={handleAddSongs}
+              startIcon={<AddIcon />}
+              variant="contained"
+            >
+              Add Songs
+            </Button>
+          </Box>
+        </Paper>
+
+        <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Typography gutterBottom variant="h3">
+            Rescan Library
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Typography
+              color="text.secondary"
+              sx={{ display: 'block', fontSize: '0.75rem' }}
+            >
+              Check your music folder for any new, changed, or removed files and
+              update your library to match.
+            </Typography>
+            <Button
+              color="primary"
+              disabled={!libraryPath || isScanning}
+              fullWidth
+              onClick={handleRescanLibrary}
+              startIcon={<RefreshIcon />}
+              variant="contained"
+            >
+              {isScanning ? 'Scanning...' : 'Rescan Library'}
+            </Button>
+          </Box>
+        </Paper>
+
+        <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Typography gutterBottom variant="h3">
+            Backup Library
+          </Typography>
+          <Typography
+            color="text.secondary"
+            sx={{ display: 'block', mb: 2 }}
+            variant="caption"
+          >
+            Copy your music library to an external drive or another folder. Only
+            new and changed files are copied each time, so backups after the
+            first one are fast. Your existing backup files are never removed.
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Button
+              color="primary"
+              disabled={!libraryPath || isScanning || isBackupInProgress}
+              onClick={handleBackupLibrary}
+              startIcon={<BackupIcon />}
+              variant="contained"
+            >
+              {isBackupInProgress ? 'Backing Up...' : 'Backup Library'}
+            </Button>
+          </Box>
+        </Paper>
+
+        <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Typography gutterBottom variant="h3">
             Appearance
           </Typography>
           <Typography
@@ -791,7 +765,7 @@ export default function Settings({ onClose }: SettingsProps) {
         </Paper>
 
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
-          <Typography gutterBottom variant="h2">
+          <Typography gutterBottom variant="h3">
             Sorting
           </Typography>
           <Typography
@@ -819,7 +793,7 @@ export default function Settings({ onClose }: SettingsProps) {
         </Paper>
 
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
-          <Typography gutterBottom variant="h2">
+          <Typography gutterBottom variant="h3">
             Column Visibility
           </Typography>
           <Typography
@@ -916,7 +890,7 @@ export default function Settings({ onClose }: SettingsProps) {
         </Paper>
 
         <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
-          <Typography gutterBottom variant="h2">
+          <Typography gutterBottom variant="h3">
             Reset
           </Typography>
           <Box sx={{ mt: 2 }}>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -600,7 +600,11 @@ export default function Settings({ onClose }: SettingsProps) {
           alignItems: 'center',
           justifyContent: 'space-between',
           px: 2,
-          py: 1.35,
+          py: 0.5,
+          // Match the library/playlist top toolbar height (.vt-toolbar
+          // min-height: 44px in virtualTable.css) so the Settings header
+          // lines up with every other header in the app.
+          minHeight: 44,
           borderBottom: (t) => `1px solid ${t.palette.divider}`,
           position: 'sticky',
           top: 0,

--- a/src/renderer/styles/materialTheme.ts
+++ b/src/renderer/styles/materialTheme.ts
@@ -36,8 +36,8 @@ const baseThemeOptions: ThemeOptions = {
       fontWeight: 600,
     },
     h3: {
-      fontSize: '18px',
-      fontWeight: 500,
+      fontSize: '17px',
+      fontWeight: 600,
     },
     body1: {
       fontSize: '14px',


### PR DESCRIPTION
## Summary

Fixes #94 — the Settings panel header didn't match any other header in the app. Fixing that surfaced a few adjacent inconsistencies in the panel, all addressed here as one design pass.

## Changes

Settings panel only — `src/renderer/components/Settings.tsx` plus one theme token in `materialTheme.ts`. Pure design: no logic, IPC, or behavior changes.

**Header**
1. **Height** — the header `Box` used `py: 1.35` (~52px tall). Now `py: 0.5` + `minHeight: 44`, matching `.vt-toolbar`'s `min-height: 44px` (the Library/Playlists toolbar).
2. **Title** — the header title was `h1` (24px); toolbar titles are `h2` (20px). The header title is now `h2`.
3. **Close button hover** — the header's `X` button had no hover feedback (the theme strips MUI's default IconButton hover globally). It now uses the shared `mutedIconButtonSx` — `text.secondary` at rest, `text.primary` on hover — matching every other icon button in the app.

**Type hierarchy**
4. **Section headers** (Music Folder, Import Music, …) move from `h2` to `h3`, so they sit a step below the `h2` panel title.
5. **`h3` token** retuned to 17px / weight 600 — below the 20px `h2` title, above the 12-13px description text. `h3` is used only by these section headers, so the token change is panel-scoped.

**Layout**
6. The first four sections (Music Folder, Import Music, Rescan Library, Backup Library) were grouped in a single `Paper` + `Grid` separated by `Divider`s. Each is now its own `Paper` card — identical to the existing Appearance / Sorting / Column Visibility / Reset cards. The shared wrapper, the dividers, and the now-unused `Grid`/`Divider` imports are removed.

## Verification

- `npm run build` ✓ · `npm run typecheck` ✓ · `npm run lint` ✓
- Playwright Electron driver, 1280×800 — screenshots + DOM measurement:
  - Header height — Library `.vt-toolbar` 44px · Settings header 44px
  - Header title — Library toolbar title and Settings header title both `<h2>`, 20px / 600
  - Close button hover — X color `rgb(170,170,170)` at rest → `rgb(255,255,255)` on hover
  - Type scale (theme tokens) — `h2` 20px → `h3` 17px → `caption` 12px; screenshot confirms the visual hierarchy
  - 8 uniform section cards confirmed by screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
