### PR TITLE
chore: bump version to 2.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "engines": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Patch-level version bump: `2.3.4` → `2.3.5`
- Touches the four version files only: root `package.json` / `package-lock.json` and `release/app/package.json` / `package-lock.json`

## Test plan
- `npm install` re-validates both lockfiles cleanly (no-op aside from version metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)