### PR TITLE
feat: audio output device selection in the Player

### DIFF
--- a/e2e/audio-output-device.spec.ts
+++ b/e2e/audio-output-device.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from '@playwright/test';
+import { TestHelpers } from './helpers/test-helpers';
+
+/**
+ * E2E coverage for the audio output device picker (the Speaker button in the
+ * Player bar). Playwright cannot assert that audio physically rerouted to a
+ * different device — that is left to manual, human-in-the-loop verification —
+ * so these specs exercise everything up to that boundary: the button opens
+ * the picker, the active device is marked, and selecting a device runs the
+ * full chain (setSinkId -> AudioContext route -> settings cache -> settings
+ * IPC persist -> success toast -> popover close -> marked on reopen).
+ */
+
+interface RenderedOption {
+  testid: string;
+  deviceId: string; // '' represents the System Default row
+  selected: boolean;
+  label: string;
+}
+
+async function readOptions(page: Page): Promise<RenderedOption[]> {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll('[data-testid^="output-device-option-"]'),
+    ).map((el) => {
+      const testid = el.getAttribute('data-testid') || '';
+      const suffix = testid.replace('output-device-option-', '');
+      return {
+        testid,
+        deviceId: suffix === 'default' ? '' : suffix,
+        selected: el.getAttribute('data-selected') === 'true',
+        label: (el.textContent || '').trim(),
+      };
+    }),
+  );
+}
+
+async function getPersistedDeviceId(page: Page): Promise<string | null> {
+  return page.evaluate(() =>
+    (window as Window & { electron?: any }).electron.settings
+      .get()
+      .then(
+        (s: { selectedAudioOutputDeviceId: string | null }) =>
+          s.selectedAudioOutputDeviceId ?? null,
+      ),
+  );
+}
+
+async function openPicker(page: Page): Promise<void> {
+  await page.click('[data-testid="output-device-toggle"]');
+  await page.waitForSelector('[data-testid="output-device-list"]', {
+    timeout: 5000,
+  });
+}
+
+test.describe('Audio output device picker', () => {
+  test('opens from the player bar with the active device marked', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    const toggle = page.locator('[data-testid="output-device-toggle"]');
+    await expect(toggle).toBeVisible();
+
+    await openPicker(page);
+
+    // buildDeviceList always guarantees a System Default row (deviceId ''),
+    // and on a fresh DB the persisted device is null, so System Default is
+    // the active row.
+    const systemDefault = page.locator(
+      '[data-testid="output-device-option-default"]',
+    );
+    await expect(systemDefault).toBeVisible();
+    expect(await systemDefault.getAttribute('data-selected')).toBe('true');
+
+    // Exactly one row is marked active, and it is the System Default.
+    const options = await readOptions(page);
+    expect(options.length).toBeGreaterThan(0);
+    const active = options.filter((o) => o.selected);
+    expect(active).toHaveLength(1);
+    expect(active[0].deviceId).toBe('');
+
+    await TestHelpers.takeScreenshot(page, 'audio-output-popover-open');
+    await TestHelpers.closeApp(app);
+  });
+
+  test('selecting a device persists it, toasts, closes the picker, and marks it on reopen', async () => {
+    const { app, page } = await TestHelpers.launchApp();
+
+    await openPicker(page);
+
+    const options = await readOptions(page);
+    expect(options.length).toBeGreaterThan(0);
+
+    // Prefer switching to a real, non-default device so the test exercises an
+    // actual output change; fall back to the System Default row when the test
+    // machine exposes only one output (e.g. a headless CI box). Either target
+    // runs the full click -> setSinkId -> persist -> toast -> close chain;
+    // setSinkId('') is permission-free and always resolves.
+    const target = options.find((o) => o.deviceId !== '') ?? options[0];
+
+    await page.click(`[data-testid="${target.testid}"]`);
+
+    // Popover closes only on a successful switch (handleSelect keeps it open
+    // and shows an error toast on rejection), so this doubles as proof the
+    // engine confirmed the route.
+    await expect(
+      page.locator('[data-testid="output-device-list"]'),
+    ).toBeHidden();
+
+    // Success toast surfaces in the notification panel (which auto-expands).
+    const panel = page.locator('[data-testid="notification-panel"]');
+    await expect(
+      panel
+        .locator('[data-testid="notification-item"]')
+        .filter({ hasText: 'Output set to' }),
+    ).toBeVisible();
+
+    // Persisted through settings IPC. '' (System Default) is stored as null.
+    const expectedPersisted = target.deviceId === '' ? null : target.deviceId;
+    await expect
+      .poll(() => getPersistedDeviceId(page), { timeout: 5000 })
+      .toBe(expectedPersisted);
+
+    // Reopen: the chosen device is now the marked/active row.
+    await openPicker(page);
+    const reopened = page.locator(`[data-testid="${target.testid}"]`);
+    await expect(reopened).toBeVisible();
+    expect(await reopened.getAttribute('data-selected')).toBe('true');
+
+    await TestHelpers.takeScreenshot(page, 'audio-output-selected');
+    await TestHelpers.closeApp(app);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@regosen/gapless-5": "github:johnnyshankman/Gapless-5",
+        "@regosen/gapless-5": "github:johnnyshankman/Gapless-5#johnny/add-sink-id-output-device",
         "@tanstack/react-query": "^5.100.8",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.23",
@@ -4814,8 +4814,8 @@
       }
     },
     "node_modules/@regosen/gapless-5": {
-      "version": "1.5.6",
-      "resolved": "git+ssh://git@github.com/johnnyshankman/Gapless-5.git#b7479f651862fb72460a8933cb125cca029c9277",
+      "version": "1.6.2",
+      "resolved": "git+ssh://git@github.com/johnnyshankman/Gapless-5.git#73f76a2090c50a009f034083e6c1c5a1aea804ce",
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
-    "@regosen/gapless-5": "github:johnnyshankman/Gapless-5",
+    "@regosen/gapless-5": "github:johnnyshankman/Gapless-5#johnny/add-sink-id-output-device",
     "@tanstack/react-query": "^5.100.8",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.23",

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -223,6 +223,11 @@ function runMigrations(): void {
       'sortArtistByAlbumArtist',
       'INTEGER NOT NULL DEFAULT 1',
     );
+
+    // Migration 11: Add selectedAudioOutputDeviceId column to settings table.
+    // Stored as TEXT (the sinkId from navigator.mediaDevices.enumerateDevices);
+    // null/'' means route to the system default output device.
+    addColumnIfNotExists('settings', 'selectedAudioOutputDeviceId', 'TEXT');
   } catch (error) {
     console.error('Error running database migrations:', error);
   }
@@ -371,13 +376,14 @@ function initDefaultSettings(): void {
           librarySorting: null,
           columnOrder: null,
           sortArtistByAlbumArtist: true,
+          selectedAudioOutputDeviceId: null,
         };
 
         // Insert default settings
         db.prepare(
           `
-          INSERT INTO settings (id, libraryPath, theme, columns, lastPlayedSongId, volume, columnWidths, librarySorting, columnOrder, sortArtistByAlbumArtist)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          INSERT INTO settings (id, libraryPath, theme, columns, lastPlayedSongId, volume, columnWidths, librarySorting, columnOrder, sortArtistByAlbumArtist, selectedAudioOutputDeviceId)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
         ).run(
           defaultSettings.id,
@@ -390,6 +396,7 @@ function initDefaultSettings(): void {
           defaultSettings.librarySorting,
           defaultSettings.columnOrder,
           defaultSettings.sortArtistByAlbumArtist ? 1 : 0,
+          defaultSettings.selectedAudioOutputDeviceId,
         );
       }
     } catch (error) {
@@ -425,13 +432,14 @@ function initDefaultSettings(): void {
         librarySorting: null,
         columnOrder: null,
         sortArtistByAlbumArtist: true,
+        selectedAudioOutputDeviceId: null,
       };
 
       // Insert default settings
       db.prepare(
         `
-        INSERT INTO settings (id, libraryPath, theme, columns, lastPlayedSongId, volume, columnWidths, librarySorting, columnOrder, sortArtistByAlbumArtist)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO settings (id, libraryPath, theme, columns, lastPlayedSongId, volume, columnWidths, librarySorting, columnOrder, sortArtistByAlbumArtist, selectedAudioOutputDeviceId)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       ).run(
         defaultSettings.id,
@@ -444,6 +452,7 @@ function initDefaultSettings(): void {
         defaultSettings.librarySorting,
         defaultSettings.columnOrder,
         defaultSettings.sortArtistByAlbumArtist ? 1 : 0,
+        defaultSettings.selectedAudioOutputDeviceId,
       );
     }
   } catch (outerError) {
@@ -1458,6 +1467,7 @@ interface RawSettingsRow {
   librarySorting: string | null;
   columnOrder: string | null;
   sortArtistByAlbumArtist: number | null;
+  selectedAudioOutputDeviceId: string | null;
 }
 
 /**
@@ -1510,6 +1520,8 @@ function parseSettingsRow(raw: RawSettingsRow): Settings {
       raw.sortArtistByAlbumArtist == null
         ? true
         : Boolean(raw.sortArtistByAlbumArtist),
+    // `null`/'' both mean "use the system default output device".
+    selectedAudioOutputDeviceId: raw.selectedAudioOutputDeviceId || null,
   };
 }
 
@@ -1542,6 +1554,7 @@ export function getSettings(): Settings {
         librarySorting: null,
         columnOrder: null,
         sortArtistByAlbumArtist: true,
+        selectedAudioOutputDeviceId: null,
       };
     }
 
@@ -1586,6 +1599,7 @@ export function getSettings(): Settings {
       librarySorting: null,
       columnOrder: null,
       sortArtistByAlbumArtist: true,
+      selectedAudioOutputDeviceId: null,
     };
   }
 }
@@ -1612,7 +1626,8 @@ export function updateSettings(settings: Settings): boolean {
           columnWidths = ?,
           librarySorting = ?,
           columnOrder = ?,
-          sortArtistByAlbumArtist = ?
+          sortArtistByAlbumArtist = ?,
+          selectedAudioOutputDeviceId = ?
         WHERE id = ?
       `,
         )
@@ -1628,6 +1643,7 @@ export function updateSettings(settings: Settings): boolean {
             : null,
           settings.columnOrder ? JSON.stringify(settings.columnOrder) : null,
           settings.sortArtistByAlbumArtist ? 1 : 0,
+          settings.selectedAudioOutputDeviceId || null,
           settings.id,
         );
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -94,6 +94,23 @@ function ThemedAppContent() {
     if (player) player.setVolume(settingsVolume);
   }, [settingsVolume]);
 
+  // Reconcile the audio output device once useSettings settles, mirroring
+  // the volume reconcile above. initPlayer already constructs the engine
+  // with the persisted sinkId when the settings snapshot is warm; this
+  // effect covers the cold-start race and re-applies on change. If the
+  // persisted device is gone (unplugged since last launch), setSinkId
+  // rejects — fall back to the system default and clear the stored id so
+  // we don't keep retrying a dead device on future launches.
+  const settingsSinkId = settings?.selectedAudioOutputDeviceId;
+  useEffect(() => {
+    const { player, setSinkId } = useSettingsAndPlaybackStore.getState();
+    if (!player || !player.canSetSinkId) return;
+    const desired = settingsSinkId ?? '';
+    player.setSinkId(desired).catch(() => {
+      if (desired) setSinkId('');
+    });
+  }, [settingsSinkId]);
+
   // Cold-boot reseed: the persisted librarySorting needs to land in
   // libraryStore.libraryViewState so trackSelectionUtils sees it for
   // next/prev track math. Write-only effect.

--- a/src/renderer/components/AudioOutputPopover.tsx
+++ b/src/renderer/components/AudioOutputPopover.tsx
@@ -127,10 +127,19 @@ export default function AudioOutputPopover({
       open={open}
       transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
     >
-      <Box sx={{ minWidth: 240, maxWidth: 360, py: 1 }}>
+      <Box sx={{ minWidth: 240, maxWidth: 360, pb: 1 }}>
         <Typography
-          sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
-          variant="overline"
+          sx={{
+            px: 1,
+            py: 1,
+            fontSize: '11px',
+            fontWeight: 600,
+            letterSpacing: '0.5px',
+            textTransform: 'uppercase',
+            color: (t) => t.palette.text.secondary,
+            opacity: 0.7,
+            userSelect: 'none',
+          }}
         >
           Audio Output
         </Typography>
@@ -149,8 +158,12 @@ export default function AudioOutputPopover({
                   data-testid={`output-device-option-${device.deviceId || 'default'}`}
                   onClick={() => handleSelect(device)}
                   selected={selected}
+                  sx={{
+                    py: 0,
+                    px: 0.5,
+                  }}
                 >
-                  <ListItemIcon sx={{ minWidth: 36 }}>
+                  <ListItemIcon sx={{ minWidth: 26 }}>
                     {selected ? <CheckIcon fontSize="small" /> : null}
                   </ListItemIcon>
                   <ListItemText primary={device.label} />

--- a/src/renderer/components/AudioOutputPopover.tsx
+++ b/src/renderer/components/AudioOutputPopover.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Popover,
+  Typography,
+} from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import { useSettingsAndPlaybackStore, useUIStore } from '../stores';
+import { useSettings } from '../queries';
+
+interface OutputDevice {
+  deviceId: string;
+  label: string;
+}
+
+/**
+ * Normalize the raw MediaDeviceInfo list into the rows we render.
+ *
+ * The OS-reported `'default'` (and the rare empty-string) output device is
+ * collapsed onto our `''` sentinel so the "System Default" row always maps
+ * to the value we persist (`selectedAudioOutputDeviceId === null/''`).
+ * Real devices keep their `deviceId`; empty labels (Chromium hides them
+ * until media permission is granted) degrade to a generic name rather than
+ * us prompting for microphone access. A System Default row is guaranteed
+ * even when the platform reports no `'default'` device.
+ */
+function buildDeviceList(infos: MediaDeviceInfo[]): OutputDevice[] {
+  const seen = new Set<string>();
+  const devices: OutputDevice[] = [];
+
+  infos
+    .filter((info) => info.kind === 'audiooutput')
+    .forEach((info) => {
+      const isSystemDefault =
+        info.deviceId === 'default' || info.deviceId === '';
+      const deviceId = isSystemDefault ? '' : info.deviceId;
+      if (seen.has(deviceId)) return;
+      seen.add(deviceId);
+      devices.push({
+        deviceId,
+        label: isSystemDefault
+          ? 'System Default'
+          : info.label || 'Output device',
+      });
+    });
+
+  if (!seen.has('')) {
+    devices.unshift({ deviceId: '', label: 'System Default' });
+  }
+
+  return devices;
+}
+
+interface AudioOutputPopoverProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  open: boolean;
+}
+
+/**
+ * Popover launched from the Player's Speaker button. Lists the available
+ * audio output devices, marks the active one, and routes playback to a
+ * new device on click via the store's `setSinkId` action (which persists
+ * the choice). Anchored above the player bar, mirroring the MiniPlayer
+ * volume popover.
+ */
+export default function AudioOutputPopover({
+  anchorEl,
+  onClose,
+  open,
+}: AudioOutputPopoverProps) {
+  const [devices, setDevices] = useState<OutputDevice[]>([]);
+
+  const setSinkId = useSettingsAndPlaybackStore((state) => state.setSinkId);
+  const canSetSinkId = useSettingsAndPlaybackStore(
+    (state) => state.player?.canSetSinkId ?? true,
+  );
+  const showNotification = useUIStore((state) => state.showNotification);
+  const currentDeviceId = useSettings().data?.selectedAudioOutputDeviceId ?? '';
+
+  const refreshDevices = useCallback(() => {
+    navigator.mediaDevices
+      .enumerateDevices()
+      .then((infos) => setDevices(buildDeviceList(infos)))
+      .catch((error: unknown) => {
+        console.error('Failed to enumerate audio output devices:', error);
+      });
+  }, []);
+
+  // Enumerate on mount and whenever the OS device set changes (a headset
+  // is plugged in, a monitor's speakers appear, etc.).
+  useEffect(() => {
+    refreshDevices();
+    navigator.mediaDevices.addEventListener('devicechange', refreshDevices);
+    return () =>
+      navigator.mediaDevices.removeEventListener(
+        'devicechange',
+        refreshDevices,
+      );
+  }, [refreshDevices]);
+
+  // Refresh each time the popover opens so it reflects current hardware
+  // without waiting for a devicechange event.
+  useEffect(() => {
+    if (open) refreshDevices();
+  }, [open, refreshDevices]);
+
+  const handleSelect = async (device: OutputDevice) => {
+    try {
+      await setSinkId(device.deviceId);
+      showNotification(`Output set to ${device.label}`, 'success');
+      onClose();
+    } catch {
+      showNotification('Could not switch audio output device', 'error');
+    }
+  };
+
+  return (
+    <Popover
+      anchorEl={anchorEl}
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      onClose={onClose}
+      open={open}
+      transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    >
+      <Box sx={{ minWidth: 240, maxWidth: 360, py: 1 }}>
+        <Typography
+          sx={{ px: 2, py: 0.5, color: 'text.secondary' }}
+          variant="overline"
+        >
+          Audio Output
+        </Typography>
+        {!canSetSinkId ? (
+          <Typography sx={{ px: 2, py: 1 }} variant="body2">
+            Output device selection isn&apos;t supported here.
+          </Typography>
+        ) : (
+          <List data-testid="output-device-list" dense disablePadding>
+            {devices.map((device) => {
+              const selected = device.deviceId === currentDeviceId;
+              return (
+                <ListItemButton
+                  key={device.deviceId || 'default'}
+                  data-selected={selected ? 'true' : 'false'}
+                  data-testid={`output-device-option-${device.deviceId || 'default'}`}
+                  onClick={() => handleSelect(device)}
+                  selected={selected}
+                >
+                  <ListItemIcon sx={{ minWidth: 36 }}>
+                    {selected ? <CheckIcon fontSize="small" /> : null}
+                  </ListItemIcon>
+                  <ListItemText primary={device.label} />
+                </ListItemButton>
+              );
+            })}
+          </List>
+        )}
+      </Box>
+    </Popover>
+  );
+}

