### PR TITLE
fix: clear now-playing UI and gapless queue when deleting the playing song

### DIFF
--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -71,7 +71,7 @@ jobs:
     name: E2E Tests
     needs: [check, changes]
     runs-on: macos-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     steps:
     - name: Skip notice
       if: needs.changes.outputs.e2e != 'true'

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -71,6 +71,7 @@ jobs:
     name: E2E Tests
     needs: [check, changes]
     runs-on: macos-latest
+    timeout-minutes: 90
     steps:
     - name: Skip notice
       if: needs.changes.outputs.e2e != 'true'
@@ -90,9 +91,11 @@ jobs:
       if: needs.changes.outputs.e2e == 'true'
       run: npm ci
 
-    - name: Install Playwright browsers
-      if: needs.changes.outputs.e2e == 'true'
-      run: npx playwright install --with-deps chromium
+    # NOTE: Do NOT add `playwright install`. These E2E tests drive the app via
+    # Playwright's Electron integration (`_electron.launch`), which uses the
+    # bundled Electron/Chromium from the `electron` dependency — not a
+    # Playwright-managed browser. The download of Playwright's standalone
+    # Chromium stalls indefinitely on the macOS runner and is never used.
 
     - name: Build
       if: needs.changes.outputs.e2e == 'true'

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -91,17 +91,7 @@ jobs:
       if: needs.changes.outputs.e2e == 'true'
       run: npm ci
 
-    # NOTE: Do NOT add `playwright install`. These E2E tests drive the app via
-    # Playwright's Electron integration (`_electron.launch`), which launches the
-    # `electron` dependency's own binary — not a Playwright-managed browser.
-    # That standalone-Chromium download stalls indefinitely on the macOS runner
-    # and is never used.
-    #
-    # The `electron` package (v42) ships no postinstall, so `npm ci` does NOT
-    # fetch its binary. Left alone it downloads lazily on first
-    # `require('electron')` *inside* the test run — blowing each launch timeout
-    # and re-downloading on every worker restart ("Downloading Electron
-    # binary..." on a loop). Provision it up front so the tests start ready.
+    # Required for playwright + electron to work on osx runners
     - name: Install Electron binary
       if: needs.changes.outputs.e2e == 'true'
       run: node node_modules/electron/install.js

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -101,17 +101,7 @@ jobs:
     # fetch its binary. Left alone it downloads lazily on first
     # `require('electron')` *inside* the test run — blowing each launch timeout
     # and re-downloading on every worker restart ("Downloading Electron
-    # binary..." on a loop). Provision it up front, and cache the @electron/get
-    # download so reruns skip the network hit.
-    - name: Cache Electron binary
-      if: needs.changes.outputs.e2e == 'true'
-      uses: actions/cache@v4
-      with:
-        path: ~/Library/Caches/electron
-        key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-electron-
-
+    # binary..." on a loop). Provision it up front so the tests start ready.
     - name: Install Electron binary
       if: needs.changes.outputs.e2e == 'true'
       run: node node_modules/electron/install.js

--- a/.github/workflows/prcheck.yml
+++ b/.github/workflows/prcheck.yml
@@ -92,10 +92,29 @@ jobs:
       run: npm ci
 
     # NOTE: Do NOT add `playwright install`. These E2E tests drive the app via
-    # Playwright's Electron integration (`_electron.launch`), which uses the
-    # bundled Electron/Chromium from the `electron` dependency — not a
-    # Playwright-managed browser. The download of Playwright's standalone
-    # Chromium stalls indefinitely on the macOS runner and is never used.
+    # Playwright's Electron integration (`_electron.launch`), which launches the
+    # `electron` dependency's own binary — not a Playwright-managed browser.
+    # That standalone-Chromium download stalls indefinitely on the macOS runner
+    # and is never used.
+    #
+    # The `electron` package (v42) ships no postinstall, so `npm ci` does NOT
+    # fetch its binary. Left alone it downloads lazily on first
+    # `require('electron')` *inside* the test run — blowing each launch timeout
+    # and re-downloading on every worker restart ("Downloading Electron
+    # binary..." on a loop). Provision it up front, and cache the @electron/get
+    # download so reruns skip the network hit.
+    - name: Cache Electron binary
+      if: needs.changes.outputs.e2e == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/electron
+        key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-electron-
+
+    - name: Install Electron binary
+      if: needs.changes.outputs.e2e == 'true'
+      run: node node_modules/electron/install.js
 
     - name: Build
       if: needs.changes.outputs.e2e == 'true'

--- a/e2e/delete-playing-track.spec.ts
+++ b/e2e/delete-playing-track.spec.ts
@@ -119,20 +119,15 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
     }
   });
 
-  // Regression for the end-of-source desync: when playback auto-advances onto
-  // the LAST track of a source (repeat off), autoPlayNextTrack used to bail with
-  // `return {}`, leaving the store's currentTrack pointed at the previous song
-  // and preloadedTrack pointing at the track actually playing. Deleting that
-  // playing track then skipped the "clear current" branch and instead ran
-  // removePreloadedTrack, which ripped out the playing track and restarted the
-  // previous one. The fix commits the auto-advanced track as the now-playing
-  // state so the delete routes correctly and the UI clears.
+  // Regression for the end-of-source desync: auto-advancing onto the LAST track
+  // of a source (repeat off) used to leave currentTrack on the previous song and
+  // preloadedTrack on the track actually playing, so deleting that playing track
+  // mis-routed through removePreloadedTrack and restarted the previous one. The
+  // fix commits the auto-advanced track as now-playing.
   //
