### PR TITLE
chore: add GitHub issue templates and chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,68 @@
+---
+name: 🐛 Bug Report
+about: Report something in hihat that is broken or behaving incorrectly
+title: 'Bug: '
+labels: bug
+---
+
+<!--
+  Thanks for helping make hihat better!
+
+  TITLE: Keep the "Bug: " prefix above, then add a short, specific summary.
+    Good → "Bug: Backup fails when target folder shares a prefix with the library folder"
+    Weak → "Bug: backup broken"
+
+  LABELS: the "bug" label is added for you. If you can set labels, add a
+    priority (high/med/low priority). If you can't, just note your suggested
+    priority below — the maintainer will apply the rest.
+
+  Fill in the sections below. Delete a section only if it truly doesn't apply;
+  more detail = faster fix.
+-->
+
+## Summary
+
+<!-- One or two sentences: what's wrong? -->
+
+## Steps to Reproduce
+
+<!-- Exact steps, or a Given/When/Then block like the example below. Be specific enough that someone else can trigger it. -->
+
+```
+Given ...
+When ...
+Then ...
+```
+
+## Expected Behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual Behavior
+
+<!-- What actually happened? Paste any error text or notification copy verbatim. -->
+
+## Screenshots / Screen Recording
+
+<!-- Drag images or a short clip here. For visual/UI bugs this is the single most useful thing you can add. -->
+
+## Environment
+
+- **hihat version:** <!-- e.g. 2.3.5 — see the hihat menu, or the release you downloaded -->
+- **macOS version:** <!-- e.g. macOS 14.6 Sonoma -->
+- **Where your music lives:** <!-- internal drive / external drive / network share -->
+
+## Suggested Priority
+
+<!--
+  Your read (maintainer makes the final call):
+  - high — crashes, data loss, or core playback broken for everyone
+  - med  — a real problem with a workaround, or one hitting many users
+  - low  — minor / cosmetic / rare-setup edge case
+-->
+
+## Checklist
+
+- [ ] I searched [existing issues](https://github.com/johnnyshankman/hihat/issues?q=is%3Aissue) and this isn't a duplicate
+- [ ] I'm on the [latest release](https://github.com/johnnyshankman/hihat/releases/latest)
+- [ ] This is **not** a security vulnerability (those use [private reporting](https://github.com/johnnyshankman/hihat/security/advisories/new))

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Controls the "New Issue" chooser.
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/johnnyshankman/hihat/security/advisories/new
+    about: Never report security issues in a public issue. Use private vulnerability reporting (see SECURITY.md).
+  - name: 📖 Read the User Guide first
+    url: https://github.com/johnnyshankman/hihat/blob/main/USER_GUIDE.md
+    about: Wondering how something works? The User Guide covers playback, playlists, search, metadata editing, settings, and shortcuts.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,65 @@
+---
+name: ✨ Feature, Design, or Improvement Request
+about: Suggest a new feature, a visual/design tweak, or an improvement to existing behavior
+title: 'Feature Request: '
+labels: enhancement
+---
+
+<!--
+  Thanks for the idea! A well-specified request is far more likely to get built.
+
+  TITLE: Swap the prefix if another fits better, then add a short summary:
+    "Feature Request: ..."  a new capability
+    "Design Request: ..."   a visual / layout / styling change
+    "Improvement: ..."      better behavior for something that already exists
+
+  LABELS: the "enhancement" label is added for you (it covers features, design,
+    and improvements). Note your suggested priority below; the maintainer labels it.
+
+  THE #1 TIP: requests written as a concrete user story WITH acceptance criteria
+  get picked up fastest — they're clear enough to build without a back-and-forth.
+-->
+
+## Summary
+
+<!-- One or two sentences, in plain terms: what do you want? -->
+
+## User Story
+
+<!-- Frame it from the user's perspective. This is the format hihat issues use: -->
+
+```
+As a user
+When I ...
+Then I expect ...
+(Because ...)
+```
+
+## Why / Motivation
+
+<!-- What problem does this solve? Prior art in other players (Swinsian, Spotify, Tidal, iTunes) is great context. -->
+
+## Proposed Behavior
+
+<!-- How should it work? Cover edge cases you can think of. If it's a setting, what's the default (on/off) and why? -->
+
+## Acceptance Criteria
+
+<!--
+  How do we know it's done? These often map directly to e2e tests. Example:
+  - [ ] Sorting the Artist column sorts by Album Artist by default
+  - [ ] A Settings toggle switches it back to raw Artist
+-->
+
+## Mockups / Screenshots
+
+<!-- Optional: sketches, screenshots, or annotated images of what you have in mind. -->
+
+## Suggested Priority
+
+<!-- high / med / low — your opinion; the maintainer sets the final label. -->
+
+## Checklist
+
+- [ ] I searched [existing issues](https://github.com/johnnyshankman/hihat/issues?q=is%3Aissue) and this isn't a duplicate
+- [ ] This is a single, focused request (split unrelated ideas into separate issues)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,24 @@
+---
+name: ❓ Question / Help
+about: Ask how something works or get help using hihat
+title: 'Question: '
+labels: question
+---
+
+<!--
+  First check the User Guide — it covers most of how hihat works:
+  https://github.com/johnnyshankman/hihat/blob/main/USER_GUIDE.md
+-->
+
+## Your Question
+
+<!-- Ask away. The more context, the better the answer. -->
+
+## What You've Tried
+
+<!-- Optional: what have you already looked at or attempted? -->
+
+## Environment (if relevant)
+
+- **hihat version:**
+- **macOS version:**


### PR DESCRIPTION
## What

Adds a structured **New Issue** experience under `.github/ISSUE_TEMPLATE/`. The repo had no issue templates before; new issues started from a blank box, so format/labels were inconsistent.

Modeled on the conventions already visible across existing hihat issues: the `Type: summary` title prefix, Gherkin `Given/When/Then` blocks, user stories + acceptance criteria, and screenshots for anything visual.

## Files

| File | Purpose |
|---|---|
| `bug_report.md` | Repro steps, expected vs actual, environment, screenshots, suggested priority. Auto-labels `bug`, prefills title `Bug: `. |
| `feature_request.md` | Pushes a concrete **user story + acceptance criteria** (the "ralph ready" quality bar). Covers feature/design/improvement. Auto-labels `enhancement`, prefills `Feature Request: `. |
| `question.md` | Lightweight help path; points at the User Guide first. Auto-labels `question`. |
| `config.yml` | `blank_issues_enabled: false`; routes **security reports** to private vulnerability reporting (per `SECURITY.md`) and links the User Guide. |

## Notes / decisions

- **Markdown templates, not YAML forms** — matches the existing freeform-Gherkin-prose culture.
- Instructions live in `<!-- HTML comments -->`: visible while editing, hidden in the posted issue.
- Templates auto-apply the **base type label only** (non-collaborators can't set labels), so each template asks the author to *state* a suggested priority for the maintainer to label.
- **Discussions are disabled** on the repo, so there's intentionally no Discussions contact link (would 404).
- Three toggles worth a look: blank issues disabled (vs allowed), the question template (keep vs drop), and emoji in template names.

## Verification

YAML front matter for all three templates + `config.yml` validated with a parser (titles, labels, and both contact links parse correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)