--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -877,7 +877,7 @@ export default function Player() {
               data-testid="output-device-toggle"
               onClick={(e) => setOutputAnchorEl(e.currentTarget)}
               size="small"
-              sx={{ ...mutedIconButtonSx, flexShrink: 0 }}
+              sx={{ ...mutedIconButtonSx, flexShrink: 0, left: 2 }}
             >
               <Speaker sx={{ fontSize: 20 }} />
             </IconButton>

--- a/src/renderer/components/Player.tsx
+++ b/src/renderer/components/Player.tsx
@@ -12,6 +12,7 @@ import {
 import {
   PlayArrow,
   Pause,
+  Speaker,
   VolumeUp,
   VolumeDown,
   VolumeOff,
@@ -27,6 +28,7 @@ import {
 } from '../stores';
 import { useSettings } from '../queries';
 import PositionDisplay from './PositionDisplay';
+import AudioOutputPopover from './AudioOutputPopover';
 import {
   mutedIconButtonSx,
   toggleIconButtonSx,
@@ -142,6 +144,10 @@ export default function Player() {
   const [albumArt, setAlbumArt] = useState<string | null>(null);
   const [isTitleScrolling, setIsTitleScrolling] = useState(false);
   const [isArtistAlbumScrolling, setIsArtistAlbumScrolling] = useState(false);
+  // Anchor for the audio-output-device picker popover (Speaker button).
+  const [outputAnchorEl, setOutputAnchorEl] = useState<HTMLElement | null>(
+    null,
+  );
   // Refs for title and artist+album text elements
   const titleRef = useRef<HTMLDivElement>(null);
   const titleRef2 = useRef<HTMLDivElement>(null);
@@ -855,7 +861,7 @@ export default function Player() {
           <PositionDisplay disabled={!currentTrack} />
         </Box>
 
-        {/* Right cell: Inline volume control (slider → mute icon) */}
+        {/* Right cell: output-device button → volume slider → mute icon */}
         <Box
           sx={{
             display: 'flex',
@@ -865,6 +871,17 @@ export default function Player() {
             minWidth: 0,
           }}
         >
+          <Tooltip arrow placement="bottom" title="Audio output device">
+            <IconButton
+              aria-label="Audio output device"
+              data-testid="output-device-toggle"
+              onClick={(e) => setOutputAnchorEl(e.currentTarget)}
+              size="small"
+              sx={{ ...mutedIconButtonSx, flexShrink: 0 }}
+            >
+              <Speaker sx={{ fontSize: 20 }} />
+            </IconButton>
+          </Tooltip>
           <Slider
             aria-label="Volume"
             data-testid="volume-slider"
@@ -903,6 +920,11 @@ export default function Player() {
             </IconButton>
           </Tooltip>
         </Box>
+        <AudioOutputPopover
+          anchorEl={outputAnchorEl}
+          onClose={() => setOutputAnchorEl(null)}
+          open={Boolean(outputAnchorEl)}
+        />
       </Box>
     </Paper>
   );

--- a/src/renderer/stores/settingsAndPlaybackStore.ts
+++ b/src/renderer/stores/settingsAndPlaybackStore.ts
@@ -230,6 +230,31 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
       });
     },
 
+    setSinkId: async (deviceId) => {
+      // Route audio to the chosen output device. Unlike setVolume,
+      // Gapless-5's setSinkId is async (it applies to the shared
+      // AudioContext), so we only mirror the settings cache + persist
+      // once the engine confirms the switch. A rejection (device
+      // unplugged/unavailable) propagates to the caller and leaves the
+      // persisted value untouched. Deliberately toast-free — the startup
+      // reconcile in App.tsx also drives this action and must fail
+      // silently.
+      const { player } = get();
+      if (!player) return;
+      await player.setSinkId(deviceId);
+      queryClient.setQueryData<Settings>(queryKeys.settings, (old) =>
+        old ? { ...old, selectedAudioOutputDeviceId: deviceId || null } : old,
+      );
+      window.electron.settings
+        .update({ selectedAudioOutputDeviceId: deviceId || null })
+        .catch((error: unknown) => {
+          console.error(
+            'Error persisting selected audio output device:',
+            error,
+          );
+        });
+    },
+
     selectSpecificSong: (trackId, playbackSource, playlistId = null) => {
       set((state) => {
         if (!state.player) {
@@ -902,12 +927,20 @@ const useSettingsAndPlaybackStore = create<SettingsAndPlaybackStore>(
         // not zero), fall back to 1.0; the reconcile-volume effect in
         // App.tsx applies the persisted value once useSettings settles.
         const initialVolume = getSettingsSnapshot()?.volume ?? 1.0;
+        // Persisted output device (sinkId). '' routes to the system
+        // default. Passing it here lets Gapless-5 apply the device as
+        // soon as the AudioContext exists; the reconcile effect in
+        // App.tsx re-applies it (and cleans up stale devices) once
+        // useSettings settles, mirroring the volume reconcile.
+        const initialSinkId =
+          getSettingsSnapshot()?.selectedAudioOutputDeviceId ?? '';
         const player = new Gapless5({
           useHTML5Audio: false,
           crossfade: 25, // 25ms crossfade between tracks
           exclusive: true, // Only one track can play at a time
           loadLimit: 3, // Load up to 3 tracks at a time
           volume: initialVolume,
+          sinkId: initialSinkId,
         });
 
         // E2E diagnostic hook: lets Playwright specs observe what

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -213,6 +213,13 @@ export interface SettingsAndPlaybackStore {
   // or getSettingsSnapshot().
   setVolume: (volume: number) => void;
 
+  // Output-device (sinkId) action: routes audio to the given device
+  // ('' = system default), then mirrors the settings cache + persists
+  // via IPC once the engine confirms the switch. Async because
+  // Gapless-5's setSinkId applies to the shared AudioContext; the
+  // returned promise rejects if routing fails (device unavailable).
+  setSinkId: (deviceId: string) => Promise<void>;
+
   // Playback actions
   initPlayer: () => void;
   selectSpecificSong: (

--- a/src/types/dbTypes.ts
+++ b/src/types/dbTypes.ts
@@ -84,6 +84,7 @@ export interface Settings {
   librarySorting: Array<{ id: string; desc: boolean }> | null; // Persisted sorting preference for the library view
   columnOrder: string[] | null; // Persisted column order for the track table
   sortArtistByAlbumArtist: boolean; // When true, Artist column sorts by albumArtist (with fallback to artist)
+  selectedAudioOutputDeviceId: string | null; // Persisted audio output device (sinkId); null/'' = system default
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a **Speaker button** to the left of the volume slider in the Player bar. Clicking it opens a popover listing the system's audio output devices, marks the active one, and routes playback to a new device on click. The selection is **persisted and re-applied on launch**, falling back to the system default if the device is gone. The **MiniPlayer is intentionally unchanged**.

## How it works

- **Fork dependency**: repoints `@regosen/gapless-5` to the branch that adds `setSinkId` (`johnny/add-sink-id-output-device`, [PR #2](https://github.com/johnnyshankman/Gapless-5/pull/2)), exposing `player.setSinkId()`, `player.canSetSinkId`, and the `sinkId` constructor option. Routing uses `AudioContext.setSinkId` (Chromium/Electron), which the app's WebAudio path (`useHTML5Audio: false`) requires.
- **Persistence**: new `selectedAudioOutputDeviceId` setting threaded through the `Settings` type + migration 11 + the hand-listed spots in `db/index.ts`. Rides the existing `settings:update` IPC — no new channel. `null`/`''` = system default.
- **Store**: `settingsAndPlaybackStore.setSinkId` mirrors `setVolume` (route → cache → IPC persist); `initPlayer` seeds the persisted `sinkId`; an `App.tsx` reconcile effect re-applies on startup and **clears a stale device** on failure.
- **UI**: new `AudioOutputPopover` — `enumerateDevices()` + `devicechange` refresh, the OS `'default'` device normalized onto the `''` sentinel, empty labels degrade gracefully (no mic prompt), active row marked with a check. Button styled like the existing mute button, no responsive sizing (per the player-bar convention).

## Testing

- `typecheck`, `lint`, `build` — clean.
- **New committed e2e** (`e2e/audio-output-device.spec.ts`): button opens the picker with the active device marked; selecting a device persists it, toasts, closes the picker, and marks it on reopen. Prefers a real non-default device when available, falls back to the permission-free System Default on single-device/CI environments.
- Ran player-related regression specs (`playback`, `playing-row-alignment`, `app-launch`) — all pass.
- Screenshots confirm the popover (✓ System Default / AirPods / MacBook Pro Speakers) and a real switch with an "Output set to AirPods" success toast.

### Manual verification (hardware-dependent, not automatable)

Real audio actually rerouting, `devicechange` hot-plug, restart re-applying the device, and stale-device fallback with a device physically removed.

## Note

The dependency points at the **PR branch**. Once [Gapless-5 PR #2](https://github.com/johnnyshankman/Gapless-5/pull/2) merges to the fork's default branch, repoint `@regosen/gapless-5` back to `github:johnnyshankman/Gapless-5` (drop the `#branch` suffix) in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)