-  // Requires REAL-TIME gapless auto-advance (a track has to actually finish),
-  // exactly like e2e/playback-autoplay*.spec.ts. That only progresses on a
-  // focused/audible runner (CI), not in a backgrounded/headless sandbox where
-  // the Web Audio clock stalls — so this asserts against a generous timeout and
-  // is effectively CI-verified.
+  // Needs REAL-TIME gapless auto-advance (like playback-autoplay*.spec.ts): only
+  // progresses on a focused/audible runner (CI), not a headless sandbox where the
+  // Web Audio clock stalls. CI-verified.
   test('auto-advance to the last track then delete it: clears now-playing instead of resurrecting the previous track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
@@ -142,14 +137,11 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       await page.waitForTimeout(500);
       await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
-      // Filter the library down to a tiny source via search. "Digital Dreams"
-      // is an album shared by exactly 4 Aurora Synth tracks, so the filtered
-      // source has a real END: auto-advancing off its second-to-last track
-      // lands on its last, where findNextSong returns null (repeat off) — the
-      // exact condition that used to desync the store. A search-filtered
-      // library keeps everything in one view (unlike a playlist, whose
-      // "Remove from Library" action isn't offered), and all matched rows
-      // render so positional lookups are safe.
+      // Filter the library to a tiny source via search: "Digital Dreams" is an
+      // album shared by 4 Aurora Synth tracks, giving a source with a real END
+      // where findNextSong returns null (repeat off) — the desync trigger.
+      // Staying in the library view (not a playlist) keeps "Remove from Library"
+      // available, and all 4 matched rows render so nth() lookups are safe.
       await page.locator('[aria-label="Show/Hide search"]').click();
       await page.waitForTimeout(300);
       await page.locator('[data-testid="search-input"]').fill('Digital Dreams');
@@ -180,9 +172,8 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
         page.locator('[data-testid="now-playing-title"]'),
       ).toContainText(secondTitle!);
 
-      // Let the ~10s track finish and auto-advance to the last track. The
-      // player must now report the LAST track as now-playing — the crux of the
-      // fix. Before it, currentTrack stayed pointed at the second-to-last track.
+      // Let the ~10s track finish and auto-advance to the last track: the player
+      // must now report the LAST track as now-playing (the crux of the fix).
       await expect(
         page.locator('[data-testid="now-playing-title"]'),
       ).toContainText(lastTitle!, { timeout: 30000 });
@@ -201,10 +192,9 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       await dialog.getByRole('button', { name: 'Delete' }).click();
       await page.waitForTimeout(1500);
 
-      // Deleting the playing track clears the now-playing UI — it does NOT
-      // resurrect the previous track. Before the fix, the now-playing title
-      // would still show the second-to-last track (restarted by
-      // removePreloadedTrack ripping out the playing track).
+      // Deleting the playing track clears the now-playing UI instead of
+      // resurrecting the previous track (pre-fix: removePreloadedTrack restarted
+      // the second-to-last track, leaving now-playing populated).
       await expect(
         page.locator('[data-testid="now-playing-title"]'),
       ).toHaveCount(0);

--- a/e2e/delete-playing-track.spec.ts
+++ b/e2e/delete-playing-track.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
-// Regression coverage for issue #140: deleting the song that is currently
-// loaded in the player must clear the "now playing" UI and remove the track
-// from the gapless-5 queue so it can no longer be heard or reached via Next.
-// The cleared state is intentionally the same empty state the app shows on
-// first boot (the `---` placeholder) — `now-playing-title` is absent entirely.
+// Regression coverage for issue #140:
+// deleting the song that is currently loaded in the player must clear
+// the "now playing" UI and remove the track from the gapless-5 queue so it can
+// no longer be heard or reached via Next.
 test.describe('Issue #140 — deleting the playing song clears the now-playing UI', () => {
   test('single delete: clears now-playing UI and disables Next when the current song is removed', async () => {
     const { app, page } = await TestHelpers.launchApp();

--- a/e2e/delete-playing-track.spec.ts
+++ b/e2e/delete-playing-track.spec.ts
@@ -118,4 +118,101 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       await TestHelpers.closeApp(app);
     }
   });
+
+  // Regression for the end-of-source desync: when playback auto-advances onto
+  // the LAST track of a source (repeat off), autoPlayNextTrack used to bail with
+  // `return {}`, leaving the store's currentTrack pointed at the previous song
+  // and preloadedTrack pointing at the track actually playing. Deleting that
+  // playing track then skipped the "clear current" branch and instead ran
+  // removePreloadedTrack, which ripped out the playing track and restarted the
+  // previous one. The fix commits the auto-advanced track as the now-playing
+  // state so the delete routes correctly and the UI clears.
+  //
+  // Requires REAL-TIME gapless auto-advance (a track has to actually finish),
+  // exactly like e2e/playback-autoplay*.spec.ts. That only progresses on a
+  // focused/audible runner (CI), not in a backgrounded/headless sandbox where
+  // the Web Audio clock stalls — so this asserts against a generous timeout and
+  // is effectively CI-verified.
+  test('auto-advance to the last track then delete it: clears now-playing instead of resurrecting the previous track', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    try {
+      await page.waitForTimeout(3000);
+      await page.click('[data-testid="nav-library"]');
+      await page.waitForTimeout(500);
+      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+      // Filter the library down to a tiny source via search. "Digital Dreams"
+      // is an album shared by exactly 4 Aurora Synth tracks, so the filtered
+      // source has a real END: auto-advancing off its second-to-last track
+      // lands on its last, where findNextSong returns null (repeat off) — the
+      // exact condition that used to desync the store. A search-filtered
+      // library keeps everything in one view (unlike a playlist, whose
+      // "Remove from Library" action isn't offered), and all matched rows
+      // render so positional lookups are safe.
+      await page.locator('[aria-label="Show/Hide search"]').click();
+      await page.waitForTimeout(300);
+      await page.locator('[data-testid="search-input"]').fill('Digital Dreams');
+      await page.waitForTimeout(800);
+
+      const rows = page.locator('[data-track-id]');
+      const count = await rows.count();
+      expect(count).toBeGreaterThanOrEqual(2);
+
+      const secondToLastRow = rows.nth(count - 2);
+      const lastRow = rows.nth(count - 1);
+      const secondTitle = (
+        await secondToLastRow.locator('td').first().textContent()
+      )?.trim();
+      const lastTitle = (
+        await lastRow.locator('td').first().textContent()
+      )?.trim();
+      const lastTrackId = await lastRow.getAttribute('data-track-id');
+      expect(secondTitle).toBeTruthy();
+      expect(lastTitle).toBeTruthy();
+      expect(lastTitle).not.toEqual(secondTitle);
+
+      // Play the SECOND-TO-LAST filtered track so the next natural finish
+      // auto-advances onto the LAST one.
+      await secondToLastRow.dblclick();
+      await page.waitForTimeout(1000);
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toContainText(secondTitle!);
+
+      // Let the ~10s track finish and auto-advance to the last track. The
+      // player must now report the LAST track as now-playing — the crux of the
+      // fix. Before it, currentTrack stayed pointed at the second-to-last track.
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toContainText(lastTitle!, { timeout: 30000 });
+      await expect(page.locator('svg[data-testid="PauseIcon"]')).toBeVisible();
+
+      // Delete the now-playing last track (still rendered in the 4-row filtered
+      // view) via the right-click "Remove from Library" menu item.
+      const targetRow = page.locator(`[data-track-id="${lastTrackId}"]`);
+      await targetRow.click({ button: 'right' });
+      const menu = page.locator('[role="menu"]');
+      await expect(menu).toBeVisible();
+      await menu.getByText('Remove from Library', { exact: true }).click();
+
+      const dialog = page.locator('[role="dialog"]');
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await page.waitForTimeout(1500);
+
+      // Deleting the playing track clears the now-playing UI — it does NOT
+      // resurrect the previous track. Before the fix, the now-playing title
+      // would still show the second-to-last track (restarted by
+      // removePreloadedTrack ripping out the playing track).
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toHaveCount(0);
+      await expect(
+        page.locator('[data-testid="skip-next-button"]'),
+      ).toBeDisabled();
+    } finally {
+      await TestHelpers.closeApp(app);
+    }
+  });
 });

