### PR TITLE
chore: bump version to 2.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "name": "hihat",
   "main": "./.erb/dll/main.bundle.dev.js",
   "engines": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hihat",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hihat",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hihat",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "The minimalist offline music library player for macOS",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Patch-level version bump `2.3.5` → `2.3.6`.

Updates all four version-tracked files per the project's version-bump convention:

- `package.json`
- `package-lock.json`
- `release/app/package.json`
- `release/app/package-lock.json`

The `release/app/` pair is what `electron-builder` reads when producing the packaged app, so both pairs must move together to avoid artifacts named with the old version.

## Test plan

- [x] `npm install` re-validates both lockfiles (no-op aside from lockfile check)
- [x] All four files report `2.3.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)