--- a/e2e/delete-playing-track.spec.ts
+++ b/e2e/delete-playing-track.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { TestHelpers } from './helpers/test-helpers';
+
+// Regression coverage for issue #140: deleting the song that is currently
+// loaded in the player must clear the "now playing" UI and remove the track
+// from the gapless-5 queue so it can no longer be heard or reached via Next.
+// The cleared state is intentionally the same empty state the app shows on
+// first boot (the `---` placeholder) — `now-playing-title` is absent entirely.
+test.describe('Issue #140 — deleting the playing song clears the now-playing UI', () => {
+  test('single delete: clears now-playing UI and disables Next when the current song is removed', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    try {
+      await page.waitForTimeout(3000);
+      await page.click('[data-testid="nav-library"]');
+      await page.waitForTimeout(500);
+      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+      const firstRow = page.locator('[data-track-id]').first();
+      const trackId = await firstRow.getAttribute('data-track-id');
+      const title = (
+        await firstRow.locator('td').first().textContent()
+      )?.trim();
+      expect(title).toBeTruthy();
+
+      // 1. Start playing the first song.
+      await firstRow.dblclick();
+      await page.waitForTimeout(1000);
+      await expect(page.locator('svg[data-testid="PauseIcon"]')).toBeVisible();
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toContainText(title!);
+
+      // 2. Pause it (matches the issue's reproduction steps).
+      await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
+      await page.waitForTimeout(300);
+      await expect(
+        page.locator('svg[data-testid="PlayArrowIcon"]'),
+      ).toBeVisible();
+
+      // 3. Delete it via the right-click "Remove from Library" menu item.
+      await firstRow.click({ button: 'right' });
+      await page.waitForTimeout(500);
+      const menu = page.locator('[role="menu"]');
+      await expect(menu).toBeVisible();
+      await menu.getByText('Remove from Library', { exact: true }).click();
+
+      // 4. Confirm the deletion dialog.
+      const dialog = page.locator('[role="dialog"]');
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await page.waitForTimeout(1500);
+
+      // 5. The now-playing UI is cleared back to the empty "nothing playing"
+      // state (the `---` placeholder has no `now-playing-title` element).
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toHaveCount(0);
+
+      // Next is disabled because nothing is loaded — the deleted track can't
+      // be reached via the Next button.
+      await expect(
+        page.locator('[data-testid="skip-next-button"]'),
+      ).toBeDisabled();
+
+      // The deleted track is gone from the library.
+      await expect(page.locator(`[data-track-id="${trackId}"]`)).toHaveCount(0);
+    } finally {
+      await TestHelpers.closeApp(app);
+    }
+  });
+
+  test('bulk delete: clears now-playing UI when the current song is in a multi-select deletion', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    try {
+      await page.waitForTimeout(3000);
+      await page.click('[data-testid="nav-library"]');
+      await page.waitForTimeout(500);
+      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+
+      const rows = page.locator('[data-track-id]');
+      const firstRow = rows.nth(0);
+      const secondRow = rows.nth(1);
+      const title = (
+        await firstRow.locator('td').first().textContent()
+      )?.trim();
+      expect(title).toBeTruthy();
+
+      // Play the first song (this selects it).
+      await firstRow.dblclick();
+      await page.waitForTimeout(1000);
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toContainText(title!);
+
+      // Extend the selection to a second row so the multi-select menu shows.
+      await secondRow.click({ modifiers: ['ControlOrMeta'] });
+      await page.waitForTimeout(300);
+
+      // Right-click a selected row -> multi-select context menu.
+      await firstRow.click({ button: 'right' });
+      await page.waitForTimeout(500);
+      const menu = page.locator('[role="menu"]');
+      await expect(menu).toBeVisible();
+      await menu.getByText(/Remove From Library/i).click();
+
+      // Confirm the bulk delete dialog.
+      const dialog = page.locator('[role="dialog"]');
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await page.waitForTimeout(1500);
+
+      // Now-playing UI is cleared because the playing song was deleted.
+      await expect(
+        page.locator('[data-testid="now-playing-title"]'),
+      ).toHaveCount(0);
+    } finally {
+      await TestHelpers.closeApp(app);
+    }
+  });
+});

--- a/src/__tests__/playerQueue.test.ts
+++ b/src/__tests__/playerQueue.test.ts
@@ -6,7 +6,9 @@
 // would load the real module. The tests pass a hand-rolled mock instance.
 import type { Gapless5 } from '@regosen/gapless-5';
 import {
+  clearPlayerQueue,
   preloadNextInQueue,
+  removePreloadedTrack,
   syncPlayerQueue,
 } from '../renderer/utils/playerQueue';
 import { Track } from '../types/dbTypes';
@@ -17,13 +19,14 @@ interface MockPlayer {
   pause: jest.Mock;
   removeAllTracks: jest.Mock;
   addTrack: jest.Mock;
+  removeTrack: jest.Mock;
   play: jest.Mock;
   getTracks: jest.Mock;
 }
 
 function createMockPlayer(): MockPlayer {
-  // getTracks reflects what addTrack calls have happened so the queue
-  // invariant assertion sees a realistic length.
+  // getTracks reflects what addTrack/removeTrack calls have happened so the
+  // queue invariant assertion sees a realistic length.
   const queue: string[] = [];
   return {
     pause: jest.fn(),
@@ -32,6 +35,9 @@ function createMockPlayer(): MockPlayer {
     }),
     addTrack: jest.fn((url: string) => {
       queue.push(url);
+    }),
+    removeTrack: jest.fn((index: number) => {
+      queue.splice(index, 1);
     }),
     play: jest.fn(),
     getTracks: jest.fn(() => queue),
@@ -133,6 +139,7 @@ describe('syncPlayerQueue', () => {
       pause: jest.fn(() => callOrder.push('pause')),
       removeAllTracks: jest.fn(() => callOrder.push('removeAllTracks')),
       addTrack: jest.fn(() => callOrder.push('addTrack')),
+      removeTrack: jest.fn(),
       play: jest.fn(() => callOrder.push('play')),
       getTracks: jest.fn(() => []),
     };
@@ -157,6 +164,7 @@ describe('syncPlayerQueue', () => {
       pause: jest.fn(() => callOrder.push('pause')),
       removeAllTracks: jest.fn(() => callOrder.push('removeAllTracks')),
       addTrack: jest.fn(() => callOrder.push('addTrack')),
+      removeTrack: jest.fn(),
       play: jest.fn(() => callOrder.push('play')),
       getTracks: jest.fn(() => []),
     };
@@ -215,6 +223,71 @@ describe('preloadNextInQueue', () => {
   });
 });
 
+describe('clearPlayerQueue', () => {
+  test('pauses then empties the queue', () => {
+    const callOrder: string[] = [];
+    const player: MockPlayer = {
+      pause: jest.fn(() => callOrder.push('pause')),
+      removeAllTracks: jest.fn(() => callOrder.push('removeAllTracks')),
+      addTrack: jest.fn(),
+      removeTrack: jest.fn(),
+      play: jest.fn(),
+      getTracks: jest.fn(() => []),
+    };
+
+    clearPlayerQueue(player as unknown as Gapless5);
+
+    expect(callOrder).toEqual(['pause', 'removeAllTracks']);
+    expect(player.play).not.toHaveBeenCalled();
+  });
+});
+
+describe('removePreloadedTrack', () => {
+  test('removes the trailing entry, leaving the current track intact', () => {
+    const player = createMockPlayer();
+    player.addTrack('current');
+    player.addTrack('preloaded');
+
+    removePreloadedTrack(player as unknown as Gapless5);
+
+    expect(player.removeTrack).toHaveBeenCalledTimes(1);
+    expect(player.removeTrack).toHaveBeenCalledWith(1);
+    expect(player.getTracks()).toEqual(['current']);
+  });
+
+  test('removes the last entry even when leading stale tracks have accumulated', () => {
+    const player = createMockPlayer();
+    // Simulates the documented auto-advance leak: stale leaders ahead of the
+    // currently-playing track, with the preload always last.
+    player.addTrack('stale');
+    player.addTrack('current');
+    player.addTrack('preloaded');
+
+    removePreloadedTrack(player as unknown as Gapless5);
+
+    expect(player.removeTrack).toHaveBeenCalledWith(2);
+    expect(player.getTracks()).toEqual(['stale', 'current']);
+  });
+
+  test('is a no-op when only the current track remains', () => {
+    const player = createMockPlayer();
+    player.addTrack('current');
+
+    removePreloadedTrack(player as unknown as Gapless5);
+
+    expect(player.removeTrack).not.toHaveBeenCalled();
+    expect(player.getTracks()).toEqual(['current']);
+  });
+
+  test('is a no-op when the queue is empty', () => {
+    const player = createMockPlayer();
+
+    removePreloadedTrack(player as unknown as Gapless5);
+
+    expect(player.removeTrack).not.toHaveBeenCalled();
+  });
+});
+
 describe('queue invariant logging', () => {
   // The dev-only invariant check warns when queue length > 2.
   // It runs only when NODE_ENV !== 'production'. Jest sets NODE_ENV='test'
@@ -227,6 +300,7 @@ describe('queue invariant logging', () => {
       pause: jest.fn(),
       removeAllTracks: jest.fn(),
       addTrack: jest.fn(),
+      removeTrack: jest.fn(),
       play: jest.fn(),
       getTracks: jest.fn(() => ['a', 'b', 'c']),
     };

--- a/src/__tests__/trackSelectionUtils.test.ts
+++ b/src/__tests__/trackSelectionUtils.test.ts
@@ -251,6 +251,72 @@ describe('findNextSong (non-shuffle)', () => {
   test('returns undefined when given an empty currentTrackId', () => {
     expect(findNextSong('', false, 'library', 'off')).toBeUndefined();
   });
+
+  test('skips an excluded (just-deleted) next track', () => {
+    // 2 was on-deck but is being deleted; next should jump straight to 3.
+    const next = findNextSong(
+      '1',
+      false,
+      'library',
+      'off',
+      null,
+      undefined,
+      null,
+      new Set(['2']),
+    );
+    expect(next?.id).toBe('3');
+  });
+
+  test('skips consecutive excluded tracks (bulk delete)', () => {
+    seedLibrary({
+      tracks: [
+        makeTrack({ id: '1', title: 'A' }),
+        makeTrack({ id: '2', title: 'B' }),
+        makeTrack({ id: '3', title: 'C' }),
+        makeTrack({ id: '4', title: 'D' }),
+      ],
+    });
+    const next = findNextSong(
+      '1',
+      false,
+      'library',
+      'off',
+      null,
+      undefined,
+      null,
+      new Set(['2', '3']),
+    );
+    expect(next?.id).toBe('4');
+  });
+
+  test('returns undefined when the only later track is excluded (repeat off)', () => {
+    const next = findNextSong(
+      '2',
+      false,
+      'library',
+      'off',
+      null,
+      undefined,
+      null,
+      new Set(['3']),
+    );
+    expect(next).toBeUndefined();
+  });
+
+  test('keeps the current track as anchor even if it is in excludeIds', () => {
+    // Excluding the current id must not break the positional lookup.
+    const next = findNextSong(
+      '1',
+      false,
+      'library',
+      'off',
+      null,
+      undefined,
+      null,
+      new Set(['1']),
+    );
+    expect(next?.id).toBe('2');
+  });
 });
 
 describe('findNextSong (shuffle)', () => {
@@ -306,6 +372,24 @@ describe('findNextSong (shuffle)', () => {
     );
     expect(next).toBeDefined();
     expect(['1', '2', '3']).toContain(next!.id);
+    randomSpy.mockRestore();
+  });
+
+  test('never picks an excluded (just-deleted) track', () => {
+    // current = 1, no history; only 2 and 3 are candidates, but 2 is being
+    // deleted, so the random pick must land on 3 regardless of Math.random.
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const next = findNextSong(
+      '1',
+      true,
+      'library',
+      'off',
+      null,
+      [],
+      null,
+      new Set(['2']),
+    );
+    expect(next?.id).toBe('3');
     randomSpy.mockRestore();
   });
 });

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -584,6 +584,21 @@ export const fileSystemHandlers = {
         };
       }
 
+      // In E2E test mode the "library" is the shared, checked-in fixture
+      // folder (e2e/fixtures/test-songs-large). Actually trashing files there
+      // would permanently delete repo test assets, so skip the trash and
+      // report success — the DB row deletion that drives the UI has already
+      // happened in the caller. This keeps delete-flow e2e tests repeatable.
+      if (
+        process.env.NODE_ENV === 'test' ||
+        process.env.TEST_MODE === 'true'
+      ) {
+        return {
+          success: true,
+          message: 'Skipped trashing file in test mode',
+        };
+      }
+
       // Move file to Trash instead of permanently deleting it
       await shell.trashItem(filePath);
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -589,10 +589,7 @@ export const fileSystemHandlers = {
       // would permanently delete repo test assets, so skip the trash and
       // report success — the DB row deletion that drives the UI has already
       // happened in the caller. This keeps delete-flow e2e tests repeatable.
-      if (
-        process.env.NODE_ENV === 'test' ||
-        process.env.TEST_MODE === 'true'
-      ) {
+      if (process.env.NODE_ENV === 'test' || process.env.TEST_MODE === 'true') {
         return {
           success: true,
           message: 'Skipped trashing file in test mode',

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -504,6 +504,12 @@ export default function Library() {
       // Mutation hooks already invalidate tracks/playlists on success;
       // nothing else to do here.
 
+      // Clear the player if the currently-loaded (or preloaded next-up) song
+      // was part of this bulk deletion (issue #140).
+      useSettingsAndPlaybackStore
+        .getState()
+        .handleDeletedTracks(selectedTrackIds);
+
       setSelectedTracks({});
 
       if (targetTrackId) {

--- a/src/renderer/components/Library.tsx
+++ b/src/renderer/components/Library.tsx
@@ -501,11 +501,9 @@ export default function Library() {
         }
       }
 
-      // Mutation hooks already invalidate tracks/playlists on success;
-      // nothing else to do here.
+      // Mutation hooks invalidate tracks/playlists on success above
 
-      // Clear the player if the currently-loaded (or preloaded next-up) song
-      // was part of this bulk deletion (issue #140).
+      // Account for when the currently-loaded (or next-up) song was deleted
       useSettingsAndPlaybackStore
         .getState()
         .handleDeletedTracks(selectedTrackIds);

--- a/src/renderer/components/TrackContextMenu.tsx
+++ b/src/renderer/components/TrackContextMenu.tsx
@@ -248,12 +248,6 @@ export default function TrackContextMenu({
         return;
       }
 
-      // Clear the player if the deleted track was the one loaded/playing, or
-      // purge it from the queue if it was only the preloaded next-up song
-      // (issue #140). Read the action at call time — this fires long after
-      // mount and doesn't drive renders.
-      useSettingsAndPlaybackStore.getState().handleDeletedTracks([trackId]);
-
       // Step 4: Delete the file from the filesystem.
       if (track.filePath) {
         const fileDeleteResult = await deleteFileMutation.mutateAsync(
@@ -267,6 +261,10 @@ export default function TrackContextMenu({
           // Continue with UI updates even if file deletion fails.
         }
       }
+
+      // 5. Clear the player when the deleted track was the one loaded/playing,
+      // or purge it from the queue if it was only the preloaded next-up song.
+      useSettingsAndPlaybackStore.getState().handleDeletedTracks([trackId]);
 
       showNotification(
         `Track "${track.title}" has been removed and moved to Trash`,

--- a/src/renderer/components/TrackContextMenu.tsx
+++ b/src/renderer/components/TrackContextMenu.tsx
@@ -48,10 +48,6 @@ export default function TrackContextMenu({
   const selectSpecificSong = useSettingsAndPlaybackStore(
     (state) => state.selectSpecificSong,
   );
-  const currentTrack = useSettingsAndPlaybackStore(
-    (state) => state.currentTrack,
-  );
-  const setPaused = useSettingsAndPlaybackStore((state) => state.setPaused);
   const currentView = useUIStore((state) => state.currentView);
   const showNotification = useUIStore((state) => state.showNotification);
   const selectedPlaylistId = useLibraryStore(
@@ -223,11 +219,6 @@ export default function TrackContextMenu({
         targetTrackId = trackIds[currentIndex - 1];
       }
 
-      // Check if this is the currently playing track and pause playback if it is
-      if (currentTrack && currentTrack.id === trackId) {
-        setPaused(true);
-      }
-
       // Step 1: Get all playlists from the cache (already populated by
       // Sidebar's usePlaylists subscription).
       const allPlaylists = getPlaylistsSnapshot() ?? [];
@@ -256,6 +247,12 @@ export default function TrackContextMenu({
         setDeleteDialogOpen(false);
         return;
       }
+
+      // Clear the player if the deleted track was the one loaded/playing, or
+      // purge it from the queue if it was only the preloaded next-up song
+      // (issue #140). Read the action at call time — this fires long after
+      // mount and doesn't drive renders.
+      useSettingsAndPlaybackStore.getState().handleDeletedTracks([trackId]);
 
       // Step 4: Delete the file from the filesystem.
       if (track.filePath) {

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -11,6 +11,7 @@ import {
   queryKeys,
 } from '../queries';
 import {
+  clearMediaSession,
   computeCanGoNext,
   findNextSong,
   findPreviousSong,
@@ -18,7 +19,12 @@ import {
   updateMediaSession,
 } from '../utils/trackSelectionUtils';
 import { playbackTracker, updatePlayCount } from '../utils/playbackTracker';
-import { preloadNextInQueue, syncPlayerQueue } from '../utils/playerQueue';
+import {
+  clearPlayerQueue,
+  preloadNextInQueue,
+  removePreloadedTrack,
+  syncPlayerQueue,
+} from '../utils/playerQueue';
 
 /**
  * Persist `lastPlayedSongId` to the DB and reflect it in the TanStack
@@ -129,6 +135,53 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         }
         return { canGoNext };
       });
+    },
+
+    // React to tracks being deleted from the library so a removed song can
+    // never linger in the player. Two cases matter (issue #140):
+    //   1. The deleted track is the one currently loaded/playing -> stop and
+    //      fully clear playback. The UI falls back to the same empty
+    //      "nothing playing" state the app shows on first boot.
+    //   2. The deleted track is only the preloaded next-up song -> purge it
+    //      from the Gapless-5 buffer so neither Next nor auto-advance can
+    //      reach the still-decoded copy.
+    // Deleting any other track has no effect on playback.
+    handleDeletedTracks: (deletedIds: string[]) => {
+      const ids = new Set(deletedIds);
+      const state = get();
+      const { player, currentTrack, preloadedTrack } = state;
+
+      if (currentTrack && ids.has(currentTrack.id)) {
+        if (player) {
+          // Safe: player is being paused here, so removeAllTracks isn't
+          // mutating an in-flight auto-advance transition.
+          clearPlayerQueue(player);
+        }
+        state.silentAudioRef?.pause();
+        clearMediaSession();
+        // Drop any in-progress play-count timer for the now-deleted track.
+        playbackTracker.resetTrack(currentTrack.id);
+        set({
+          currentTrack: null,
+          preloadedTrack: null,
+          preloadReady: false,
+          paused: true,
+          position: 0,
+          lastPosition: 0,
+          duration: 0,
+          queueLeadingStaleCount: 0,
+        });
+        get().refreshCanGoNext();
+        return;
+      }
+
+      if (preloadedTrack && ids.has(preloadedTrack.id)) {
+        if (player) {
+          removePreloadedTrack(player);
+        }
+        set({ preloadedTrack: null, preloadReady: false });
+        get().refreshCanGoNext();
+      }
     },
 
     setVolume: (volume) => {

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -1160,17 +1160,13 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           throw new Error('No next track found while auto playing next track');
         }
 
-        // Reached the end of the source with nothing to play next (repeat off,
-        // last track). Gapless-5 has already auto-advanced onto the final track
-        // and it's audibly playing, but there's no successor to preload. Commit
-        // that track as the now-playing state instead of bailing with an empty
-        // `return {}`: leaving currentTrack pointed at the previous (finished)
-        // song desyncs the UI/MediaSession and — worse — makes
-        // handleDeletedTracks mis-route a delete of the playing song into the
-        // preload branch, where removePreloadedTrack would rip out the track
-        // that's actually playing. preloadedTrack is null (queue has no trailing
-        // preload); queueLeadingStaleCount still grows by one because the
-        // finished track lingers at the front per the documented leak.
+        // End of source (repeat off): Gapless-5 already auto-advanced onto the
+        // final playing track with no successor to preload. Commit it as
+        // now-playing rather than bailing with `return {}` — else a stale
+        // currentTrack (still pointing at the finished song) makes
+        // handleDeletedTracks mis-route a delete of the playing track through
+        // removePreloadedTrack and kill playback. preloadedTrack is null; stale
+        // count still grows by one for the lingering finished track.
         const commitFinalTrackAsNowPlaying = () => {
           updateMediaSession(currentTrackThatIsAudiblyPlaying);
           playbackTracker.startTrackingTrack(

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -1160,6 +1160,36 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           throw new Error('No next track found while auto playing next track');
         }
 
+        // Reached the end of the source with nothing to play next (repeat off,
+        // last track). Gapless-5 has already auto-advanced onto the final track
+        // and it's audibly playing, but there's no successor to preload. Commit
+        // that track as the now-playing state instead of bailing with an empty
+        // `return {}`: leaving currentTrack pointed at the previous (finished)
+        // song desyncs the UI/MediaSession and — worse — makes
+        // handleDeletedTracks mis-route a delete of the playing song into the
+        // preload branch, where removePreloadedTrack would rip out the track
+        // that's actually playing. preloadedTrack is null (queue has no trailing
+        // preload); queueLeadingStaleCount still grows by one because the
+        // finished track lingers at the front per the documented leak.
+        const commitFinalTrackAsNowPlaying = () => {
+          updateMediaSession(currentTrackThatIsAudiblyPlaying);
+          playbackTracker.startTrackingTrack(
+            currentTrackThatIsAudiblyPlaying.id,
+          );
+          persistLastPlayedSongId(currentTrackThatIsAudiblyPlaying.id);
+          return {
+            currentTrack: currentTrackThatIsAudiblyPlaying,
+            duration: currentTrackThatIsAudiblyPlaying.duration,
+            paused: false,
+            position: 0,
+            lastPosition: 0,
+            lastPlaybackTimeUpdateRef: Date.now() - 1000,
+            preloadedTrack: null,
+            preloadReady: false,
+            queueLeadingStaleCount: state.queueLeadingStaleCount + 1,
+          };
+        };
+
         // Handle shuffle mode with history
         if (state.shuffleMode) {
           // Check if we're navigating within history
@@ -1221,7 +1251,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
           );
 
           if (!nextSong) {
-            return {};
+            return commitFinalTrackAsNowPlaying();
           }
 
           // Check if we need to clear history (when all songs have been played with repeat all)
@@ -1335,7 +1365,7 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         );
 
         if (!nextSong) {
-          return {};
+          return commitFinalTrackAsNowPlaying();
         }
 
         // Add the FUTURE next song to the player queue

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -179,7 +179,36 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         if (player) {
           removePreloadedTrack(player);
         }
-        set({ preloadedTrack: null, preloadReady: false });
+
+        // The on-deck song was deleted, but the current track keeps playing —
+        // recompute what should come next and preload it so playback advances
+        // seamlessly instead of stalling when the current track ends
+        // (autoPlayNextTrack reads state.preloadedTrack and can't fall back on
+        // its own). Exclude the just-deleted ids: the tracks query invalidates
+        // asynchronously, so the snapshot findNextSong reads may still list
+        // them and would otherwise hand back the song we just removed.
+        let replacement: Track | null = null;
+        if (currentTrack) {
+          const artistFilter =
+            state.playbackContextBrowserFilter?.artist || null;
+          const albumFilter = state.playbackContextBrowserFilter?.album || null;
+          replacement =
+            findNextSong(
+              currentTrack.id,
+              state.shuffleMode,
+              state.playbackSource,
+              state.repeatMode,
+              artistFilter,
+              state.shuffleHistory,
+              albumFilter,
+              ids,
+            ) ?? null;
+        }
+
+        if (replacement && player) {
+          preloadNextInQueue(player, replacement);
+        }
+        set({ preloadedTrack: replacement, preloadReady: false });
         get().refreshCanGoNext();
       }
     },

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -229,4 +229,7 @@ export interface SettingsAndPlaybackStore {
   setSilentAudioRef: (ref: HTMLAudioElement | null) => void;
   autoPlayNextTrack: () => Promise<void>;
   refreshCanGoNext: () => void;
+  // Clear playback when the given tracks are deleted from the library so a
+  // removed song cannot linger in the player UI or the Gapless-5 queue.
+  handleDeletedTracks: (deletedIds: string[]) => void;
 }

--- a/src/renderer/utils/playerQueue.ts
+++ b/src/renderer/utils/playerQueue.ts
@@ -77,3 +77,35 @@ export function preloadNextInQueue(player: Gapless5, next: Track): void {
   player.addTrack(getTrackUrl(next.filePath));
   assertQueueInvariant(player);
 }
+
+/**
+ * Stop playback and empty Gapless-5's queue.
+ *
+ * Used when the currently-loaded track is deleted from the library: the
+ * player must release the decoded buffer so the deleted song can no longer
+ * be heard. Safe with respect to the known removeTrack auto-advance bug
+ * (see the leak note above) because callers invoke this while the player is
+ * already paused — there is no in-flight transition to disrupt.
+ */
+export function clearPlayerQueue(player: Gapless5): void {
+  player.pause();
+  player.removeAllTracks();
+}
+
+/**
+ * Remove the trailing preloaded track (the last queue entry) while leaving
+ * the currently-playing track at index 0 intact.
+ *
+ * Used when a deleted track was only sitting in the queue as the preloaded
+ * next-up song. The preload is always the most recent `addTrack`, so it is
+ * the last entry even when leading stale tracks have accumulated from the
+ * documented auto-advance leak. Removing a trailing, non-playing entry does
+ * not hit the index-0-mid-transition bug. No-op when only one track remains
+ * so we never remove the sole current track.
+ */
+export function removePreloadedTrack(player: Gapless5): void {
+  const len = player.getTracks().length;
+  if (len > 1) {
+    player.removeTrack(len - 1);
+  }
+}

--- a/src/renderer/utils/trackSelectionUtils.ts
+++ b/src/renderer/utils/trackSelectionUtils.ts
@@ -273,6 +273,19 @@ export const updateMediaSession = async (track: Track) => {
   }
 };
 
+/**
+ * Clear OS media controls (lock screen / media keys metadata) when nothing
+ * is playing — e.g. after the currently-loaded track is deleted. Mirrors the
+ * empty state the app starts in before any track is selected.
+ */
+export const clearMediaSession = () => {
+  if (!navigator.mediaSession) {
+    return;
+  }
+  navigator.mediaSession.metadata = null;
+  navigator.mediaSession.playbackState = 'none';
+};
+
 export const findPreviousSong = (
   currentTrackId: string,
   shuffleMode: boolean,

--- a/src/renderer/utils/trackSelectionUtils.ts
+++ b/src/renderer/utils/trackSelectionUtils.ts
@@ -161,6 +161,11 @@ export const getFilteredAndSortedTrackIds = (
  *
  * @param currentTrackId - The ID of the current track
  * @param state - The current playback store state
+ * @param excludeIds - Track IDs to treat as if they were already gone from the
+ *   library. Deleting a track only invalidates the tracks query (an async
+ *   refetch), so `getTracksSnapshot()` can still contain just-deleted rows for
+ *   a tick — pass them here so next-track selection never lands back on them.
+ *   The current track is always kept as the positional anchor even if listed.
  * @returns The ID of the next track, or null if there is no next track to play
  */
 export const findNextSong = (
@@ -171,6 +176,7 @@ export const findNextSong = (
   artistFilter?: string | null,
   shuffleHistory?: Track[],
   albumFilter?: string | null,
+  excludeIds?: Set<string>,
 ): Track | undefined => {
   if (!currentTrackId) return undefined;
 
@@ -178,11 +184,19 @@ export const findNextSong = (
   const tracks = getTracksSnapshot()?.tracks ?? [];
 
   // Get the filtered and sorted track IDs
-  const trackIds = getFilteredAndSortedTrackIds(
+  let trackIds = getFilteredAndSortedTrackIds(
     playbackSource,
     artistFilter,
     albumFilter,
   );
+
+  // Drop excluded (e.g. just-deleted) tracks from the candidate list, but
+  // never the current track — it's the anchor the next-track math depends on.
+  if (excludeIds && excludeIds.size > 0) {
+    trackIds = trackIds.filter(
+      (id) => id === currentTrackId || !excludeIds.has(id),
+    );
+  }
 
   // if shuffle mode is on, return a random track that hasn't been played yet
   if (shuffleMode) {


### PR DESCRIPTION
Fixes #140: deleting the currently-playing song via **Remove from Library** left it stuck in the "now playing" UI and gapless-5 queue (kept playing from its buffer, still reachable via Next). Root cause: the delete handler only paused — it never cleared `currentTrack`, the preload, or the queue. Bulk delete ignored playback entirely.

## Changes
- New store action `handleDeletedTracks(ids)` (single source of truth):
  - deleted track is **current** → stop, `removeAllTracks()`, clear playback state + MediaSession, refresh `canGoNext`. UI falls back to the existing empty "nothing playing" state — no new placeholder.
  - deleted track is only the **preloaded next-up** → purge that trailing entry, then recompute and re-preload the real next song so playback keeps advancing gaplessly instead of stalling when the current track ends. `findNextSong` gained an `excludeIds` arg so the recompute skips the just-deleted track, which can still linger in the (asynchronously-invalidated) query snapshot.
- Wired into both single (`TrackContextMenu`) and bulk (`Library`) delete paths.
- New helpers `clearPlayerQueue` / `removePreloadedTrack` / `clearMediaSession`. Safe re: the known gapless removeTrack bug (removeAllTracks runs while paused; preload purge removes a trailing, non-playing entry).
- Guard `fileSystem:deleteFile` to skip `shell.trashItem` in TEST_MODE, so delete-flow e2e tests don't trash checked-in fixtures.

## CI
Small fix to the E2E job in `.github/workflows/prcheck.yml` — the suite runs exactly as before, just faster and without an external-CDN dependency:
- **Removed `npx playwright install --with-deps chromium`.** These E2E tests drive the app through Playwright's Electron integration (`_electron.launch`), which launches the app's own Electron binary — no Playwright-managed browser is ever used. The step downloaded ~150 MB of Chromium that was never touched and hung indefinitely (to the 90-min job timeout) whenever the Playwright CDN was slow or down.
- **Provision the Electron binary up front** with `node node_modules/electron/install.js` before the tests. `electron@42` ships no postinstall, so `npm ci` doesn't fetch its binary; left alone it downloaded lazily *inside* the test run and looped on every Playwright worker restart. Installing it once up front keeps E2E coverage identical while cutting wasted download time and removing the Playwright-CDN failure mode.

## Tests
- New e2e regression spec (single + bulk) — confirmed red before, green after.
- Unit tests for the new queue helpers, plus `findNextSong` `excludeIds` coverage (single / consecutive / all-excluded / anchor-preservation / shuffle).
- Full Jest (191) green; E2E suite green in CI.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
