### PR TITLE
test(e2e): replace arbitrary sleeps with state-based waits

### DIFF
--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -28,9 +28,6 @@ test.describe('Application Launch', () => {
   test('should display default main UI components', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
     // 1. Check for sidebar/drawer
     const drawer = await page.locator('.MuiDrawer-root').isVisible();
     expect(drawer).toBe(true);
@@ -65,7 +62,6 @@ test.describe('Application Launch', () => {
 
     // 8. Check for MaterialReactTable with tracks from fixture data
     // MaterialReactTable uses virtualization, so we check for track rows by data-track-id
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
     const trackRows = await page.locator('[data-track-id]').count();
     expect(trackRows).toBeGreaterThan(0);
 

--- a/e2e/artist-browser.spec.ts
+++ b/e2e/artist-browser.spec.ts
@@ -1,25 +1,40 @@
-/* eslint-disable no-console, no-await-in-loop */
-import { test, expect } from '@playwright/test';
+/* eslint-disable no-await-in-loop */
+import { test, expect, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+const BROWSER_TOGGLE = '[data-testid="browser-toggle"]';
+const BROWSER_PANEL = '[data-testid="browser-panel"]';
+
+/** Open the browser panel and wait for it to render. */
+async function openBrowser(page: Page) {
+  await page.locator(BROWSER_TOGGLE).click();
+  await expect(page.locator(BROWSER_PANEL)).toBeVisible();
+}
+
+/**
+ * Select an artist in the browser's left column and wait for the track table to
+ * settle on that artist's rows — the filtered table is the signal, so there's
+ * nothing to guess at.
+ */
+async function selectArtist(page: Page, artist: string, trackCount: number) {
+  const item = page.locator(`[data-artist="${artist}"]`);
+  await expect(item).toBeVisible();
+  await item.click();
+  await expect(item).toHaveClass(/browser-item-selected/);
+  await TestHelpers.waitForTrackCount(page, trackCount);
+}
 
 test.describe('Browser Panel Filtering', () => {
   test('browser toggle shows and hides the panel', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Browser panel should NOT be visible by default
-    await expect(
-      page.locator('[data-testid="browser-panel"]'),
-    ).not.toBeVisible();
+    await expect(page.locator(BROWSER_PANEL)).toBeHidden();
 
     // Click browser toggle button in Player bar
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
 
     // Browser panel should now be visible with two columns
-    await expect(page.locator('[data-testid="browser-panel"]')).toBeVisible();
     await expect(
       page.locator('[data-testid="browser-artist-column"]'),
     ).toBeVisible();
@@ -28,12 +43,8 @@ test.describe('Browser Panel Filtering', () => {
     ).toBeVisible();
 
     // Click toggle again to hide
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    await expect(
-      page.locator('[data-testid="browser-panel"]'),
-    ).not.toBeVisible();
+    await page.locator(BROWSER_TOGGLE).click();
+    await expect(page.locator(BROWSER_PANEL)).toBeHidden();
 
     await TestHelpers.closeApp(app);
   });
@@ -41,30 +52,18 @@ test.describe('Browser Panel Filtering', () => {
   test('selecting an album artist filters albums and tracks', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await openBrowser(page);
 
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    // Click "Aurora Synth" in left column
-    const auroraItem = page.locator('[data-artist="Aurora Synth"]');
-    await expect(auroraItem).toBeVisible({ timeout: 5000 });
-    await auroraItem.click();
-    await page.waitForTimeout(1000);
-
-    // Track table should show only Aurora Synth tracks (10 tracks)
-    const trackRows = page.locator('[data-track-id]');
-    const filteredCount = await trackRows.count();
-    expect(filteredCount).toBe(10);
+    // Click "Aurora Synth" in left column — the table should show only that
+    // artist's 10 tracks
+    await selectArtist(page, 'Aurora Synth', 10);
 
     // Verify each visible row contains "Aurora Synth" in the artist column
+    const trackRows = page.locator('[data-track-id]');
+    const filteredCount = await trackRows.count();
     for (let i = 0; i < filteredCount; i += 1) {
-      const row = trackRows.nth(i);
-      const artistCell = row.locator('td').nth(1);
-      const artistText = await artistCell.textContent();
-      expect(artistText?.trim()).toBe('Aurora Synth');
+      const artistCell = trackRows.nth(i).locator('td').nth(1);
+      expect((await artistCell.textContent())?.trim()).toBe('Aurora Synth');
     }
 
     await TestHelpers.closeApp(app);
@@ -73,33 +72,23 @@ test.describe('Browser Panel Filtering', () => {
   test('closing browser clears all filters', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Get initial track count
     const initialCount = await page.locator('[data-track-id]').count();
     expect(initialCount).toBeGreaterThan(0);
 
     // Open browser, select an artist
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
+    await selectArtist(page, 'Aurora Synth', 10);
+    expect(await page.locator('[data-track-id]').count()).toBeLessThan(
+      initialCount,
+    );
 
-    const auroraItem = page.locator('[data-artist="Aurora Synth"]');
-    await expect(auroraItem).toBeVisible({ timeout: 5000 });
-    await auroraItem.click();
-    await page.waitForTimeout(1000);
-
-    // Should be filtered (fewer tracks)
-    const filteredCount = await page.locator('[data-track-id]').count();
-    expect(filteredCount).toBeLessThan(initialCount);
-
-    // Close browser
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(1000);
-
-    // Track table should show all tracks again
-    const clearedCount = await page.locator('[data-track-id]').count();
-    expect(clearedCount).toBeGreaterThanOrEqual(initialCount);
+    // Close browser — track table should show all tracks again
+    await page.locator(BROWSER_TOGGLE).click();
+    await expect(page.locator(BROWSER_PANEL)).toBeHidden();
+    await expect
+      .poll(() => page.locator('[data-track-id]').count())
+      .toBeGreaterThanOrEqual(initialCount);
 
     await TestHelpers.closeApp(app);
   });
@@ -107,50 +96,39 @@ test.describe('Browser Panel Filtering', () => {
   test('artist filter context preserved through skip', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
 
     // Select "Aurora Synth" to filter
-    const auroraItem = page.locator('[data-artist="Aurora Synth"]');
-    await expect(auroraItem).toBeVisible({ timeout: 5000 });
-    await auroraItem.click();
-    await page.waitForTimeout(1000);
+    await selectArtist(page, 'Aurora Synth', 10);
 
     // Double-click first visible track to start playback
-    const firstFilteredTrack = page.locator('[data-track-id]').first();
-    await firstFilteredTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
+    const playingTitle = await TestHelpers.nowPlayingTitle(page);
 
-    // Verify it's playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    // Now change the artist browser to a different artist (10 tracks)
+    await selectArtist(page, 'The Jazz Collective', 10);
 
-    // Now change the artist browser to a different artist
-    const jazzItem = page.locator('[data-artist="The Jazz Collective"]');
-    await expect(jazzItem).toBeVisible({ timeout: 5000 });
-    await jazzItem.click();
-    await page.waitForTimeout(1000);
-
-    // Click skip-next
+    // Click skip-next — playback should follow the queue it started from
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForNowPlayingChange(page, playingTitle);
 
-    // Verify the now-playing track is from Aurora Synth
-    const playerArtistText = await page.evaluate(() => {
-      const body2Elements = Array.from(
-        document.querySelectorAll('.MuiTypography-body2'),
-      );
-      const match = body2Elements.find(
-        (el) => el.textContent && el.textContent.includes('\u2022'),
-      );
-      return match?.textContent || '';
-    });
-
-    expect(playerArtistText).toContain('Aurora Synth');
+    // Verify the now-playing track is still from Aurora Synth
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const body2Elements = Array.from(
+            document.querySelectorAll('.MuiTypography-body2'),
+          );
+          const match = body2Elements.find(
+            (el) => el.textContent && el.textContent.includes('•'),
+          );
+          return match?.textContent || '';
+        }),
+      )
+      .toContain('Aurora Synth');
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/audio-formats.spec.ts
+++ b/e2e/audio-formats.spec.ts
@@ -8,15 +8,14 @@ async function searchForTrack(
   page: import('@playwright/test').Page,
   title: string,
 ) {
-  await page.waitForTimeout(3000);
   await page.click('[data-testid="nav-library"]');
-  await page.waitForTimeout(500);
-  await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+  await TestHelpers.waitForTracks(page);
 
   await page.locator('[aria-label="Show/Hide search"]').click();
-  await page.waitForTimeout(300);
   await page.locator('[data-testid="search-input"]').fill(title);
-  await page.waitForTimeout(500);
+  // These titles are unique in the fixture, so a single matching row is the
+  // signal that the debounced filter has landed.
+  await TestHelpers.waitForTrackCount(page, 1);
 
   return page.locator('[data-track-id]').first();
 }
@@ -77,11 +76,7 @@ test.describe('Audio Format Support', () => {
       const { app, page } = await TestHelpers.launchApp();
       const track = await searchForTrack(page, 'Test FLAC Song');
 
-      await track.dblclick();
-      await page.waitForTimeout(1000);
-
-      const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-      await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+      await TestHelpers.startPlayback(page, track);
 
       await TestHelpers.closeApp(app);
     });
@@ -90,11 +85,7 @@ test.describe('Audio Format Support', () => {
       const { app, page } = await TestHelpers.launchApp();
       const track = await searchForTrack(page, 'Test WAV Song');
 
-      await track.dblclick();
-      await page.waitForTimeout(1000);
-
-      const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-      await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+      await TestHelpers.startPlayback(page, track);
 
       await TestHelpers.closeApp(app);
     });
@@ -103,11 +94,7 @@ test.describe('Audio Format Support', () => {
       const { app, page } = await TestHelpers.launchApp();
       const track = await searchForTrack(page, 'Test OGG Song');
 
-      await track.dblclick();
-      await page.waitForTimeout(1000);
-
-      const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-      await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+      await TestHelpers.startPlayback(page, track);
 
       await TestHelpers.closeApp(app);
     });
@@ -118,11 +105,7 @@ test.describe('Audio Format Support', () => {
       const { app, page } = await TestHelpers.launchApp();
       const track = await searchForTrack(page, 'Test AAC Song');
 
-      await track.dblclick();
-      await page.waitForTimeout(1000);
-
-      const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-      await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+      await TestHelpers.startPlayback(page, track);
 
       await TestHelpers.closeApp(app);
     });
@@ -135,12 +118,12 @@ test.describe('Audio Format Support', () => {
 
       // Right-click and open Edit Metadata
       await track.click({ button: 'right' });
-      await page.waitForTimeout(500);
-      await page
-        .locator('[role="menu"]')
-        .getByText('Edit Metadata', { exact: true })
-        .click();
-      await page.waitForTimeout(500);
+      const menu = page.locator('[role="menu"]');
+      await expect(menu).toBeVisible();
+      await menu.getByText('Edit Metadata', { exact: true }).click();
+      await expect(
+        page.locator('[data-testid="edit-metadata-dialog"]'),
+      ).toBeVisible();
 
       // Change the title
       const titleInput = page.locator('[data-testid="metadata-title-input"]');
@@ -148,7 +131,9 @@ test.describe('Audio Format Support', () => {
 
       // Save
       await page.click('[data-testid="save-metadata-button"]');
-      await page.waitForTimeout(1500);
+      await expect(
+        page.locator('[data-testid="edit-metadata-dialog"]'),
+      ).toBeHidden();
 
       // Verify success notification
       const notificationPanel = page.locator(
@@ -166,7 +151,7 @@ test.describe('Audio Format Support', () => {
       await page
         .locator('[data-testid="search-input"]')
         .fill('Edited FLAC Title');
-      await page.waitForTimeout(500);
+      await TestHelpers.waitForTrackCount(page, 1);
       await expect(page.locator('[data-track-id]').first()).toContainText(
         'Edited FLAC Title',
       );
@@ -180,12 +165,12 @@ test.describe('Audio Format Support', () => {
 
       // Right-click and open Edit Metadata
       await track.click({ button: 'right' });
-      await page.waitForTimeout(500);
-      await page
-        .locator('[role="menu"]')
-        .getByText('Edit Metadata', { exact: true })
-        .click();
-      await page.waitForTimeout(500);
+      const menu = page.locator('[role="menu"]');
+      await expect(menu).toBeVisible();
+      await menu.getByText('Edit Metadata', { exact: true }).click();
+      await expect(
+        page.locator('[data-testid="edit-metadata-dialog"]'),
+      ).toBeVisible();
 
       // Change the title
       const titleInput = page.locator('[data-testid="metadata-title-input"]');
@@ -193,7 +178,9 @@ test.describe('Audio Format Support', () => {
 
       // Save
       await page.click('[data-testid="save-metadata-button"]');
-      await page.waitForTimeout(1500);
+      await expect(
+        page.locator('[data-testid="edit-metadata-dialog"]'),
+      ).toBeHidden();
 
       // Verify success notification
       const notificationPanel = page.locator(
@@ -211,7 +198,7 @@ test.describe('Audio Format Support', () => {
       await page
         .locator('[data-testid="search-input"]')
         .fill('Edited OGG Title');
-      await page.waitForTimeout(500);
+      await TestHelpers.waitForTrackCount(page, 1);
       await expect(page.locator('[data-track-id]').first()).toContainText(
         'Edited OGG Title',
       );

--- a/e2e/basic-functionality.spec.ts
+++ b/e2e/basic-functionality.spec.ts
@@ -5,47 +5,37 @@ test.describe('Basic Functionality', () => {
   test('should navigate between views', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
     // 1. Start in Library view - verify we see tracks
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
     const initialTrackCount = await page.locator('[data-track-id]').count();
     expect(initialTrackCount).toBeGreaterThan(0);
 
     // 2. Navigate to a Playlist view by clicking a playlist name
     // Click on "Test Playlist" from fixture data
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(1000);
 
     // Verify we're in playlist view (tracks should still be visible but filtered)
-    const playlistTracks = await page.locator('[data-track-id]').count();
-    expect(playlistTracks).toBeGreaterThan(0);
+    // The fixture playlist holds 3 of the 200 library tracks, so waiting for the
+    // count to drop is a precise "the view swapped" signal.
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // 3. Navigate to Settings by clicking the settings cog icon
     // Sidebar stays open now, so no need to re-open it
     await page.getByRole('button', { name: 'Settings' }).click();
-    await page.waitForTimeout(1000);
 
     // Verify we're in Settings view - check for settings heading
-    const settingsHeading = await page.getByRole('heading', {
-      name: 'Settings',
-    });
+    const settingsHeading = page.getByRole('heading', { name: 'Settings' });
     await expect(settingsHeading).toBeVisible();
 
     // Close the Settings drawer before navigating
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(500);
+    await expect(settingsHeading).toBeHidden();
 
     // 4. Navigate back to Library view by clicking "All" button
     // Sidebar is still open, so click directly
     await page.locator('[data-view="library"]').click();
-    await page.waitForTimeout(1000);
 
     // Verify we're back in Library view with all tracks
-    const finalTrackCount = await page.locator('[data-track-id]').count();
-    expect(finalTrackCount).toBeGreaterThan(0);
-    expect(finalTrackCount).toBe(initialTrackCount); // Should have same tracks as before
+    await TestHelpers.waitForTrackCount(page, initialTrackCount);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/browser-type-ahead.spec.ts
+++ b/e2e/browser-type-ahead.spec.ts
@@ -1,34 +1,61 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+const ARTIST_COLUMN = '[data-testid="browser-artist-column"]';
+const ALBUM_COLUMN = '[data-testid="browser-album-column"]';
+
+/**
+ * Open the browser panel and wait for it to render.
+ */
+async function openBrowser(page: Page) {
+  await page.locator('[data-testid="browser-toggle"]').click();
+  await expect(page.locator('[data-testid="browser-panel"]')).toBeVisible();
+}
+
+/**
+ * Click a browser item and wait for its column to take focus. Type-ahead only
+ * works on the focused column, so this is the precondition every keypress test
+ * needs — waiting for the focus class is what makes the keypress deterministic.
+ */
+async function focusItem(page: Page, item: string, column: string) {
+  const target = page.locator(item);
+  await expect(target).toBeVisible();
+  await target.click();
+  await expect(page.locator(column)).toHaveClass(/browser-column-focused/);
+}
+
+/**
+ * Let one frame pass. Used before *negative* assertions (nothing should have
+ * changed): the type-ahead handler is synchronous, so if a change were coming
+ * it would already be committed by the next frame.
+ */
+async function nextFrame(page: Page) {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      }),
+  );
+}
 
 test.describe('Browser Type-Ahead Navigation', () => {
   test('type single letter in artist column selects matching artist', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
 
     // Click on "Aurora Synth" to focus the artist column
-    const auroraItem = page.locator('[data-artist="Aurora Synth"]');
-    await expect(auroraItem).toBeVisible({ timeout: 5000 });
-    await auroraItem.click();
-    await page.waitForTimeout(500);
+    await focusItem(page, '[data-artist="Aurora Synth"]', ARTIST_COLUMN);
 
     // Press 'e' — first artist whose sortKey starts with 'e' is Electronic Pulse
     await page.keyboard.press('e');
-    await page.waitForTimeout(500);
 
     // Assert Electronic Pulse is selected
     const epItem = page.locator('[data-artist="Electronic Pulse"]');
     await expect(epItem).toHaveClass(/browser-item-selected/);
 
     // Assert track table is filtered to Electronic Pulse tracks (10 tracks)
-    const trackRows = page.locator('[data-track-id]');
-    await expect(trackRows).toHaveCount(10);
+    await expect(page.locator('[data-track-id]')).toHaveCount(10);
 
     await TestHelpers.closeApp(app);
   });
@@ -36,23 +63,12 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('type multiple letters quickly accumulates search', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await openBrowser(page);
+    await focusItem(page, '[data-artist="Aurora Synth"]', ARTIST_COLUMN);
 
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    // Click any artist item to focus the column
-    const anyArtist = page.locator('[data-artist="Aurora Synth"]');
-    await expect(anyArtist).toBeVisible({ timeout: 5000 });
-    await anyArtist.click();
-    await page.waitForTimeout(300);
-
-    // Press 'r' then 'o' quickly (within 600ms)
+    // Press 'r' then 'o' quickly (within the 600ms type-ahead buffer window)
     await page.keyboard.press('r');
     await page.keyboard.press('o');
-    await page.waitForTimeout(500);
 
     // Assert "Rock Titans" is selected (sortKey "rock titans" starts with "ro")
     const rockItem = page.locator('[data-artist="Rock Titans"]');
@@ -68,24 +84,15 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('buffer resets after timeout', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await openBrowser(page);
+    await focusItem(page, '[data-artist="Aurora Synth"]', ARTIST_COLUMN);
 
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    // Click artist to focus
-    const anyArtist = page.locator('[data-artist="Aurora Synth"]');
-    await expect(anyArtist).toBeVisible({ timeout: 5000 });
-    await anyArtist.click();
-    await page.waitForTimeout(300);
-
-    // Press 'r', wait 800ms (> 600ms timeout), then press 'a'
+    // Press 'r', outwait the buffer, then press 'a'. This delay is the feature
+    // under test — Browser.tsx clears the type-ahead buffer 600ms after the
+    // last keypress — so it is deliberately longer than that window.
     await page.keyboard.press('r');
     await page.waitForTimeout(800);
     await page.keyboard.press('a');
-    await page.waitForTimeout(500);
 
     // Buffer reset, 'a' matches "Acoustic Sessions" (first artist with sortKey starting with "a")
     const acousticItem = page.locator('[data-artist="Acoustic Sessions"]');
@@ -97,24 +104,17 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('type letter in album column works independently', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
 
     // Click on the first album item to focus the album column
-    const firstAlbum = page
-      .locator('[data-testid="browser-album-item"]')
-      .first();
-    await expect(firstAlbum).toBeVisible({ timeout: 5000 });
-    await firstAlbum.click();
-    await page.waitForTimeout(300);
+    await focusItem(
+      page,
+      '[data-testid="browser-album-item"] >> nth=0',
+      ALBUM_COLUMN,
+    );
 
     // Press 's' — first album whose sortKey starts with 's' is "Slow Jams"
     await page.keyboard.press('s');
-    await page.waitForTimeout(500);
 
     // Assert "Slow Jams" is selected in the album column
     const slowJamsItem = page.locator('[data-album="Slow Jams"]');
@@ -126,33 +126,28 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('clicking outside browser clears focus and typing does nothing', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
+    await openBrowser(page);
 
     // Click artist to focus and select Electronic Pulse
+    await focusItem(page, '[data-artist="Electronic Pulse"]', ARTIST_COLUMN);
     const epItem = page.locator('[data-artist="Electronic Pulse"]');
-    await expect(epItem).toBeVisible({ timeout: 5000 });
-    await epItem.click();
-    await page.waitForTimeout(500);
-
-    // Verify Electronic Pulse is selected
     await expect(epItem).toHaveClass(/browser-item-selected/);
 
-    // Click on the track table (outside browser)
-    const trackRow = page.locator('[data-track-id]').first();
-    await trackRow.click();
-    await page.waitForTimeout(300);
+    // Click on the track table (outside browser) — focus should clear
+    await page.locator('[data-track-id]').first().click();
+    await expect(page.locator(ARTIST_COLUMN)).not.toHaveClass(
+      /browser-column-focused/,
+    );
 
     // Press 'a' — should do nothing since focus is cleared
     await page.keyboard.press('a');
-    await page.waitForTimeout(500);
+    await nextFrame(page);
 
     // Electronic Pulse should still be selected (not changed to Acoustic Sessions)
     await expect(epItem).toHaveClass(/browser-item-selected/);
+    await expect(
+      page.locator('[data-artist="Acoustic Sessions"]'),
+    ).not.toHaveClass(/browser-item-selected/);
 
     await TestHelpers.closeApp(app);
   });
@@ -160,22 +155,11 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('sortKey matching — The Jazz Collective matches j', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    // Click any artist to focus
-    const anyArtist = page.locator('[data-artist="Aurora Synth"]');
-    await expect(anyArtist).toBeVisible({ timeout: 5000 });
-    await anyArtist.click();
-    await page.waitForTimeout(300);
+    await openBrowser(page);
+    await focusItem(page, '[data-artist="Aurora Synth"]', ARTIST_COLUMN);
 
     // Press 'j' — sortKey strips "the " so "The Jazz Collective" becomes "jazz collective"
     await page.keyboard.press('j');
-    await page.waitForTimeout(500);
 
     // Assert "The Jazz Collective" is selected
     const jazzItem = page.locator('[data-artist="The Jazz Collective"]');
@@ -187,33 +171,21 @@ test.describe('Browser Type-Ahead Navigation', () => {
   test('focus indicator CSS class applied to focused column', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await openBrowser(page);
 
-    // Open browser panel
-    await page.locator('[data-testid="browser-toggle"]').click();
-    await page.waitForTimeout(500);
-
-    const artistColumn = page.locator('[data-testid="browser-artist-column"]');
-    const albumColumn = page.locator('[data-testid="browser-album-column"]');
+    const artistColumn = page.locator(ARTIST_COLUMN);
+    const albumColumn = page.locator(ALBUM_COLUMN);
 
     // Click artist column — it should get the focus class
-    const anyArtist = page.locator('[data-artist="Aurora Synth"]');
-    await expect(anyArtist).toBeVisible({ timeout: 5000 });
-    await anyArtist.click();
-    await page.waitForTimeout(300);
-
-    await expect(artistColumn).toHaveClass(/browser-column-focused/);
+    await focusItem(page, '[data-artist="Aurora Synth"]', ARTIST_COLUMN);
     await expect(albumColumn).not.toHaveClass(/browser-column-focused/);
 
     // Click album column — focus should move
-    const firstAlbum = page
-      .locator('[data-testid="browser-album-item"]')
-      .first();
-    await firstAlbum.click();
-    await page.waitForTimeout(300);
-
-    await expect(albumColumn).toHaveClass(/browser-column-focused/);
+    await focusItem(
+      page,
+      '[data-testid="browser-album-item"] >> nth=0',
+      ALBUM_COLUMN,
+    );
     await expect(artistColumn).not.toHaveClass(/browser-column-focused/);
 
     await TestHelpers.closeApp(app);

--- a/e2e/column-reorder.spec.ts
+++ b/e2e/column-reorder.spec.ts
@@ -110,22 +110,11 @@ test.describe('Column Reorder', () => {
     });
 
     expect(dragResult).toBe(true);
-    await page.waitForTimeout(500);
-
-    // Read new column order
-    const newOrder = await getColumnOrder(page);
-
-    // Find Artist and Album indices in both orders
-    const oldArtistIdx = initialOrder.indexOf('Artist');
-    const oldAlbumIdx = initialOrder.indexOf('Album');
-    const newArtistIdx = newOrder.indexOf('Artist');
-    const newAlbumIdx = newOrder.indexOf('Album');
 
     // Artist should have moved — its position should differ from original
-    // (the exact result depends on drag direction, but it should change)
-    expect(newArtistIdx !== oldArtistIdx || newAlbumIdx !== oldAlbumIdx).toBe(
-      true,
-    );
+    // (the exact result depends on drag direction, but it should change).
+    // Polling the header order waits for React to commit the new order.
+    await expect.poll(() => getColumnOrder(page)).not.toEqual(initialOrder);
 
     await TestHelpers.closeApp(app);
   });
@@ -181,10 +170,9 @@ test.describe('Column Reorder', () => {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3000);
 
     // Wait for the library table to render
-    await page.waitForSelector('.vt-table', { timeout: 10000 });
+    await page.waitForSelector('.vt-table', { timeout: 20000 });
 
     // Read the column header order
     const headerOrder = await getColumnOrder(page);
@@ -232,18 +220,21 @@ test.describe('Column Reorder', () => {
     await page.mouse.move(handleX + 100, handleY, { steps: 10 });
     await page.mouse.up();
 
-    await page.waitForTimeout(200);
-
     // Get the new width
-    const newArtistWidth = await page.evaluate(() => {
-      const headers = document.querySelectorAll('th');
-      const arr = Array.from(headers);
-      const artistTh = arr.find(
-        (header) => header.textContent?.trim() === 'Artist',
-      );
-      return artistTh ? (artistTh as HTMLElement).offsetWidth : null;
-    });
+    const readArtistWidth = () =>
+      page.evaluate(() => {
+        const headers = document.querySelectorAll('th');
+        const arr = Array.from(headers);
+        const artistTh = arr.find(
+          (header) => header.textContent?.trim() === 'Artist',
+        );
+        return artistTh ? (artistTh as HTMLElement).offsetWidth : null;
+      });
 
+    // Poll the measured width: the resize commits on the next paint, so this
+    // settles immediately instead of after a guessed delay.
+    await expect.poll(readArtistWidth).toBeGreaterThan(initialWidth + 50);
+    const newArtistWidth = await readArtistWidth();
     expect(newArtistWidth).not.toBeNull();
     expect(newArtistWidth!).toBeGreaterThan(initialWidth + 50);
 

--- a/e2e/column-visibility.spec.ts
+++ b/e2e/column-visibility.spec.ts
@@ -124,12 +124,8 @@ test.describe('Column Visibility', () => {
     });
     await genreMenuItem.click();
 
-    // Wait for the column to disappear
-    await page.waitForTimeout(500);
-
-    // Verify Genre header is no longer visible
-    const updatedHeaders = await getColumnHeaders(page);
-    expect(updatedHeaders).not.toContain('Genre');
+    // Wait for the column to actually disappear from the header row
+    await expect.poll(() => getColumnHeaders(page)).not.toContain('Genre');
 
     await TestHelpers.closeApp(app);
   });
@@ -146,15 +142,13 @@ test.describe('Column Visibility', () => {
 
     const genreItem1 = page.locator('[role="menuitem"]', { hasText: 'Genre' });
     await genreItem1.click();
-    await page.waitForTimeout(500);
+
+    // Verify Genre is hidden
+    await expect.poll(() => getColumnHeaders(page)).not.toContain('Genre');
 
     // Close the menu by pressing Escape
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(300);
-
-    // Verify Genre is hidden
-    let headers = await getColumnHeaders(page);
-    expect(headers).not.toContain('Genre');
+    await expect(page.locator('[role="menu"]')).toBeHidden();
 
     // Right-click again and re-check Genre
     const header2 = page.locator('.vt-thead th:not(.vt-th-filler)').first();
@@ -163,11 +157,9 @@ test.describe('Column Visibility', () => {
 
     const genreItem2 = page.locator('[role="menuitem"]', { hasText: 'Genre' });
     await genreItem2.click();
-    await page.waitForTimeout(500);
 
     // Verify Genre is visible again
-    headers = await getColumnHeaders(page);
-    expect(headers).toContain('Genre');
+    await expect.poll(() => getColumnHeaders(page)).toContain('Genre');
 
     await TestHelpers.closeApp(app);
   });
@@ -211,15 +203,13 @@ test.describe('Column Visibility', () => {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3000);
-
-    await page.waitForSelector('.vt-table', { timeout: 10000 });
+    await page.waitForSelector('.vt-table', { timeout: 20000 });
 
     // Verify Genre column is hidden on boot
-    const headers = await getColumnHeaders(page);
-    expect(headers).not.toContain('Genre');
+    await expect.poll(() => getColumnHeaders(page)).not.toContain('Genre');
 
     // Other columns should still be visible
+    const headers = await getColumnHeaders(page);
     expect(headers).toContain('Title');
     expect(headers).toContain('Artist');
     expect(headers).toContain('Album');

--- a/e2e/column-widths.spec.ts
+++ b/e2e/column-widths.spec.ts
@@ -81,10 +81,9 @@ test.describe('Column Widths Persistence', () => {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3000);
 
     // Wait for the library table to render
-    await page.waitForSelector('.vt-table', { timeout: 10000 });
+    await page.waitForSelector('.vt-table', { timeout: 20000 });
 
     // Get the rendered width of the artist column header
     const artistWidth = await page.evaluate(() => {
@@ -155,18 +154,21 @@ test.describe('Column Widths Persistence', () => {
     await page.mouse.move(handleX + 100, handleY, { steps: 10 });
     await page.mouse.up();
 
-    await page.waitForTimeout(200);
-
     // Get the new width of the artist column
-    const newArtistWidth = await page.evaluate(() => {
-      const headers = document.querySelectorAll('th');
-      const arr = Array.from(headers);
-      const artistTh = arr.find(
-        (header) => header.textContent?.trim() === 'Artist',
-      );
-      return artistTh ? (artistTh as HTMLElement).offsetWidth : null;
-    });
+    const readArtistWidth = () =>
+      page.evaluate(() => {
+        const headers = document.querySelectorAll('th');
+        const arr = Array.from(headers);
+        const artistTh = arr.find(
+          (header) => header.textContent?.trim() === 'Artist',
+        );
+        return artistTh ? (artistTh as HTMLElement).offsetWidth : null;
+      });
 
+    // Poll the measured width: the resize commits on the next paint, so this
+    // settles immediately instead of after a guessed delay.
+    await expect.poll(readArtistWidth).toBeGreaterThan(initialWidth + 50);
+    const newArtistWidth = await readArtistWidth();
     expect(newArtistWidth).not.toBeNull();
     // The column should have gotten wider by approximately 100px
     expect(newArtistWidth!).toBeGreaterThan(initialWidth + 50);

--- a/e2e/deduplication.spec.ts
+++ b/e2e/deduplication.spec.ts
@@ -82,7 +82,10 @@ test.describe('Deduplication on Fresh Scan', () => {
 
     page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(2000);
+    // Empty-library CTA is the readiness signal for a brand new database.
+    await page.waitForSelector('text=Your library is empty', {
+      timeout: 20000,
+    });
   });
 
   test.afterAll(async () => {
@@ -111,14 +114,12 @@ test.describe('Deduplication on Fresh Scan', () => {
       throw new Error('Electron API not available');
     }, tempDir);
 
-    // Wait for scan to complete
-    await page.waitForTimeout(5000);
-
-    // Count track rows in the library
-    const trackCount = await page.locator('[data-track-id]').count();
-
-    // Should have exactly 3 unique tracks, not 12
-    expect(trackCount).toBe(SOURCE_SONGS.length);
+    // Wait for the scan to land in the UI — should be exactly 3 unique
+    // tracks, not 12.
+    await expect(page.locator('[data-track-id]')).toHaveCount(
+      SOURCE_SONGS.length,
+      { timeout: 20000 },
+    );
   });
 
   test('should keep same track count when rescanning library with duplicates', async () => {
@@ -130,11 +131,10 @@ test.describe('Deduplication on Fresh Scan', () => {
       throw new Error('Electron API not available');
     }, tempDir);
 
-    // Wait for rescan to complete
-    await page.waitForTimeout(5000);
-
-    // Count should still be exactly 3
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(SOURCE_SONGS.length);
+    // Count should still be exactly 3 once the rescan lands
+    await expect(page.locator('[data-track-id]')).toHaveCount(
+      SOURCE_SONGS.length,
+      { timeout: 20000 },
+    );
   });
 });

--- a/e2e/delete-playing-track.spec.ts
+++ b/e2e/delete-playing-track.spec.ts
@@ -10,10 +10,8 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
     const { app, page } = await TestHelpers.launchApp();
 
     try {
-      await page.waitForTimeout(3000);
       await page.click('[data-testid="nav-library"]');
-      await page.waitForTimeout(500);
-      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+      await TestHelpers.waitForTracks(page);
 
       const firstRow = page.locator('[data-track-id]').first();
       const trackId = await firstRow.getAttribute('data-track-id');
@@ -23,23 +21,19 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       expect(title).toBeTruthy();
 
       // 1. Start playing the first song.
-      await firstRow.dblclick();
-      await page.waitForTimeout(1000);
-      await expect(page.locator('svg[data-testid="PauseIcon"]')).toBeVisible();
+      await TestHelpers.startPlayback(page, firstRow);
       await expect(
         page.locator('[data-testid="now-playing-title"]'),
       ).toContainText(title!);
 
       // 2. Pause it (matches the issue's reproduction steps).
       await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-      await page.waitForTimeout(300);
       await expect(
         page.locator('svg[data-testid="PlayArrowIcon"]'),
       ).toBeVisible();
 
       // 3. Delete it via the right-click "Remove from Library" menu item.
       await firstRow.click({ button: 'right' });
-      await page.waitForTimeout(500);
       const menu = page.locator('[role="menu"]');
       await expect(menu).toBeVisible();
       await menu.getByText('Remove from Library', { exact: true }).click();
@@ -48,7 +42,7 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible();
       await dialog.getByRole('button', { name: 'Delete' }).click();
-      await page.waitForTimeout(1500);
+      await expect(dialog).toBeHidden();
 
       // 5. The now-playing UI is cleared back to the empty "nothing playing"
       // state (the `---` placeholder has no `now-playing-title` element).
@@ -73,10 +67,8 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
     const { app, page } = await TestHelpers.launchApp();
 
     try {
-      await page.waitForTimeout(3000);
       await page.click('[data-testid="nav-library"]');
-      await page.waitForTimeout(500);
-      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+      await TestHelpers.waitForTracks(page);
 
       const rows = page.locator('[data-track-id]');
       const firstRow = rows.nth(0);
@@ -87,19 +79,17 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       expect(title).toBeTruthy();
 
       // Play the first song (this selects it).
-      await firstRow.dblclick();
-      await page.waitForTimeout(1000);
+      await TestHelpers.startPlayback(page, firstRow);
       await expect(
         page.locator('[data-testid="now-playing-title"]'),
       ).toContainText(title!);
 
       // Extend the selection to a second row so the multi-select menu shows.
       await secondRow.click({ modifiers: ['ControlOrMeta'] });
-      await page.waitForTimeout(300);
+      await expect(secondRow).toHaveClass(/vt-row-selected/);
 
       // Right-click a selected row -> multi-select context menu.
       await firstRow.click({ button: 'right' });
-      await page.waitForTimeout(500);
       const menu = page.locator('[role="menu"]');
       await expect(menu).toBeVisible();
       await menu.getByText(/Remove From Library/i).click();
@@ -108,7 +98,7 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible();
       await dialog.getByRole('button', { name: 'Delete' }).click();
-      await page.waitForTimeout(1500);
+      await expect(dialog).toBeHidden();
 
       // Now-playing UI is cleared because the playing song was deleted.
       await expect(
@@ -132,10 +122,8 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
     const { app, page } = await TestHelpers.launchApp();
 
     try {
-      await page.waitForTimeout(3000);
       await page.click('[data-testid="nav-library"]');
-      await page.waitForTimeout(500);
-      await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+      await TestHelpers.waitForTracks(page);
 
       // Filter the library to a tiny source via search: "Digital Dreams" is an
       // album shared by 4 Aurora Synth tracks, giving a source with a real END
@@ -143,13 +131,13 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       // Staying in the library view (not a playlist) keeps "Remove from Library"
       // available, and all 4 matched rows render so nth() lookups are safe.
       await page.locator('[aria-label="Show/Hide search"]').click();
-      await page.waitForTimeout(300);
       await page.locator('[data-testid="search-input"]').fill('Digital Dreams');
-      await page.waitForTimeout(800);
+      // 4 Aurora Synth tracks share this album — waiting for the filtered count
+      // is the signal the debounced search has landed.
+      await TestHelpers.waitForTrackCount(page, 4);
 
       const rows = page.locator('[data-track-id]');
       const count = await rows.count();
-      expect(count).toBeGreaterThanOrEqual(2);
 
       const secondToLastRow = rows.nth(count - 2);
       const lastRow = rows.nth(count - 1);
@@ -166,8 +154,7 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
 
       // Play the SECOND-TO-LAST filtered track so the next natural finish
       // auto-advances onto the LAST one.
-      await secondToLastRow.dblclick();
-      await page.waitForTimeout(1000);
+      await TestHelpers.startPlayback(page, secondToLastRow);
       await expect(
         page.locator('[data-testid="now-playing-title"]'),
       ).toContainText(secondTitle!);
@@ -190,7 +177,7 @@ test.describe('Issue #140 — deleting the playing song clears the now-playing U
       const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible();
       await dialog.getByRole('button', { name: 'Delete' }).click();
-      await page.waitForTimeout(1500);
+      await expect(dialog).toBeHidden();
 
       // Deleting the playing track clears the now-playing UI instead of
       // resurrecting the previous track (pre-fix: removePreloadedTrack restarted

--- a/e2e/drag-to-playlist.spec.ts
+++ b/e2e/drag-to-playlist.spec.ts
@@ -70,6 +70,17 @@ async function dragTrackToPlaylist(
   );
 }
 
+/**
+ * Wait for the toast the drop handler raises. Every accepted drop ends in a
+ * notification, so it is the exact "the playlist mutation finished" signal —
+ * far tighter and more honest than sleeping for a second and a half.
+ */
+async function expectDropNotification(page: Page, text: RegExp) {
+  await expect(
+    page.locator('[data-testid="notification-item"]').filter({ hasText: text }),
+  ).toBeVisible();
+}
+
 test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
   test('single track drag to regular playlist', async () => {
     const { app, page } = await TestHelpers.launchApp();
@@ -87,19 +98,17 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     expect(result).toBe(true);
 
     // Wait for the async playlist update
-    await page.waitForTimeout(1500);
+    await expectDropNotification(page, /Added .* to "Test Playlist"/);
 
     // Navigate to Test Playlist to verify the track was added
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(1000);
 
-    // Verify test-large-010 is now in the playlist
-    const addedTrack = page.locator('[data-track-id="test-large-010"]');
-    await addedTrack.waitFor({ state: 'visible', timeout: 5000 });
-
-    // Should have 4 tracks now (was 3: 001, 002, 003)
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(4);
+    // Verify test-large-010 is now in the playlist, which should now hold
+    // 4 tracks (was 3: 001, 002, 003)
+    await expect(
+      page.locator('[data-track-id="test-large-010"]'),
+    ).toBeVisible();
+    await TestHelpers.waitForTrackCount(page, 4);
 
     await TestHelpers.closeApp(app);
   });
@@ -122,20 +131,18 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     );
     expect(result).toBe(true);
 
-    await page.waitForTimeout(1500);
+    await expectDropNotification(page, /Added 2 tracks to "Jazz Favorites"/);
 
     // Navigate to Jazz Favorites to verify
     await page.click('[data-playlist-id="playlist-2"]');
-    await page.waitForTimeout(1000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
     // Should have 5 tracks now (Jazz Favorites had 3: 002, 022, 042; we added 010 + 011)
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(5);
+    await TestHelpers.waitForTrackCount(page, 5);
 
     // Verify at least one of the added tracks is present in DOM
-    const added010 = page.locator('[data-track-id="test-large-010"]');
-    await added010.waitFor({ state: 'visible', timeout: 5000 });
+    await expect(
+      page.locator('[data-track-id="test-large-010"]'),
+    ).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });
@@ -146,6 +153,16 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     await page.waitForSelector('.vt-table', { timeout: 10000 });
     await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
+    const readSmartTrackIds = () =>
+      page.evaluate(async () => {
+        const playlists = await (
+          window as Window & { electron?: any }
+        ).electron.playlists.getAll();
+        return playlists.find((p: { id: string }) => p.id === 'playlist-3')
+          ?.trackIds;
+      });
+    const beforeDrop = await readSmartTrackIds();
+
     // Attempt to drag to "Recently Added" (playlist-3, smart)
     const result = await dragTrackToPlaylist(
       page,
@@ -154,22 +171,15 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     );
     expect(result).toBe(true); // Events dispatched, but drop should be rejected
 
-    await page.waitForTimeout(1000);
+    // The drop handler bails synchronously for smart playlists, so the stored
+    // playlist must be byte-for-byte unchanged — assert that directly rather
+    // than sleeping and hoping nothing happened.
+    expect(await readSmartTrackIds()).toEqual(beforeDrop);
 
     // Navigate to Recently Added — it's a smart playlist computed dynamically.
-    // Verify test-large-010 wasn't somehow added to the smart playlist's underlying data.
-    // Smart playlists show tracks based on SQL queries, not trackIds array,
-    // so we verify no unexpected state change by checking the playlist renders normally.
-    await page.click('[data-playlist-id="playlist-3"]');
-    await page.waitForTimeout(1000);
-
     // The smart playlist should still be functional (no errors).
-    // Since it's "Recently Added", it shows the 50 most recently added tracks.
-    // test-large-010 may or may not appear here based on dateAdded,
-    // but the key thing is no error occurred from the rejected drop.
-    const vtTable = page.locator('.vt-table');
-    const hasTable = await vtTable.count();
-    expect(hasTable).toBeGreaterThan(0);
+    await page.click('[data-playlist-id="playlist-3"]');
+    await expect(page.locator('.vt-table')).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });
@@ -188,15 +198,16 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     );
     expect(result).toBe(true);
 
-    await page.waitForTimeout(1500);
+    // The duplicate is detected in the mutation's onMutate, which toasts.
+    // Waiting for that toast means the write path has run to completion, so
+    // the count assertion below can't pass merely by being early.
+    await expectDropNotification(page, /already in this playlist/);
 
     // Navigate to Test Playlist
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(1000);
 
     // Should still have exactly 3 tracks (no duplicates)
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(3);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     await TestHelpers.closeApp(app);
   });
@@ -206,8 +217,7 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
 
     // Navigate to Test Playlist first
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(1000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // Drag test-large-001 from Test Playlist to Jazz Favorites (playlist-2)
     const result = await dragTrackToPlaylist(
@@ -217,18 +227,16 @@ test.describe('Drag and Drop Tracks to Sidebar Playlists', () => {
     );
     expect(result).toBe(true);
 
-    await page.waitForTimeout(1500);
+    await expectDropNotification(page, /Added .* to "Jazz Favorites"/);
 
     // Navigate to Jazz Favorites to verify
     await page.click('[data-playlist-id="playlist-2"]');
-    await page.waitForTimeout(1000);
 
     // Verify test-large-001 appears (4 tracks now, was 3: 002, 022, 042)
-    const addedTrack = page.locator('[data-track-id="test-large-001"]');
-    await addedTrack.waitFor({ state: 'visible', timeout: 5000 });
-
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(4);
+    await expect(
+      page.locator('[data-track-id="test-large-001"]'),
+    ).toBeVisible();
+    await TestHelpers.waitForTrackCount(page, 4);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/edit-metadata.spec.ts
+++ b/e2e/edit-metadata.spec.ts
@@ -2,23 +2,29 @@ import { test, expect, type Page, type Locator } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
 /**
+ * Right-click a track locator and open the Edit Metadata dialog, waiting on the
+ * menu and the dialog themselves rather than on fixed delays.
+ */
+async function openEditMetadataFor(page: Page, track: Locator): Promise<void> {
+  await track.click({ button: 'right' });
+  const menu = page.locator('[role="menu"]');
+  await expect(menu).toBeVisible();
+  await menu.getByText('Edit Metadata', { exact: true }).click();
+  await expect(
+    page.locator('[data-testid="edit-metadata-dialog"]'),
+  ).toBeVisible();
+}
+
+/**
  * Navigate to library view, wait for tracks, right-click the first track,
  * and open the Edit Metadata dialog. Returns the first track locator.
  */
 async function openEditMetadataForFirstTrack(page: Page): Promise<Locator> {
-  await page.waitForTimeout(3000);
   await page.click('[data-testid="nav-library"]');
-  await page.waitForTimeout(500);
-  await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+  await TestHelpers.waitForTracks(page);
 
   const firstTrack = page.locator('[data-track-id]').first();
-  await firstTrack.click({ button: 'right' });
-  await page.waitForTimeout(500);
-  await page
-    .locator('[role="menu"]')
-    .getByText('Edit Metadata', { exact: true })
-    .click();
-  await page.waitForTimeout(500);
+  await openEditMetadataFor(page, firstTrack);
 
   return firstTrack;
 }
@@ -27,13 +33,7 @@ async function openEditMetadataForFirstTrack(page: Page): Promise<Locator> {
  * Right-click a track locator and reopen the Edit Metadata dialog.
  */
 async function reopenEditMetadata(page: Page, track: Locator): Promise<void> {
-  await track.click({ button: 'right' });
-  await page.waitForTimeout(500);
-  await page
-    .locator('[role="menu"]')
-    .getByText('Edit Metadata', { exact: true })
-    .click();
-  await page.waitForTimeout(500);
+  await openEditMetadataFor(page, track);
 }
 
 test.describe('Edit Metadata', () => {
@@ -89,8 +89,7 @@ test.describe('Edit Metadata', () => {
 
     // Close dialog via Cancel
     await page.click('[data-testid="cancel-metadata-button"]');
-    await page.waitForTimeout(500);
-    await expect(dialog).not.toBeVisible();
+    await expect(dialog).toBeHidden();
 
     await TestHelpers.closeApp(app);
   });
@@ -111,12 +110,11 @@ test.describe('Edit Metadata', () => {
 
     // Click Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1000);
 
     // Verify dialog closed
     await expect(
       page.locator('[data-testid="edit-metadata-dialog"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     // Verify the track row in the library table now shows the updated values
     const updatedRow = page.locator('[data-track-id]').first();
@@ -144,7 +142,9 @@ test.describe('Edit Metadata', () => {
 
     // Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator('[data-testid="edit-metadata-dialog"]'),
+    ).toBeHidden();
 
     // Reopen the dialog for the same track
     await reopenEditMetadata(page, firstTrack);
@@ -197,7 +197,9 @@ test.describe('Edit Metadata', () => {
 
     // Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator('[data-testid="edit-metadata-dialog"]'),
+    ).toBeHidden();
 
     // Reopen dialog for same track
     await reopenEditMetadata(page, firstTrack);
@@ -237,7 +239,9 @@ test.describe('Edit Metadata', () => {
 
     // Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator('[data-testid="edit-metadata-dialog"]'),
+    ).toBeHidden();
 
     // Reopen and clear those fields
     await reopenEditMetadata(page, firstTrack);
@@ -247,7 +251,9 @@ test.describe('Edit Metadata', () => {
 
     // Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator('[data-testid="edit-metadata-dialog"]'),
+    ).toBeHidden();
 
     // Reopen and verify they're empty
     await reopenEditMetadata(page, firstTrack);
@@ -267,26 +273,17 @@ test.describe('Edit Metadata', () => {
   test('should successfully write metadata to M4A file (not just database)', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
     await page.click('[data-testid="nav-library"]');
-    await page.waitForTimeout(500);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await TestHelpers.waitForTracks(page);
 
     // Open search and filter to the M4A track
     await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
     await page.locator('[data-testid="search-input"]').fill('Test M4A Song');
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTrackCount(page, 1);
 
     // Right-click the M4A track and open Edit Metadata
     const m4aTrack = page.locator('[data-track-id]').first();
-    await m4aTrack.click({ button: 'right' });
-    await page.waitForTimeout(500);
-    await page
-      .locator('[role="menu"]')
-      .getByText('Edit Metadata', { exact: true })
-      .click();
-    await page.waitForTimeout(500);
+    await openEditMetadataFor(page, m4aTrack);
 
     // Change the title
     const titleInput = page.locator('[data-testid="metadata-title-input"]');
@@ -294,7 +291,6 @@ test.describe('Edit Metadata', () => {
 
     // Save
     await page.click('[data-testid="save-metadata-button"]');
-    await page.waitForTimeout(1500);
 
     // Verify notification panel shows success (not a warning about file tags)
     const notificationPanel = page.locator(
@@ -311,7 +307,7 @@ test.describe('Edit Metadata', () => {
 
     // Search for the renamed track to verify it appears with the new title
     await page.locator('[data-testid="search-input"]').fill('Edited M4A Title');
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTrackCount(page, 1);
 
     // Verify the track row shows the updated title
     await expect(page.locator('[data-track-id]').first()).toContainText(

--- a/e2e/electron-helper.ts
+++ b/e2e/electron-helper.ts
@@ -102,9 +102,11 @@ export class ElectronHelper {
     // Wait for the first window
     const page = await this.waitForWindow(app);
 
-    // Wait for React to load
+    // Wait for React to load. The library table is the first thing the app
+    // renders once the renderer has booted, so wait for it rather than
+    // guessing at an initialization delay.
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000); // Give React time to initialize
+    await page.waitForSelector('[data-track-id]', { timeout: 30000 });
 
     return { app, page };
   }

--- a/e2e/filler-column.spec.ts
+++ b/e2e/filler-column.spec.ts
@@ -1,5 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/** Width the virtual table's scroll container currently reports. */
+const containerWidth = (page: Page) =>
+  page.evaluate(() => {
+    const container = document.querySelector(
+      '[data-testid="vt-container"]',
+    ) as HTMLElement | null;
+    return container ? container.clientWidth : 0;
+  });
 
 test.describe('Filler Column', () => {
   test('filler column appears on wide windows', async () => {
@@ -11,11 +20,13 @@ test.describe('Filler Column', () => {
     // Resize the Electron window to be very wide
     const browserWindow = await app.browserWindow(page);
     await browserWindow.evaluate((win) => win.setSize(2000, 800));
-    await page.waitForTimeout(500);
+    // The table re-lays-out from a ResizeObserver, so wait for the container to
+    // report the new width rather than sleeping through the resize.
+    await expect.poll(() => containerWidth(page)).toBeGreaterThan(1500);
 
-    // Assert filler header exists
-    const fillerThCount = await page.locator('.vt-th-filler').count();
-    expect(fillerThCount).toBeGreaterThan(0);
+    // Assert filler header exists. The filler is committed on the render after
+    // the container reports its new width, so this retries until it lands.
+    await expect(page.locator('.vt-th-filler')).not.toHaveCount(0);
 
     // Get the container width and sum of non-filler th widths
     const widths = await page.evaluate(() => {
@@ -48,8 +59,7 @@ test.describe('Filler Column', () => {
     expect(widths.fillerW).toBeLessThanOrEqual(expectedFiller + 5);
 
     // Assert filler cells exist in data rows
-    const fillerTdCount = await page.locator('.vt-td-filler').count();
-    expect(fillerTdCount).toBeGreaterThan(0);
+    await expect(page.locator('.vt-td-filler')).not.toHaveCount(0);
 
     await TestHelpers.closeApp(app);
   });
@@ -63,7 +73,7 @@ test.describe('Filler Column', () => {
     // Resize window to narrow width where columns should fill/exceed container
     const browserWindow = await app.browserWindow(page);
     await browserWindow.evaluate((win) => win.setSize(800, 600));
-    await page.waitForTimeout(500);
+    await expect.poll(() => containerWidth(page)).toBeLessThan(900);
 
     // Filler header should not exist or have 0 width
     const fillerTh = await page.locator('.vt-th-filler');

--- a/e2e/first-import-scroll.spec.ts
+++ b/e2e/first-import-scroll.spec.ts
@@ -5,16 +5,11 @@ test.describe('First-time Library Import Scroll', () => {
   test('should render table correctly after first-time library import', async () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
 
-    // Wait for app to fully load and verify empty library state
-    await page.waitForTimeout(3000);
-    const emptyMessage = page.getByText('Your library is empty');
-    expect(await emptyMessage.isVisible()).toBe(true);
+    // Verify empty library state
+    await expect(page.getByText('Your library is empty')).toBeVisible();
 
-    // Trigger library scan via the electron API
+    // Trigger library scan via the electron API (waits for rows to land)
     await TestHelpers.importSongs(page);
-
-    // Wait for tracks to appear (scan complete event triggers loadLibrary)
-    await page.waitForSelector('[data-track-id]', { timeout: 30000 });
 
     // Verify tracks loaded
     const initialTrackCount = await page.locator('[data-track-id]').count();
@@ -24,21 +19,26 @@ test.describe('First-time Library Import Scroll', () => {
     const tableContainer = page.locator('[data-testid="vt-container"]').first();
     await expect(tableContainer).toBeVisible();
 
-    // Perform rapid scrolling to stress the virtualizer
-    await tableContainer.evaluate((container) => {
-      const scrollSteps = 10;
-      const scrollAmount = 500;
-      for (let i = 0; i < scrollSteps; i += 1) {
-        setTimeout(() => {
-          container.scrollTop += scrollAmount;
-        }, i * 100);
-      }
+    // Perform rapid scrolling to stress the virtualizer. Stepping on
+    // requestAnimationFrame keeps the multi-frame burst the virtualizer has to
+    // cope with, while letting the evaluate resolve when the burst is actually
+    // done — no sleeping past a guessed duration.
+    await tableContainer.evaluate(async (container) => {
+      await new Promise<void>((resolve) => {
+        let step = 0;
+        const tick = () => {
+          container.scrollTop += 500;
+          step += 1;
+          if (step < 10) {
+            requestAnimationFrame(tick);
+          } else {
+            // One extra frame so the virtualizer commits the final range.
+            requestAnimationFrame(() => resolve());
+          }
+        };
+        requestAnimationFrame(tick);
+      });
     });
-    // Wait for all scroll steps to complete
-    await page.waitForTimeout(1500);
-
-    // Give the virtualizer a moment to settle after scrolling
-    await page.waitForTimeout(500);
 
     // Verify rows are still present after scrolling
     const postScrollTrackCount = await page.locator('[data-track-id]').count();
@@ -46,22 +46,24 @@ test.describe('First-time Library Import Scroll', () => {
 
     // Key assertion: every visible row should have non-empty cell content
     // If the duplicate loadLibrary bug were present, some rows would render blank
-    const blankRows = await page.evaluate(() => {
-      const rows = document.querySelectorAll('[data-track-id]');
-      let blankCount = 0;
-      rows.forEach((row) => {
-        const cells = row.querySelectorAll('td');
-        const hasContent = Array.from(cells).some(
-          (cell) => (cell.textContent || '').trim().length > 0,
-        );
-        if (!hasContent) {
-          blankCount += 1;
-        }
-      });
-      return blankCount;
-    });
-
-    expect(blankRows).toBe(0);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const rows = document.querySelectorAll('[data-track-id]');
+          let blankCount = 0;
+          rows.forEach((row) => {
+            const cells = row.querySelectorAll('td');
+            const hasContent = Array.from(cells).some(
+              (cell) => (cell.textContent || '').trim().length > 0,
+            );
+            if (!hasContent) {
+              blankCount += 1;
+            }
+          });
+          return blankCount;
+        }),
+      )
+      .toBe(0);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -1,7 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 import {
   _electron as electron,
+  expect,
   ElectronApplication,
+  Locator,
   Page,
 } from '@playwright/test';
 import path from 'path';
@@ -11,6 +13,12 @@ import sqlite3 from 'sqlite3';
 // All tests use the consolidated test library (200 tracks)
 const TEST_SONGS_DIR = 'test-songs-large';
 const TEST_DB_SQL = 'test-db.sql';
+
+// Generous ceiling for "the app should have settled by now" waits. These are
+// upper bounds on retrying assertions, not sleeps — a healthy app resolves them
+// in tens of milliseconds, so raising the ceiling costs nothing when passing and
+// only buys headroom on a loaded CI machine.
+const READY_TIMEOUT = 20000;
 
 export class TestHelpers {
   static async initializeTestDatabase(
@@ -134,7 +142,10 @@ export class TestHelpers {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3000); // Give time for library to render
+    // The seeded library is the readiness signal: once rows are in the DOM the
+    // renderer has booted, queries have resolved and the virtual table has laid
+    // out. No arbitrary sleep required.
+    await this.waitForTracks(page);
 
     const rootContent = await page.locator('#root').innerHTML();
     if (rootContent.length < 100) {
@@ -180,7 +191,12 @@ export class TestHelpers {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(1000);
+    // A brand new user has no tracks, so the empty-state CTA is the readiness
+    // signal. MainLayout only renders it once the tracks/playlists queries have
+    // settled, so seeing it means the renderer is fully booted.
+    await page.waitForSelector('text=Your library is empty', {
+      timeout: READY_TIMEOUT,
+    });
 
     const rootContent = await page.locator('#root').innerHTML();
     if (rootContent.length < 100) {
@@ -201,23 +217,132 @@ export class TestHelpers {
     });
   }
 
+  /**
+   * Wait until the track table has rendered at least one row.
+   *
+   * This is the canonical "the library is on screen" signal — the virtual table
+   * only emits `data-track-id` rows after the tracks query has resolved and the
+   * virtualizer has measured the container.
+   */
+  static async waitForTracks(
+    page: Page,
+    timeout = READY_TIMEOUT,
+  ): Promise<void> {
+    await page.waitForSelector('[data-track-id]', { timeout });
+  }
+
+  /**
+   * Wait until the rendered track row count settles on `expected`.
+   *
+   * Prefer this over `count()`-after-a-sleep: it retries until the DOM agrees,
+   * so it returns the moment the table has re-rendered rather than after a
+   * guessed delay.
+   */
+  static async waitForTrackCount(
+    page: Page,
+    expected: number,
+    timeout = READY_TIMEOUT,
+  ): Promise<void> {
+    await expect(page.locator('[data-track-id]')).toHaveCount(expected, {
+      timeout,
+    });
+  }
+
   static async waitForLibraryLoad(page: Page): Promise<void> {
-    try {
-      await page.waitForTimeout(1000);
+    await this.waitForTracks(page);
+  }
 
-      const emptyMessage = page.getByText('Your library is empty');
-      const isEmptyVisible = await emptyMessage.isVisible().catch(() => false);
+  /** Locator for the transport button's "currently playing" state. */
+  static pauseIcon(page: Page): Locator {
+    return page.locator('button svg[data-testid="PauseIcon"]');
+  }
 
-      if (isEmptyVisible) {
-        throw new Error('Library is empty - no tracks loaded');
-      }
+  /** Locator for the transport button's "currently paused/stopped" state. */
+  static playIcon(page: Page): Locator {
+    return page.locator('button svg[data-testid="PlayArrowIcon"]');
+  }
 
-      // eslint-disable-next-line no-console
-      console.log('Library loaded successfully - tracks present');
-    } catch (error) {
-      console.error('Error waiting for library to load:', error);
-      throw error;
-    }
+  /** Wait until the transport reports playing. */
+  static async waitForPlaying(page: Page, timeout = READY_TIMEOUT) {
+    await expect(this.pauseIcon(page)).toBeVisible({ timeout });
+  }
+
+  /** Wait until the transport reports paused. */
+  static async waitForPaused(page: Page, timeout = READY_TIMEOUT) {
+    await expect(this.playIcon(page)).toBeVisible({ timeout });
+  }
+
+  /**
+   * Double-click a track row and wait until it is the current track and the
+   * transport reports playing. Replaces the `dblclick` + `waitForTimeout(1000)`
+   * pattern: playback state flips in tens of milliseconds, so waiting on the
+   * state itself is both faster and immune to a slow machine.
+   */
+  static async startPlayback(page: Page, row: Locator): Promise<void> {
+    await row.dblclick();
+    await expect(row).toHaveClass(/vt-row-playing/, { timeout: READY_TIMEOUT });
+    await this.waitForPlaying(page);
+  }
+
+  /** The title currently shown in the player's now-playing slot. */
+  static async nowPlayingTitle(page: Page): Promise<string> {
+    return (
+      (await page.locator('[data-testid="now-playing-title"]').textContent()) ??
+      ''
+    );
+  }
+
+  /** Wait until the player's now-playing title equals `title`. */
+  static async waitForNowPlaying(
+    page: Page,
+    title: string,
+    timeout = READY_TIMEOUT,
+  ): Promise<void> {
+    await expect(page.locator('[data-testid="now-playing-title"]')).toHaveText(
+      title,
+      { timeout },
+    );
+  }
+
+  /**
+   * Wait until the now-playing title is something other than `previous`.
+   * Used after skip/next/autoplay transitions where the destination track isn't
+   * known up front.
+   */
+  static async waitForNowPlayingChange(
+    page: Page,
+    previous: string,
+    timeout = READY_TIMEOUT,
+  ): Promise<void> {
+    await expect(
+      page.locator('[data-testid="now-playing-title"]'),
+    ).not.toHaveText(previous, { timeout });
+  }
+
+  /**
+   * Wait until the player's elapsed-time readout reaches at least `seconds`.
+   *
+   * Tests that need real playback to elapse (play-count thresholds, autoplay
+   * roll-over) should gate on the clock the app actually shows rather than
+   * sleeping for a guessed duration.
+   */
+  static async waitForElapsedAtLeast(
+    page: Page,
+    seconds: number,
+    timeout = 30000,
+  ): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          const text = await page
+            .locator('[data-testid="player-elapsed-time"]')
+            .textContent();
+          const [mins, secs] = (text ?? '0:00').split(':');
+          return parseInt(mins, 10) * 60 + parseInt(secs, 10);
+        },
+        { timeout },
+      )
+      .toBeGreaterThanOrEqual(seconds);
   }
 
   static async importSongs(page: Page): Promise<void> {
@@ -230,120 +355,23 @@ export class TestHelpers {
       throw new Error('Electron API not available');
     }, songsPath);
 
-    await page.waitForTimeout(3000);
-  }
-
-  static async createPlaylist(page: Page, name: string): Promise<void> {
-    await page.click('[data-testid="create-playlist-button"]');
-    await page.fill('[data-testid="playlist-name-input"]', name);
-    await page.click('[data-testid="save-playlist-button"]');
-    await page.waitForTimeout(500);
-  }
-
-  static async selectSong(page: Page, songTitle: string): Promise<void> {
-    await page.click(`[data-testid="song-row-${songTitle}"]`);
-  }
-
-  static async playSong(page: Page, songTitle: string): Promise<void> {
-    await this.selectSong(page, songTitle);
-    await page.dblclick(`[data-testid="song-row-${songTitle}"]`);
-    await page.waitForTimeout(1000);
-  }
-
-  static async getPlayerState(page: Page): Promise<{
-    isPlaying: boolean;
-    currentSong: string | null;
-    currentTime: number;
-    duration: number;
-  }> {
-    return page.evaluate(() => {
-      const player = document.querySelector('[data-testid="player"]');
-      if (!player)
-        return {
-          isPlaying: false,
-          currentSong: null,
-          currentTime: 0,
-          duration: 0,
-        };
-
-      const playButton = player.querySelector(
-        '[data-testid="play-pause-button"]',
-      );
-      const isPlaying = playButton?.getAttribute('aria-label') === 'Pause';
-      const songTitle =
-        player.querySelector('[data-testid="now-playing-title"]')
-          ?.textContent || null;
-      const currentTime = parseFloat(
-        player.querySelector('[data-testid="current-time"]')?.textContent ||
-          '0',
-      );
-      const duration = parseFloat(
-        player.querySelector('[data-testid="duration"]')?.textContent || '0',
-      );
-
-      return { isPlaying, currentSong: songTitle, currentTime, duration };
-    });
-  }
-
-  static async searchLibrary(page: Page, query: string): Promise<void> {
-    await page.fill('[data-testid="search-input"]', query);
-    await page.waitForTimeout(500);
+    // The scan resolves in the main process, then `scanCompleteInvalidator`
+    // refreshes the tracks query — wait for the rows, not a fixed delay.
+    await this.waitForTracks(page, 30000);
   }
 
   static async navigateToView(
     page: Page,
-    view: 'library' | 'playlists' | 'settings',
+    view: 'library' | 'settings',
   ): Promise<void> {
     await page.click(`[data-testid="nav-${view}"]`);
-    await page.waitForTimeout(500);
-  }
-
-  static async toggleShuffle(page: Page): Promise<void> {
-    await page.click('[data-testid="shuffle-button"]');
-  }
-
-  static async toggleRepeat(page: Page): Promise<void> {
-    await page.click('[data-testid="repeat-button"]');
-  }
-
-  static async skipToNext(page: Page): Promise<void> {
-    await page.click('[data-testid="next-button"]');
-    await page.waitForTimeout(500);
-  }
-
-  static async skipToPrevious(page: Page): Promise<void> {
-    await page.click('[data-testid="previous-button"]');
-    await page.waitForTimeout(500);
-  }
-
-  static async setVolume(page: Page, volume: number): Promise<void> {
-    const slider = await page.locator('[data-testid="volume-slider"]');
-    await slider.fill(volume.toString());
-  }
-
-  static async addToPlaylist(
-    page: Page,
-    songTitle: string,
-    playlistName: string,
-  ): Promise<void> {
-    await page.click(`[data-testid="song-row-${songTitle}"]`, {
-      button: 'right',
-    });
-    await page.click('[data-testid="add-to-playlist-menu"]');
-    await page.click(`[data-testid="playlist-option-${playlistName}"]`);
-    await page.waitForTimeout(500);
-  }
-
-  static async likeSong(page: Page, songTitle: string): Promise<void> {
-    await page.click(`[data-testid="like-button-${songTitle}"]`);
-    await page.waitForTimeout(300);
-  }
-
-  static async getSongCount(page: Page): Promise<number> {
-    const count = await page
-      .locator('[data-testid="song-count"]')
-      .textContent();
-    return parseInt(count || '0', 10);
+    if (view === 'settings') {
+      await page.waitForSelector('[data-testid="settings-view"]', {
+        timeout: READY_TIMEOUT,
+      });
+    } else {
+      await this.waitForTracks(page);
+    }
   }
 
   /**
@@ -437,7 +465,14 @@ export class TestHelpers {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(2000);
+    // Either the migration dialog took over the window, or the app booted
+    // straight into the library — whichever happens first means we're ready.
+    await page.waitForSelector(
+      '[data-testid="migration-dialog"], [data-track-id]',
+      {
+        timeout: READY_TIMEOUT,
+      },
+    );
 
     const rootContent = await page.locator('#root').innerHTML();
     if (rootContent.length < 100) {

--- a/e2e/large-library.spec.ts
+++ b/e2e/large-library.spec.ts
@@ -1,23 +1,31 @@
-/* eslint-disable no-console, no-plusplus, no-await-in-loop, @typescript-eslint/no-unused-vars */
-import { test, expect } from '@playwright/test';
+/* eslint-disable no-plusplus, no-await-in-loop */
+import { test, expect, Locator, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/** Ids of every row the virtualizer currently has mounted. */
+const renderedTrackIds = (page: Page) =>
+  page
+    .locator('[data-track-id]')
+    .evaluateAll((rows) => rows.map((r) => r.getAttribute('data-track-id')));
+
+/** Scroll the container to the bottom and wait a frame for the re-range. */
+async function scrollToBottom(container: Locator) {
+  await container.evaluate(
+    (el) =>
+      new Promise<void>((resolve) => {
+        el.scrollTop = el.scrollHeight;
+        requestAnimationFrame(() => resolve());
+      }),
+  );
+}
 
 test.describe('Large Library (200+ tracks)', () => {
   test('should load and display a large library with 200 tracks', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load and render
-    await page.waitForTimeout(3000);
-
-    // Wait for track rows to appear
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Count visible tracks (may be virtualized, so not all 200 will be visible at once)
     const visibleTrackCount = await page.locator('[data-track-id]').count();
     expect(visibleTrackCount).toBeGreaterThan(0);
-
-    // Verify we're showing multiple tracks (virtualization should render at least some)
-    console.log(`Visible track count on initial load: ${visibleTrackCount}`);
 
     await TestHelpers.takeScreenshot(page, 'large-library-initial');
 
@@ -27,73 +35,34 @@ test.describe('Large Library (200+ tracks)', () => {
   test('should scroll through large library and reach the last track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Get the scrollable table container
-    // MaterialReactTable uses a container with overflow for virtualization
     const tableContainer = page.locator('[data-testid="vt-container"]').first();
     await expect(tableContainer).toBeVisible();
 
-    // Get initial visible tracks
-    const initialTrackIds = await page
-      .locator('[data-track-id]')
-      .evaluateAll((rows) => rows.map((r) => r.getAttribute('data-track-id')));
-    console.log('Initial track IDs:', initialTrackIds.slice(0, 5), '...');
+    // Click a row first so the table has focus, as a user would
+    const firstRow = page.locator('[data-track-id]').first();
+    await firstRow.click();
+    await expect(firstRow).toHaveClass(/vt-row-selected/);
 
-    // Scroll to the bottom of the table using keyboard navigation
-    // First, click on a row to focus the table
-    await page.locator('[data-track-id]').first().click();
-    await page.waitForTimeout(300);
-
-    // Use Ctrl+End or scroll to bottom
-    // Since the table is virtualized, we need to scroll the container
-    await tableContainer.evaluate((container) => {
-      container.scrollTop = container.scrollHeight;
-    });
-    await page.waitForTimeout(1000);
-
-    // Check that we've scrolled - get track IDs after scrolling
-    const scrolledTrackIds = await page
-      .locator('[data-track-id]')
-      .evaluateAll((rows) => rows.map((r) => r.getAttribute('data-track-id')));
-    console.log(
-      'Track IDs after first scroll:',
-      scrolledTrackIds.slice(-5),
-      '...',
-    );
-
-    // The track IDs should be different after scrolling (virtualization replaces rows)
-    // Check for tracks from the end of the list (test-large-196 to test-large-200)
-    const lastTrackVisible = scrolledTrackIds.some((id) =>
-      id?.startsWith('test-large-2'),
-    );
-    console.log(`Found tracks from 200 range: ${lastTrackVisible}`);
-
-    // Continue scrolling if needed - scroll multiple times to ensure we reach the bottom
-    for (let i = 0; i < 5; i++) {
-      await tableContainer.evaluate((container) => {
-        container.scrollTop = container.scrollHeight;
-      });
-      await page.waitForTimeout(500);
-    }
-
-    // Final check for last track
-    const finalTrackIds = await page
-      .locator('[data-track-id]')
-      .evaluateAll((rows) => rows.map((r) => r.getAttribute('data-track-id')));
-    console.log('Final visible track IDs:', finalTrackIds);
-
-    // Verify we can see tracks near the end (track 200)
-    // The last track should be test-large-200
-    const hasLastTrack = finalTrackIds.some(
-      (id) =>
-        id === 'test-large-200' ||
-        id?.includes('test-large-19') ||
-        id?.includes('test-large-20'),
-    );
-    expect(hasLastTrack).toBe(true);
+    // Scroll to the bottom. The virtualizer re-ranges asynchronously, so poll
+    // the rendered ids until rows from the end of the list appear rather than
+    // scrolling-then-sleeping repeatedly.
+    await scrollToBottom(tableContainer);
+    await expect
+      .poll(
+        async () => {
+          await scrollToBottom(tableContainer);
+          const ids = await renderedTrackIds(page);
+          return ids.some(
+            (id) =>
+              id === 'test-large-200' ||
+              !!id?.includes('test-large-19') ||
+              !!id?.includes('test-large-20'),
+          );
+        },
+        { timeout: 15000 },
+      )
+      .toBe(true);
 
     await TestHelpers.takeScreenshot(page, 'large-library-scrolled-to-bottom');
 
@@ -103,17 +72,12 @@ test.describe('Large Library (200+ tracks)', () => {
   test('should sort large library by different columns', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Helper function to get song titles from visible rows
     const getSongTitles = async () => {
       const rows = await page.locator('[data-track-id]').all();
       const titles = await Promise.all(
         rows.slice(0, 10).map(async (row) => {
-          const titleCell = row.locator('td').first();
-          const title = await titleCell.textContent();
+          const title = await row.locator('td').first().textContent();
           return title ? title.trim() : '';
         }),
       );
@@ -125,8 +89,7 @@ test.describe('Large Library (200+ tracks)', () => {
       const rows = await page.locator('[data-track-id]').all();
       const artists = await Promise.all(
         rows.slice(0, 10).map(async (row) => {
-          const artistCell = row.locator('td').nth(1);
-          const artist = await artistCell.textContent();
+          const artist = await row.locator('td').nth(1).textContent();
           return artist ? artist.trim() : '';
         }),
       );
@@ -135,25 +98,23 @@ test.describe('Large Library (200+ tracks)', () => {
 
     // Get initial artists (should be sorted by artist by default)
     const initialArtists = await getSongArtists();
-    console.log('Initial artists (first 10):', initialArtists);
-
-    // The first artist alphabetically should be something like "Acoustic Sessions" or "Ambient Collective"
-    // Since we have many artists, just verify we have valid data
     expect(initialArtists.filter((a) => a.length > 0).length).toBeGreaterThan(
       0,
     );
 
-    // Sort by Title ascending — click the Title header directly
+    // Sort by Title ascending — click the Title header directly and wait for
+    // the header to report the new sort direction.
     const titleHeader = page.locator('th').filter({ hasText: 'Title' }).first();
     await titleHeader.click();
-    await page.waitForTimeout(1000);
-
-    const sortedTitles = await getSongTitles();
-    console.log('Titles after sorting by Title asc:', sortedTitles);
+    await expect(titleHeader).toHaveAttribute('aria-sort', 'ascending');
 
     // Verify titles are sorted alphabetically
-    const sortedTitlesCopy = [...sortedTitles].sort();
-    expect(sortedTitles).toEqual(sortedTitlesCopy);
+    await expect
+      .poll(async () => {
+        const titles = await getSongTitles();
+        return JSON.stringify(titles) === JSON.stringify([...titles].sort());
+      })
+      .toBe(true);
 
     await TestHelpers.takeScreenshot(page, 'large-library-sorted-by-title');
 
@@ -163,60 +124,31 @@ test.describe('Large Library (200+ tracks)', () => {
   test('should search within large library', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Get initial track count (visible in viewport)
     const initialCount = await page.locator('[data-track-id]').count();
-    console.log(`Initial visible track count: ${initialCount}`);
 
-    // Click the search toggle button (MRT_ToggleGlobalFilterButton)
-    // The button has aria-label "Show/Hide search" from MRT localization
-    const searchToggle = page.locator('[aria-label="Show/Hide search"]');
-    if (await searchToggle.isVisible()) {
-      await searchToggle.click();
-      await page.waitForTimeout(500);
-    }
+    // Click the search toggle button
+    await page.locator('[aria-label="Show/Hide search"]').click();
+    const searchInput = page.locator('[data-testid="search-input"]');
+    await expect(searchInput).toBeVisible();
 
-    // Now find the search input - MRT creates an input when search is toggled
-    // Try multiple selectors for the search input
-    let searchInput = page.locator('input[type="search"]').first();
-    if (!(await searchInput.isVisible())) {
-      searchInput = page.locator('input[placeholder*="Search"]').first();
-    }
-    if (!(await searchInput.isVisible())) {
-      // MRT might use a text input without search type
-      searchInput = page.locator('.MuiInputBase-input').first();
-    }
-
-    // Wait for search input to be visible
-    await expect(searchInput).toBeVisible({ timeout: 5000 });
-
-    // Search for a specific artist that should have multiple tracks
-    // "Aurora Synth" should have multiple tracks (every 20th track)
+    // Every rendered row matching the term is the signal that the debounced
+    // filter has applied — the unfiltered library renders many other artists,
+    // so this can't pass before the search lands.
     await searchInput.fill('Aurora Synth');
-    await page.waitForTimeout(1000);
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Aurora Synth' }),
+    ).toHaveCount(0);
 
-    // Check that results are filtered
     const filteredCount = await page.locator('[data-track-id]').count();
-    console.log(`Filtered track count for "Aurora Synth": ${filteredCount}`);
-
-    // Aurora Synth should have 10 tracks (every 20th track out of 200)
-    expect(filteredCount).toBeLessThan(initialCount);
     expect(filteredCount).toBeGreaterThan(0);
-
-    // Verify the results contain Aurora Synth
-    const pageContent = await page.content();
-    expect(pageContent).toContain('Aurora Synth');
+    expect(filteredCount).toBeLessThan(initialCount);
 
     // Clear search and verify all tracks return
     await searchInput.clear();
-    await page.waitForTimeout(1000);
-
-    const clearedCount = await page.locator('[data-track-id]').count();
-    console.log(`Track count after clearing search: ${clearedCount}`);
-    expect(clearedCount).toBeGreaterThanOrEqual(initialCount);
+    await expect
+      .poll(() => page.locator('[data-track-id]').count())
+      .toBeGreaterThanOrEqual(initialCount);
 
     await TestHelpers.takeScreenshot(page, 'large-library-search-results');
 
@@ -226,33 +158,13 @@ test.describe('Large Library (200+ tracks)', () => {
   test('should play a track from the large library', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Double-click the first track to play it
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(2000);
+    const firstTitle = await firstTrack.locator('td').first().textContent();
+    await TestHelpers.startPlayback(page, firstTrack);
 
-    // Check that the player shows the song is playing
-    // Look for the play/pause button or now playing indicator
-    const playerContainer = page
-      .locator('.player, [class*="player"], [data-testid*="player"]')
-      .first();
-
-    // The track should now be playing or at least loaded
-    // Check for any indication that the track is selected/playing
-    const nowPlayingText = await page.content();
-
-    // One of our test songs should appear in the now playing section
-    // Our first track should be "Dream of Love" by "Aurora Synth"
-    const isTrackLoaded =
-      nowPlayingText.includes('Dream') ||
-      nowPlayingText.includes('Aurora') ||
-      nowPlayingText.includes('Digital Dreams');
-
-    expect(isTrackLoaded).toBe(true);
+    // The player should now report that exact track as now-playing
+    await TestHelpers.waitForNowPlaying(page, firstTitle!.trim());
 
     await TestHelpers.takeScreenshot(page, 'large-library-track-playing');
 
@@ -262,28 +174,26 @@ test.describe('Large Library (200+ tracks)', () => {
   test('should handle scrolling performance with virtualization', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     const tableContainer = page.locator('[data-testid="vt-container"]').first();
     await expect(tableContainer).toBeVisible();
 
-    // Measure scroll performance by timing scroll operations
+    // Measure scroll performance by timing scroll operations. Each step waits
+    // for the next animation frame instead of a fixed delay, so the measurement
+    // reflects real render cost rather than the sleeps we added ourselves.
     const startTime = Date.now();
 
-    // Perform multiple rapid scrolls
     for (let i = 0; i < 10; i++) {
-      await tableContainer.evaluate((container, scrollAmount) => {
-        container.scrollTop += scrollAmount;
-      }, 500);
-      await page.waitForTimeout(100);
+      await tableContainer.evaluate(
+        (container, scrollAmount) =>
+          new Promise<void>((resolve) => {
+            container.scrollTop += scrollAmount;
+            requestAnimationFrame(() => resolve());
+          }),
+        500,
+      );
     }
 
-    const endTime = Date.now();
-    const scrollDuration = endTime - startTime;
-
-    console.log(`10 scroll operations completed in ${scrollDuration}ms`);
+    const scrollDuration = Date.now() - startTime;
 
     // Performance should be reasonable (less than 5 seconds for 10 scrolls)
     expect(scrollDuration).toBeLessThan(5000);

--- a/e2e/library-management.spec.ts
+++ b/e2e/library-management.spec.ts
@@ -6,9 +6,6 @@ test.describe('Library Management', () => {
   test('should display pre-loaded songs in library', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait a bit for the app to fully load and render
-    await page.waitForTimeout(3000);
-
     // Check if songs are visible - use multiple selectors as fallback
     const songCount = await page
       .locator(
@@ -24,10 +21,6 @@ test.describe('Library Management', () => {
 
   test('should verify test songs are loaded', async () => {
     const { app, page } = await TestHelpers.launchApp();
-
-    // Wait for app to load with pre-populated songs
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
     // Verify we have songs loaded — virtualization renders only visible rows,
     // so check that a reasonable number are in the DOM (overscan covers ~56 rows)
@@ -81,10 +74,6 @@ test.describe('Library Management', () => {
   test('should sort songs by different columns', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load with fixture data
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Helper function to get song titles from the visible table rows
     const getSongTitles = async () => {
       // Get all table rows with track data
@@ -127,9 +116,11 @@ test.describe('Library Management', () => {
 
     // Test sorting by Title column - ascending
     // Click the Title column header directly to sort ascending
+    // The header's aria-sort attribute flips as soon as the table commits the
+    // new sort, so it replaces every "click then sleep" pair below.
     const titleHeader = page.locator('th').filter({ hasText: 'Title' }).first();
     await titleHeader.click();
-    await page.waitForTimeout(1000);
+    await expect(titleHeader).toHaveAttribute('aria-sort', 'ascending');
 
     // Get titles after sorting by Title ascending
     let titles = await getSongTitles();
@@ -140,7 +131,7 @@ test.describe('Library Management', () => {
     // Test sorting by Title column - descending
     // Click the Title header again to toggle to descending
     await titleHeader.click();
-    await page.waitForTimeout(1000);
+    await expect(titleHeader).toHaveAttribute('aria-sort', 'descending');
 
     titles = await getSongTitles();
     // Titles should be sorted in reverse alphabetical order
@@ -154,9 +145,9 @@ test.describe('Library Management', () => {
       .filter({ hasText: 'Artist' })
       .first();
     await artistHeader.click();
-    await page.waitForTimeout(500);
+    await expect(artistHeader).toHaveAttribute('aria-sort', 'ascending');
     await artistHeader.click();
-    await page.waitForTimeout(1000);
+    await expect(artistHeader).toHaveAttribute('aria-sort', 'descending');
 
     artists = await getSongArtists();
     // Artists should be sorted in reverse alphabetical order
@@ -213,42 +204,33 @@ test.describe('Library Management', () => {
 
     console.log(`Initial file count: ${initialFileCount}`);
 
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-
     // Navigate to Settings
     // Click the settings button using its data-testid
     const settingsButton = page.locator('[data-testid="nav-settings"]');
     await settingsButton.click();
-
-    // Wait for settings to load
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="settings-view"]');
 
     // Find and click the "Rescan Library" button
     const rescanButton = page.locator('button:has-text("Rescan Library")');
-    await expect(rescanButton).toBeVisible({ timeout: 5000 });
+    await expect(rescanButton).toBeVisible();
     await rescanButton.click();
 
-    // Wait for scan to start
-    await page.waitForTimeout(1000);
+    // The main process pushes `library:scanComplete` when the scan finishes,
+    // which surfaces this notification. Waiting on it means the test returns
+    // the instant the scan is done rather than after a fixed 30s fallback.
+    await expect(
+      page
+        .locator('[data-testid="notification-item"]')
+        .filter({ hasText: 'Library scan completed' }),
+    ).toBeVisible({ timeout: 60000 });
 
-    // Wait for scan to complete - look for completion indicators
-    // The scan might show a progress bar or status text
-    try {
-      // Wait for scan complete text or progress to reach 100%
-      await page.waitForSelector('text=Scan Complete', { timeout: 60000 });
-    } catch {
-      // Alternative: wait for the progress indicator to disappear
-      try {
-        await page.waitForSelector('[role="progressbar"]', {
-          state: 'hidden',
-          timeout: 60000,
-        });
-      } catch {
-        // Fallback: just wait a reasonable amount of time
-        await page.waitForTimeout(30000);
-      }
-    }
+    // The scan-progress dialog is bound to the mutation's pending state, which
+    // settles a moment after the push event; wait for it to unmount so it stops
+    // intercepting clicks. (The Settings panel is itself a role="dialog", so
+    // match the scan dialog by its completion title rather than by role.)
+    await expect(
+      page.getByRole('heading', { name: 'Scan Complete' }),
+    ).toBeHidden({ timeout: 60000 });
 
     // Count files after rescan
     const finalFileCount = getFileCount(testSongsDir);
@@ -262,16 +244,13 @@ test.describe('Library Management', () => {
 
     // Close the Settings drawer before navigating back
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(500);
 
-    // Navigate back to library (sidebar is still open)
-    const libraryButton = page.locator('[data-testid="nav-library"]');
-    await libraryButton.click();
-    await page.waitForTimeout(1000);
+    // Navigate back to library (sidebar is still open). Playwright waits for
+    // the nav button to be actionable, which covers the drawer transition.
+    await page.locator('[data-testid="nav-library"]').click();
 
     // Verify songs are visible in the UI (virtualization limits visible rows to ~45)
-    const songCount = await page.locator('[data-track-id]').count();
-    expect(songCount).toBeGreaterThan(0); // Tracks should be visible after rescan
+    await TestHelpers.waitForTracks(page);
 
     await TestHelpers.takeScreenshot(page, 'library-after-rescan');
 

--- a/e2e/migration.spec.ts
+++ b/e2e/migration.spec.ts
@@ -135,10 +135,8 @@ test.describe('hihat v1 to v2 Migration', () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
 
     try {
-      // App should launch with empty library (new user state)
-      await page.waitForTimeout(2000);
-
-      // Check if we're in the welcome/empty state
+      // Check if we're in the welcome/empty state (launchAppAsBrandNewUser
+      // already waited for it to render)
       const welcomeText = await page
         .locator('text="Your library is empty"')
         .count();

--- a/e2e/miniplayer-sync.spec.ts
+++ b/e2e/miniplayer-sync.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test, expect, Page, ElectronApplication } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
@@ -10,7 +9,8 @@ async function closeMiniPlayerAndApp(page: Page, app: ElectronApplication) {
     await page.evaluate(() => {
       return (window as any).electron.miniPlayer.close();
     });
-    await page.waitForTimeout(1000);
+    // Wait for the window to actually go away rather than guessing at it.
+    await expect.poll(() => app.windows().length).toBe(1);
   } catch {
     // Ignore errors during cleanup
   }
@@ -19,86 +19,89 @@ async function closeMiniPlayerAndApp(page: Page, app: ElectronApplication) {
 
 /**
  * Helper to open MiniPlayer and return the MiniPlayer page.
- * Waits for the MiniPlayer window to fully load and sync state.
+ *
+ * `waitForEvent('window')` resolves the moment Electron creates the window, and
+ * the MiniPlayer's own title readout tells us when its first state sync landed
+ * — so neither step needs a fixed delay, even though the MiniPlayer polls on a
+ * 1s cadence.
  */
 async function openMiniPlayer(
   app: ElectronApplication,
   page: Page,
 ): Promise<Page> {
+  const miniWindow = app.waitForEvent('window');
+
   await page.evaluate(() => {
     return (window as any).electron.miniPlayer.open();
   });
 
-  // Wait for the MiniPlayer window to appear
-  await page.waitForTimeout(5000);
+  const miniPlayerPage = await miniWindow;
+  expect(app.windows().length).toBeGreaterThanOrEqual(2);
 
-  const windows = app.windows();
-  expect(windows.length).toBeGreaterThanOrEqual(2);
+  await miniPlayerPage.waitForLoadState('domcontentloaded');
 
-  const miniPlayerPage = windows.find((w: Page) => w !== page);
-  expect(miniPlayerPage).toBeTruthy();
+  // '---' is the MiniPlayer's "no track yet" placeholder; anything else means
+  // the state sync from the main window has arrived.
+  await expect(miniPlayerPage.locator('.MuiTypography-h6')).not.toHaveText(
+    '---',
+    { timeout: 20000 },
+  );
 
-  await miniPlayerPage!.waitForLoadState('domcontentloaded');
-  // MiniPlayer polls state every 1s — wait for several sync cycles
-  await miniPlayerPage!.waitForTimeout(5000);
-
-  return miniPlayerPage!;
+  return miniPlayerPage;
 }
 
 test.describe('MiniPlayer Synchronization', () => {
   test('MiniPlayer position sync', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(2000);
-
-    // Verify it's playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Open MiniPlayer and wait for state sync
     const miniPlayerPage = await openMiniPlayer(app, page);
 
-    // Wait additional time for position to advance and sync
-    await page.waitForTimeout(3000);
-
     // Verify MiniPlayer has received the track
-    const miniTrackTitle = await miniPlayerPage.evaluate(() => {
-      const h6 = document.querySelector('.MuiTypography-h6');
-      return h6?.textContent || '---';
-    });
-    console.log(`MiniPlayer track title: ${miniTrackTitle}`);
+    const miniTrackTitle = await miniPlayerPage
+      .locator('.MuiTypography-h6')
+      .textContent();
     expect(miniTrackTitle).not.toBe('---');
 
-    // Check position from main window using the PositionDisplay Slider
-    const mainSliderValue = await page.evaluate(() => {
-      const inputs = Array.from(
-        document.querySelectorAll('input[type="range"]'),
-      );
-      const seekInput = inputs.find((input) => {
-        const val = parseFloat((input as HTMLInputElement).value);
-        const max = parseFloat((input as HTMLInputElement).max);
-        return val > 0 && max > 0 && max <= 15000;
-      });
-      return seekInput ? parseFloat((seekInput as HTMLInputElement).value) : 0;
-    });
-
-    console.log(`Main slider value: ${mainSliderValue}`);
-    expect(mainSliderValue).toBeGreaterThan(0);
+    // Check position from main window using the PositionDisplay Slider.
+    // Poll: the value only becomes non-zero once playback has advanced.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const inputs = Array.from(
+              document.querySelectorAll('input[type="range"]'),
+            );
+            const seekInput = inputs.find((input) => {
+              const val = parseFloat((input as HTMLInputElement).value);
+              const max = parseFloat((input as HTMLInputElement).max);
+              return val > 0 && max > 0 && max <= 15000;
+            });
+            return seekInput
+              ? parseFloat((seekInput as HTMLInputElement).value)
+              : 0;
+          }),
+        { timeout: 20000 },
+      )
+      .toBeGreaterThan(0);
 
     // MiniPlayer should show captions with position info
-    const miniCaptions = await miniPlayerPage.evaluate(() => {
-      return Array.from(document.querySelectorAll('.MuiTypography-caption'))
-        .map((el) => el.textContent)
-        .filter(Boolean);
-    });
-    console.log(`MiniPlayer captions: ${JSON.stringify(miniCaptions)}`);
-    expect(miniCaptions.length).toBeGreaterThanOrEqual(2);
+    await expect
+      .poll(
+        () =>
+          miniPlayerPage.evaluate(
+            () =>
+              Array.from(document.querySelectorAll('.MuiTypography-caption'))
+                .map((el) => el.textContent)
+                .filter(Boolean).length,
+          ),
+        { timeout: 20000 },
+      )
+      .toBeGreaterThanOrEqual(2);
 
     await closeMiniPlayerAndApp(page, app);
   });
@@ -106,26 +109,20 @@ test.describe('MiniPlayer Synchronization', () => {
   test('MiniPlayer play/pause sync', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Open MiniPlayer and wait for state sync
     const miniPlayerPage = await openMiniPlayer(app, page);
 
     // Verify main window is playing
-    const mainPauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(mainPauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPlaying(page);
 
     // Verify MiniPlayer received the track
-    const miniTrackTitle = await miniPlayerPage.evaluate(() => {
-      const h6 = document.querySelector('.MuiTypography-h6');
-      return h6?.textContent || '---';
-    });
+    const miniTrackTitle = await miniPlayerPage
+      .locator('.MuiTypography-h6')
+      .textContent();
     expect(miniTrackTitle).not.toBe('---');
 
     // Check if MiniPlayer has a PauseIcon (playing state)
@@ -136,13 +133,7 @@ test.describe('MiniPlayer Synchronization', () => {
 
     // Pause in main window
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(2000);
-
-    // Verify main window paused
-    const mainPlayIcon = page.locator(
-      'button svg[data-testid="PlayArrowIcon"]',
-    );
-    await expect(mainPlayIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPaused(page);
 
     // Verify MiniPlayer also paused
     const miniPlayIcon = miniPlayerPage.locator(
@@ -154,16 +145,12 @@ test.describe('MiniPlayer Synchronization', () => {
     await miniPlayerPage
       .locator('button:has(svg[data-testid="PlayArrowIcon"])')
       .click();
-    await page.waitForTimeout(2000);
 
     // Verify both playing again
-    const mainPauseAgain = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(mainPauseAgain).toBeVisible({ timeout: 5000 });
-
-    const miniPauseAgain = miniPlayerPage.locator(
-      'button svg[data-testid="PauseIcon"]',
-    );
-    await expect(miniPauseAgain).toBeVisible({ timeout: 15000 });
+    await TestHelpers.waitForPlaying(page);
+    await expect(
+      miniPlayerPage.locator('button svg[data-testid="PauseIcon"]'),
+    ).toBeVisible({ timeout: 15000 });
 
     await closeMiniPlayerAndApp(page, app);
   });

--- a/e2e/new-user.spec.ts
+++ b/e2e/new-user.spec.ts
@@ -5,9 +5,6 @@ test.describe('New User Experience', () => {
   test('should display empty library message for brand new user', async () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
     // Check that the empty library message is displayed
     const emptyLibraryMessage = await page.getByText('Your library is empty');
     expect(await emptyLibraryMessage.isVisible()).toBe(true);
@@ -27,9 +24,6 @@ test.describe('New User Experience', () => {
   test('should have default smart playlists for brand new user', async () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
     // Check for the default smart playlists in the sidebar
     // These should be created automatically by the app's self-healing mechanism
     const recentlyAddedPlaylist = await page.getByText('Recently Added');
@@ -42,17 +36,13 @@ test.describe('New User Experience', () => {
     expect(await mostPlayedPlaylist.isVisible()).toBe(true);
 
     // Verify there are exactly 3 playlists (the smart playlists)
-    const playlistItems = await page.locator('[data-playlist-id]').count();
-    expect(playlistItems).toBe(3);
+    await expect(page.locator('[data-playlist-id]')).toHaveCount(3);
 
     await TestHelpers.closeApp(app);
   });
 
   test('should display basic UI components for brand new user', async () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
-
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
 
     // 1. Check for sidebar/drawer
     const drawer = await page.locator('.MuiDrawer-root').isVisible();
@@ -91,9 +81,6 @@ test.describe('New User Experience', () => {
 
   test('should have no tracks loaded for brand new user', async () => {
     const { app, page } = await TestHelpers.launchAppAsBrandNewUser();
-
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
 
     // Verify there are no track rows in the library
     const trackRows = await page.locator('[data-track-id]').count();

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -20,9 +20,11 @@ test.describe('Notification System', () => {
     const trackRow = page.locator('[data-track-id]').first();
     await trackRow.click({ button: 'right' });
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     // Badge should no longer have the invisible class
     await expect(badge).not.toHaveClass(/MuiBadge-invisible/);
@@ -40,9 +42,11 @@ test.describe('Notification System', () => {
 
     // Click "Add to Playlist" then select "Test Playlist"
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     // Panel should auto-expand with the notification
     const panel = page.locator('[data-testid="notification-panel"]');
@@ -112,9 +116,11 @@ test.describe('Notification System', () => {
     const trackRow = page.locator('[data-track-id]').first();
     await trackRow.click({ button: 'right' });
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
@@ -125,10 +131,7 @@ test.describe('Notification System', () => {
       .first();
     await dismissButton.click();
 
-    // Wait for fade-out animation
-    await page.waitForTimeout(300);
-
-    // No items should remain
+    // No items should remain once the fade-out finishes
     const items = panel.locator('[data-testid="notification-item"]');
     await expect(items).toHaveCount(0);
 
@@ -187,9 +190,11 @@ test.describe('Notification System', () => {
     const trackRow = page.locator('[data-track-id]').first();
     await trackRow.click({ button: 'right' });
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
@@ -213,9 +218,11 @@ test.describe('Notification System', () => {
     const trackRow = page.locator('[data-track-id]').first();
     await trackRow.click({ button: 'right' });
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });
@@ -235,9 +242,11 @@ test.describe('Notification System', () => {
     const trackRow = page.locator('[data-track-id]').first();
     await trackRow.click({ button: 'right' });
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1000);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
 
     const panel = page.locator('[data-testid="notification-panel"]');
     await panel.waitFor({ state: 'visible', timeout: 5000 });

--- a/e2e/playback-autoplay-skip.spec.ts
+++ b/e2e/playback-autoplay-skip.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
@@ -35,27 +34,40 @@ async function readPlayerState(page: import('@playwright/test').Page) {
   );
 }
 
+/**
+ * Wait for a single auto-advance away from `fromFilePath` and return the
+ * settled state. Fixture tracks are ~10s, so this resolves the moment
+ * Gapless-5 hands off instead of sleeping past the end of the track.
+ */
+async function waitForAutoAdvance(
+  page: import('@playwright/test').Page,
+  fromFilePath: string | null,
+): Promise<PlayerState> {
+  await expect
+    .poll(async () => (await readPlayerState(page)).storeCurrentTrackFilePath, {
+      timeout: 30000,
+    })
+    .not.toBe(fromFilePath);
+  return readPlayerState(page);
+}
+
 test.describe('Autoplay → Skip regression', () => {
   test('after 1 autoplay, skip plays the next track (not the restarted current)', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    await page.locator('[data-track-id]').nth(0).dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').nth(0),
+    );
 
     const stateAfterPlay1 = await readPlayerState(page);
     const track1FilePath = stateAfterPlay1.storeCurrentTrackFilePath;
     expect(track1FilePath).toBeTruthy();
 
-    // Let track 1 auto-advance to track 2 (fixtures are ~10s)
-    await page.waitForTimeout(12000);
-
-    const stateAfterAutoplay = await readPlayerState(page);
+    // Let track 1 auto-advance to track 2
+    const stateAfterAutoplay = await waitForAutoAdvance(page, track1FilePath);
     const track2FilePath = stateAfterAutoplay.storeCurrentTrackFilePath;
     expect(track2FilePath).toBeTruthy();
-    expect(track2FilePath).not.toBe(track1FilePath);
 
     // Gapless-5 should actually be playing track 2 (the store's view)
     expect(stateAfterAutoplay.playerCurrentFilePath).toBe(track2FilePath);
@@ -67,15 +79,19 @@ test.describe('Autoplay → Skip regression', () => {
 
     // Hit skip — Gapless-5 should now play track 3.
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1500);
 
-    const stateAfterSkip = await readPlayerState(page);
-
-    // Both store and player should agree on track 3
-    expect(stateAfterSkip.storeCurrentTrackFilePath).toBe(track3FilePath);
-    // THIS is the bug-catching assertion: the player must actually be
-    // playing track 3, not a restarted track 2.
-    expect(stateAfterSkip.playerCurrentFilePath).toBe(track3FilePath);
+    // Both store and player must land on track 3. Polling on the player's own
+    // view is the bug-catching assertion: it must actually be playing track 3,
+    // not a restarted track 2.
+    await expect
+      .poll(async () => {
+        const state = await readPlayerState(page);
+        return {
+          store: state.storeCurrentTrackFilePath,
+          player: state.playerCurrentFilePath,
+        };
+      })
+      .toEqual({ store: track3FilePath, player: track3FilePath });
 
     await TestHelpers.closeApp(app);
   });
@@ -83,16 +99,21 @@ test.describe('Autoplay → Skip regression', () => {
   test('after 2 autoplays, skip plays the next track (no track skipped)', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').nth(0),
+    );
 
-    await page.locator('[data-track-id]').nth(0).dblclick();
-    await page.waitForTimeout(1000);
+    const track1FilePath = (await readPlayerState(page))
+      .storeCurrentTrackFilePath;
 
     // Let track 1 → track 2 → track 3 autoplay (2 auto-advances)
-    await page.waitForTimeout(24000);
+    const afterFirst = await waitForAutoAdvance(page, track1FilePath);
+    const stateAfterAutoplay = await waitForAutoAdvance(
+      page,
+      afterFirst.storeCurrentTrackFilePath,
+    );
 
-    const stateAfterAutoplay = await readPlayerState(page);
     const track3FilePath = stateAfterAutoplay.storeCurrentTrackFilePath;
     const track4FilePath = stateAfterAutoplay.storePreloadedTrackFilePath;
     expect(track3FilePath).toBeTruthy();
@@ -103,12 +124,16 @@ test.describe('Autoplay → Skip regression', () => {
 
     // Skip — Gapless-5 should now play track 4.
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1500);
 
-    const stateAfterSkip = await readPlayerState(page);
-    expect(stateAfterSkip.storeCurrentTrackFilePath).toBe(track4FilePath);
-    // Bug-catching assertion:
-    expect(stateAfterSkip.playerCurrentFilePath).toBe(track4FilePath);
+    await expect
+      .poll(async () => {
+        const state = await readPlayerState(page);
+        return {
+          store: state.storeCurrentTrackFilePath,
+          player: state.playerCurrentFilePath,
+        };
+      })
+      .toEqual({ store: track4FilePath, player: track4FilePath });
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playback-autoplay.spec.ts
+++ b/e2e/playback-autoplay.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
@@ -6,25 +5,16 @@ test.describe('Playback Auto-play Behaviors', () => {
   test('double-click song causes autoplay', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the first track row to play it
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    const firstTrackTitle = await firstTrack
+      .locator('td')
+      .first()
+      .textContent();
+    await TestHelpers.startPlayback(page, firstTrack);
 
-    // Verify PauseIcon is visible (meaning it's actively playing)
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify the player bar shows the track title
-    // The first track is test-large-001 "Dream of Love" by "Aurora Synth"
-    const pageContent = await page.content();
-    expect(
-      pageContent.includes('Dream of Love') ||
-        pageContent.includes('Aurora Synth'),
-    ).toBe(true);
+    // Verify the player bar shows the track we double-clicked
+    await TestHelpers.waitForNowPlaying(page, firstTrackTitle!.trim());
 
     await TestHelpers.closeApp(app);
   });
@@ -32,36 +22,20 @@ test.describe('Playback Auto-play Behaviors', () => {
   test('song completes → next auto-plays (not paused)', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, firstTrack);
 
-    // Verify it's playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Wait for 10-second track to finish (~12s to be safe)
-    await page.waitForTimeout(12000);
-
-    // Verify PauseIcon is still visible (still playing, not paused)
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify the displayed track has changed (different title in the player)
-    // Get the current track title from the player area
+    // The fixture tracks are ~10s long. Rather than sleeping past the end,
+    // wait for the roll-over itself: the second row becomes the playing row
+    // the instant Gapless-5 hands off.
     const secondTrack = page.locator('[data-track-id]').nth(1);
-    const secondTrackTitle = await secondTrack
-      .locator('td')
-      .first()
-      .textContent();
+    await expect(secondTrack).toHaveClass(/vt-row-playing/, {
+      timeout: 30000,
+    });
 
-    // The page should now contain the second track's title in the player area
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    // Verify it kept playing across the transition rather than pausing.
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -69,34 +43,17 @@ test.describe('Playback Auto-play Behaviors', () => {
   test('skip while playing → next auto-plays', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Click skip-next button
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify PauseIcon is still visible (still playing after skip)
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify track changed - the second track title should now appear in the player
+    // Track changed to the second row, and playback continued.
     const secondTrack = page.locator('[data-track-id]').nth(1);
-    const secondTrackTitle = await secondTrack
-      .locator('td')
-      .first()
-      .textContent();
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    await expect(secondTrack).toHaveClass(/vt-row-playing/);
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -104,38 +61,21 @@ test.describe('Playback Auto-play Behaviors', () => {
   test('skip while paused → next stays paused', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Click pause
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
-
-    // Verify PlayArrowIcon visible (paused)
-    let playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPaused(page);
 
     // Click skip-next button
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify PlayArrowIcon is still visible (still paused after skip)
-    playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify track changed - the second track title should now appear in the player
+    // Track changed to the second row, and it stayed paused.
     const secondTrack = page.locator('[data-track-id]').nth(1);
-    const secondTrackTitle = await secondTrack
-      .locator('td')
-      .first()
-      .textContent();
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    await expect(secondTrack).toHaveClass(/vt-row-playing/);
+    await TestHelpers.waitForPaused(page);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playback-modes.spec.ts
+++ b/e2e/playback-modes.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-plusplus, no-console, no-await-in-loop */
+/* eslint-disable no-plusplus, no-await-in-loop */
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
@@ -6,53 +6,41 @@ test.describe('Playback Modes', () => {
   test('repeat track mode replays the same song', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
     const firstTrackTitle = await firstTrack
       .locator('td')
       .first()
       .textContent();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Enable repeat-track mode by clicking repeat button
     // Cycle is: off → track → all → off
     // Click once for "track" (data-repeat-mode should become "track")
     const repeatButton = page.locator('[data-testid="repeat-button"]');
     await repeatButton.click();
-    await page.waitForTimeout(500);
 
     // Verify the button is now in track-repeat mode
-    await expect(repeatButton).toHaveAttribute('data-repeat-mode', 'track', {
-      timeout: 5000,
-    });
+    await expect(repeatButton).toHaveAttribute('data-repeat-mode', 'track');
 
-    // Wait for 10-second track to finish (~12s to be safe)
-    await page.waitForTimeout(12000);
+    // Fixture tracks are 10s. Run to the tail of the track, then wait for the
+    // clock to wrap back to the start — that wrap *is* the repeat, so we don't
+    // have to sleep past a guessed end time.
+    await TestHelpers.waitForElapsedAtLeast(page, 9);
+    await expect(
+      page.locator('[data-testid="player-elapsed-time"]'),
+    ).toHaveText('0:00', { timeout: 15000 });
 
     // Verify the SAME track is still playing (not advanced to next)
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // The page should still show the first track's title in the player
-    const pageContent = await page.content();
-    expect(pageContent).toContain(firstTrackTitle!.trim());
+    await TestHelpers.waitForPlaying(page);
+    await TestHelpers.waitForNowPlaying(page, firstTrackTitle!.trim());
+    await expect(firstTrack).toHaveClass(/vt-row-playing/);
 
     await TestHelpers.closeApp(app);
   });
 
   test('shuffle mode produces non-sequential track order', async () => {
     const { app, page } = await TestHelpers.launchApp();
-
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
     // Get first few track titles in sequential order for comparison
     const sequentialTitles: string[] = [];
@@ -61,52 +49,30 @@ test.describe('Playback Modes', () => {
       const title = await row.locator('td').first().textContent();
       sequentialTitles.push(title!.trim());
     }
-    console.log('Sequential order:', sequentialTitles);
 
     // Double-click first track to start playback
-    await page.locator('[data-track-id]').first().dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
 
     // Enable shuffle mode by clicking the shuffle button
     const shuffleButton = page.locator('[data-testid="shuffle-button"]');
     await shuffleButton.click();
-    await page.waitForTimeout(500);
 
     // Verify the button is now in shuffle-on mode
-    await expect(shuffleButton).toHaveAttribute('data-shuffle-mode', 'on', {
-      timeout: 5000,
-    });
+    await expect(shuffleButton).toHaveAttribute('data-shuffle-mode', 'on');
 
-    // Skip through several tracks and record what plays
+    // Skip through several tracks and record what plays. Each skip is followed
+    // by a wait for the now-playing title to actually change, so the recorded
+    // sequence is never a stale read.
     const shuffledTitles: string[] = [];
     for (let i = 0; i < 5; i++) {
+      const previousTitle = await TestHelpers.nowPlayingTitle(page);
       await page.locator('[data-testid="skip-next-button"]').click();
-      await page.waitForTimeout(1000);
-
-      // Get the title from the player area by checking page content
-      // Read the track title from the first visible typography in the player
-      const currentTitle = await page.evaluate(() => {
-        // The player shows the track title in a Typography component
-        // Look for the track info section in the player bar
-        const papers = document.querySelectorAll('.MuiPaper-root');
-        const playerPaper = papers[papers.length - 1];
-        if (!playerPaper) return '';
-        const typographies = Array.from(
-          playerPaper.querySelectorAll('.MuiTypography-body1'),
-        );
-        const match = typographies.find((t) => {
-          const text = t.textContent?.trim();
-          return text && text !== '---' && text.length > 0;
-        });
-        return match?.textContent?.trim() || '';
-      });
-      shuffledTitles.push(currentTitle);
+      await TestHelpers.waitForNowPlayingChange(page, previousTitle);
+      shuffledTitles.push(await TestHelpers.nowPlayingTitle(page));
     }
-    console.log('Shuffled order:', shuffledTitles);
 
     // With 200 tracks and shuffle enabled, the probability of 5 consecutive
     // tracks matching sequential order is negligible.
@@ -131,70 +97,59 @@ test.describe('Playback Modes', () => {
   test('playlist track management — add track and verify', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Navigate to library view
     await page.click('[data-testid="nav-library"]');
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTracks(page);
 
     // Find a track not already in "Test Playlist" (playlist-1 has 001, 002, 003)
     // Search for a specific track to ensure it's visible
     const searchToggle = page.locator('[aria-label="Show/Hide search"]');
     if (await searchToggle.isVisible()) {
       await searchToggle.click();
-      await page.waitForTimeout(500);
     }
 
-    let searchInput = page.locator('input[type="search"]').first();
-    if (!(await searchInput.isVisible())) {
-      searchInput = page.locator('input[placeholder*="Search"]').first();
-    }
-    if (!(await searchInput.isVisible())) {
-      searchInput = page.locator('.MuiInputBase-input').first();
-    }
+    const searchInput = page.locator('[data-testid="search-input"]');
+    await searchInput.waitFor({ state: 'visible' });
 
     // Search for track test-large-005 which is not in the fixture playlist
     await searchInput.fill('Classical Masters');
-    await page.waitForTimeout(1000);
 
     // Right-click the track to open context menu
     const trackRow = page.locator('[data-track-id="test-large-005"]');
-    await trackRow.waitFor({ state: 'visible', timeout: 5000 });
+    await trackRow.waitFor({ state: 'visible' });
     await trackRow.click({ button: 'right' });
 
     // Click "Add to Playlist" in context menu
     await page.click('[data-testid="add-to-playlist-menu-item"]');
-    await page.waitForTimeout(500);
 
     // Select "Test Playlist" (playlist-1)
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-    await page.waitForTimeout(1500);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await playlistOption.waitFor({ state: 'visible' });
+    await playlistOption.click();
+    await expect(playlistOption).toBeHidden();
 
     // Clear search
-    const searchInputToClear = page.locator('input[type="search"]').first();
-    if (await searchInputToClear.isVisible()) {
-      await searchInputToClear.clear();
-      await page.waitForTimeout(500);
-    }
+    await searchInput.clear();
+    await TestHelpers.waitForTracks(page);
 
     // Re-open sidebar (it auto-closes after navigation)
     const sidebarToggle = page.locator('[data-testid="sidebar-toggle"]');
     if (await sidebarToggle.isVisible()) {
       await sidebarToggle.click();
-      await page.waitForTimeout(500);
     }
 
     // Navigate to "Test Playlist"
-    await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(500);
+    const playlistLink = page.locator('[data-playlist-id="playlist-1"]');
+    await playlistLink.waitFor({ state: 'visible' });
+    await playlistLink.click();
 
     // Verify the track is in the playlist (originally 3 tracks, now 4)
-    const addedTrack = page.locator('[data-track-id="test-large-005"]');
-    await addedTrack.waitFor({ state: 'visible', timeout: 5000 });
-
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBe(4);
+    await expect(
+      page.locator('[data-track-id="test-large-005"]'),
+    ).toBeVisible();
+    await TestHelpers.waitForTrackCount(page, 4);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playback-rapid-skip.spec.ts
+++ b/e2e/playback-rapid-skip.spec.ts
@@ -1,6 +1,33 @@
-/* eslint-disable no-plusplus, no-await-in-loop */
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/** Fire N clicks at a transport button in one synchronous burst. */
+async function burstClick(page: Page, testId: string, times: number) {
+  await page.evaluate(
+    ({ id, count }) => {
+      const btn = document.querySelector(`[data-testid="${id}"]`);
+      if (!btn) return;
+      for (let i = 0; i < count; i += 1) {
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    },
+    { id: testId, count: times },
+  );
+}
+
+/**
+ * Assert the elapsed readout moves. Polls the player's own clock rather than
+ * sleeping a fixed few seconds — it returns on the first tick that differs.
+ */
+async function expectElapsedToAdvance(page: Page) {
+  const elapsed = page.locator('[data-testid="player-elapsed-time"]');
+  const before = (await elapsed.textContent())?.trim() ?? '';
+  await expect
+    .poll(async () => (await elapsed.textContent())?.trim() ?? '', {
+      timeout: 15000,
+    })
+    .not.toBe(before);
+}
 
 test.describe('Rapid Skip Bug Regression', () => {
   // The optimistic-next/prev feature (issue #72) requires that rapid clicks
@@ -8,9 +35,6 @@ test.describe('Rapid Skip Bug Regression', () => {
   // 10 songs forward — not 1 or 2.
   test('rapid next x10 lands on the song 10 positions forward', async () => {
     const { app, page } = await TestHelpers.launchApp();
-
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
     // Read the title of the song we expect to land on (start + 10 = index 10).
     const expectedLandingTitle = await page
@@ -21,40 +45,30 @@ test.describe('Rapid Skip Bug Regression', () => {
       .textContent();
 
     // Double-click the first track to start playback.
-    await page.locator('[data-track-id]').first().dblclick();
-    await page.waitForTimeout(1000);
-
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
 
     // Fire 10 rapid clicks via DOM dispatching — tight synchronous loop so
     // no React state update can settle between them.
-    await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="skip-next-button"]');
-      if (!btn) return;
-      for (let i = 0; i < 10; i++) {
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-    });
+    await burstClick(page, 'skip-next-button', 10);
 
     // Assert the player's now-playing title matches the expected landing
     // track. Using a scoped locator (not pageContent) avoids false positives
     // from the track list, which also renders the same title.
     await expect(
       page.locator('[data-testid="now-playing-title"]'),
-    ).toContainText(expectedLandingTitle!.trim(), { timeout: 5000 });
+    ).toContainText(expectedLandingTitle!.trim());
 
     // And that audio is actively advancing (not stuck at 0:00).
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
 
   test('rapid previous x5 lands on the song 5 positions back', async () => {
     const { app, page } = await TestHelpers.launchApp();
-
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
 
     // Expected landing: start from track index 10, go back 5 = index 5.
     const expectedLandingTitle = await page
@@ -65,30 +79,21 @@ test.describe('Rapid Skip Bug Regression', () => {
       .textContent();
 
     // Start on the 11th track (index 10).
-    await page.locator('[data-track-id]').nth(10).dblclick();
-    await page.waitForTimeout(1000);
-
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').nth(10),
+    );
 
     // Fire 5 rapid prev clicks. Each one should walk back one index since
     // position has just reset to 0 on each skip (position > 3 restart only
     // applies on the very first click, and since we just started, position
     // is ~0 anyway so every click walks back).
-    await page.evaluate(() => {
-      const btn = document.querySelector(
-        '[data-testid="skip-previous-button"]',
-      );
-      if (!btn) return;
-      for (let i = 0; i < 5; i++) {
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-    });
+    await burstClick(page, 'skip-previous-button', 5);
 
     await expect(
       page.locator('[data-testid="now-playing-title"]'),
-    ).toContainText(expectedLandingTitle!.trim(), { timeout: 5000 });
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    ).toContainText(expectedLandingTitle!.trim());
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -96,48 +101,25 @@ test.describe('Rapid Skip Bug Regression', () => {
   test('rapid next clicks while playing — playback state stays in sync', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the first track to start playback
-    const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
 
     // Fire 5 rapid clicks via DOM dispatching (no await between clicks)
-    await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="skip-next-button"]');
-      if (!btn) return;
-      for (let i = 0; i < 5; i++) {
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-    });
+    await burstClick(page, 'skip-next-button', 5);
 
-    // Wait for things to settle
-    await page.waitForTimeout(2000);
+    // Settling signal: the 5th track ahead becomes the playing row.
+    await expect(page.locator('[data-track-id]').nth(5)).toHaveClass(
+      /vt-row-playing/,
+    );
 
     // The player UI should show PauseIcon (meaning it's playing)
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPlaying(page);
 
-    // Grab the elapsed time, wait, and verify it advanced (audio is actually playing)
-    const getElapsedTime = () =>
-      page.evaluate(() => {
-        const el = document.querySelector(
-          '[data-testid="player-elapsed-time"]',
-        );
-        return el?.textContent?.trim() || '';
-      });
-
-    const time1 = await getElapsedTime();
-    await page.waitForTimeout(3000);
-    const time2 = await getElapsedTime();
-
-    // If playback is truly active, the elapsed time should have advanced
-    expect(time2).not.toBe(time1);
+    // And the audio clock should actually be moving.
+    await expectElapsedToAdvance(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -145,49 +127,25 @@ test.describe('Rapid Skip Bug Regression', () => {
   test('rapid previous clicks while playing — playback state stays in sync', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Start on the 6th track so we have room to go back
-    const sixthTrack = page.locator('[data-track-id]').nth(5);
-    await sixthTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').nth(5),
+    );
 
     // Fire 5 rapid clicks via DOM dispatching (no await between clicks)
-    await page.evaluate(() => {
-      const btn = document.querySelector(
-        '[data-testid="skip-previous-button"]',
-      );
-      if (!btn) return;
-      for (let i = 0; i < 5; i++) {
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-    });
+    await burstClick(page, 'skip-previous-button', 5);
 
-    // Wait for things to settle
-    await page.waitForTimeout(2000);
+    // Settling signal: 5 back from index 5 is the first row.
+    await expect(page.locator('[data-track-id]').first()).toHaveClass(
+      /vt-row-playing/,
+    );
 
     // Should still show playing state
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPlaying(page);
 
     // Verify audio is actually advancing
-    const getElapsedTime = () =>
-      page.evaluate(() => {
-        const el = document.querySelector(
-          '[data-testid="player-elapsed-time"]',
-        );
-        return el?.textContent?.trim() || '';
-      });
-
-    const time1 = await getElapsedTime();
-    await page.waitForTimeout(3000);
-    const time2 = await getElapsedTime();
-
-    expect(time2).not.toBe(time1);
+    await expectElapsedToAdvance(page);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playback-skip-disable.spec.ts
+++ b/e2e/playback-skip-disable.spec.ts
@@ -5,15 +5,14 @@ test.describe('Skip Button Disable States (issue #72)', () => {
   test('next stays enabled with 200+ tracks ahead', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Play the first track — plenty of songs available ahead.
-    await page.locator('[data-track-id]').first().dblclick();
-    await page.waitForTimeout(500);
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
 
     const nextBtn = page.locator('[data-testid="skip-next-button"]');
-    await expect(nextBtn).toBeEnabled({ timeout: 3000 });
+    await expect(nextBtn).toBeEnabled();
 
     await TestHelpers.closeApp(app);
   });
@@ -21,31 +20,27 @@ test.describe('Skip Button Disable States (issue #72)', () => {
   test('previous at first track (no prev target) restarts the song instead of being disabled', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Play first track (defaults: repeat=off, shuffle=off) then pause so
     // position stays frozen well under 3s — this is the window where prev
     // used to be disabled (no prev target and the >3s restart hatch hadn't
     // opened yet). Pausing also prevents toBeEnabled's poll window from
     // masking a real failure by waiting for position to cross 3s.
-    await page.locator('[data-track-id]').first().dblclick();
-    await page.waitForTimeout(500);
-    const firstTrackTitle = await page
-      .locator('[data-testid="now-playing-title"]')
-      .textContent();
+    await TestHelpers.startPlayback(
+      page,
+      page.locator('[data-track-id]').first(),
+    );
+    const firstTrackTitle = await TestHelpers.nowPlayingTitle(page);
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(300);
+    await TestHelpers.waitForPaused(page);
 
     // On old behavior this is disabled; test should fail here against main.
     const prevBtn = page.locator('[data-testid="skip-previous-button"]');
     await expect(prevBtn).toBeEnabled({ timeout: 1500 });
     await prevBtn.click();
-    await page.waitForTimeout(500);
 
     // Same track (no navigation).
     await expect(page.locator('[data-testid="now-playing-title"]')).toHaveText(
-      firstTrackTitle!,
+      firstTrackTitle,
       { timeout: 1500 },
     );
 

--- a/e2e/playback-skip.spec.ts
+++ b/e2e/playback-skip.spec.ts
@@ -6,40 +6,23 @@ test.describe('Playback Skip Behaviors', () => {
   test('skip next multiple times while playing — stays playing', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, firstTrack);
 
-    // Verify playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Get the 4th track title for verification
-    const fourthTrack = page.locator('[data-track-id]').nth(3);
-    const fourthTrackTitle = await fourthTrack
-      .locator('td')
-      .first()
-      .textContent();
-
-    // Skip next 3 times rapidly
+    // Skip next 3 times, waiting for each transition to land so the clicks
+    // aren't racing the store.
     for (let i = 0; i < 3; i++) {
+      const previousTitle = await TestHelpers.nowPlayingTitle(page);
       await page.locator('[data-testid="skip-next-button"]').click();
-      await page.waitForTimeout(500);
+      await TestHelpers.waitForNowPlayingChange(page, previousTitle);
     }
 
-    await page.waitForTimeout(500);
-
-    // Verify still playing (PauseIcon visible)
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify we're on the 4th track
-    const pageContent = await page.content();
-    expect(pageContent).toContain(fourthTrackTitle!.trim());
+    // Verify still playing, and that we landed on the 4th track
+    await TestHelpers.waitForPlaying(page);
+    await expect(page.locator('[data-track-id]').nth(3)).toHaveClass(
+      /vt-row-playing/,
+    );
 
     await TestHelpers.closeApp(app);
   });
@@ -47,35 +30,18 @@ test.describe('Playback Skip Behaviors', () => {
   test('skip previous while playing — stays playing', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the third track to start playback
     const thirdTrack = page.locator('[data-track-id]').nth(2);
-    const secondTrackTitle = await page
-      .locator('[data-track-id]')
-      .nth(1)
-      .locator('td')
-      .first()
-      .textContent();
-    await thirdTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(page, thirdTrack);
 
     // Skip previous (within 3 seconds so it goes to previous track)
     await page.locator('[data-testid="skip-previous-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify still playing
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify we're on the second track
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    // Verify still playing, now on the second track
+    await expect(page.locator('[data-track-id]').nth(1)).toHaveClass(
+      /vt-row-playing/,
+    );
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -83,39 +49,22 @@ test.describe('Playback Skip Behaviors', () => {
   test('skip next then previous — returns to original track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
-    // Get the second track title
-    const secondTrack = page.locator('[data-track-id]').nth(1);
-    const secondTrackTitle = await secondTrack
-      .locator('td')
-      .first()
-      .textContent();
-
     // Double-click the second track to start playback
-    await secondTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify playing
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    const secondTrack = page.locator('[data-track-id]').nth(1);
+    await TestHelpers.startPlayback(page, secondTrack);
+    const secondTrackTitle = await TestHelpers.nowPlayingTitle(page);
 
     // Skip next
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForNowPlayingChange(page, secondTrackTitle);
 
     // Skip previous (within 3 seconds)
     await page.locator('[data-testid="skip-previous-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify still playing
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify we're back on the second track
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    // Verify still playing and back on the second track
+    await TestHelpers.waitForNowPlaying(page, secondTrackTitle);
+    await expect(secondTrack).toHaveClass(/vt-row-playing/);
+    await TestHelpers.waitForPlaying(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -123,38 +72,22 @@ test.describe('Playback Skip Behaviors', () => {
   test('skip next while paused — stays paused on correct track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the first track to start playback
     const firstTrack = page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Pause
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
-
-    // Verify paused (PlayArrowIcon visible)
-    let playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPaused(page);
 
     // Skip next
     await page.locator('[data-testid="skip-next-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify still paused
-    playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify we're on the second track
-    const secondTrack = page.locator('[data-track-id]').nth(1);
-    const secondTrackTitle = await secondTrack
-      .locator('td')
-      .first()
-      .textContent();
-    const pageContent = await page.content();
-    expect(pageContent).toContain(secondTrackTitle!.trim());
+    // Verify still paused, now on the second track
+    await expect(page.locator('[data-track-id]').nth(1)).toHaveClass(
+      /vt-row-playing/,
+    );
+    await TestHelpers.waitForPaused(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -162,38 +95,22 @@ test.describe('Playback Skip Behaviors', () => {
   test('skip previous while paused — stays paused on correct track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Double-click the second track to start playback
     const secondTrack = page.locator('[data-track-id]').nth(1);
-    await secondTrack.dblclick();
-    await page.waitForTimeout(1000);
+    await TestHelpers.startPlayback(page, secondTrack);
 
     // Pause
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
-
-    // Verify paused
-    let playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPaused(page);
 
     // Skip previous (within 3 seconds)
     await page.locator('[data-testid="skip-previous-button"]').click();
-    await page.waitForTimeout(1000);
 
-    // Verify still paused
-    playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
-
-    // Verify we're on the first track
-    const firstTrack = page.locator('[data-track-id]').first();
-    const firstTrackTitle = await firstTrack
-      .locator('td')
-      .first()
-      .textContent();
-    const pageContent = await page.content();
-    expect(pageContent).toContain(firstTrackTitle!.trim());
+    // Verify still paused, now on the first track
+    await expect(page.locator('[data-track-id]').first()).toHaveClass(
+      /vt-row-playing/,
+    );
+    await TestHelpers.waitForPaused(page);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playback.spec.ts
+++ b/e2e/playback.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-plusplus */
-/* eslint-disable no-await-in-loop */
-/* eslint-disable radix */
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
 
@@ -8,34 +5,21 @@ test.describe('Music Playback', () => {
   test('should play and pause songs', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load with fixture data
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
-
     // Get the first track from fixture data and double-click to play
-    const firstTrack = await page.locator('[data-track-id]').first();
-    await firstTrack.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify play icon changed to pause icon (song is playing)
-    let pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible();
+    const firstTrack = page.locator('[data-track-id]').first();
+    await TestHelpers.startPlayback(page, firstTrack);
 
     // Click the play/pause button to pause (find button containing the pause icon)
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
 
     // Verify pause icon changed to play icon (song is paused)
-    const playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible();
+    await expect(TestHelpers.playIcon(page)).toBeVisible();
 
     // Click the play/pause button to resume (find button containing the play icon)
     await page.locator('button:has(svg[data-testid="PlayArrowIcon"])').click();
-    await page.waitForTimeout(500);
 
     // Verify play icon changed back to pause icon (song is playing again)
-    pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible();
+    await expect(TestHelpers.pauseIcon(page)).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playcount-threshold.spec.ts
+++ b/e2e/playcount-threshold.spec.ts
@@ -1,6 +1,23 @@
 /* eslint-disable no-await-in-loop */
-import { test, expect } from '@playwright/test';
+import { test, expect, Locator, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/** Index of the "Plays" column in the header row. */
+async function playsColumnIndex(page: Page): Promise<number> {
+  const headers = page.locator('thead th');
+  const headerCount = await headers.count();
+  for (let i = 0; i < headerCount; i += 1) {
+    const headerText = await headers.nth(i).textContent();
+    if (headerText?.includes('Plays')) return i;
+  }
+  return -1;
+}
+
+/** Parse a play-count cell, treating the '-' placeholder as zero. */
+async function readPlayCount(cell: Locator): Promise<number> {
+  const text = (await cell.textContent())?.trim() ?? '';
+  return text === '-' ? 0 : parseInt(text || '0', 10);
+}
 
 test.describe('Dynamic Playcount Threshold', () => {
   /**
@@ -9,88 +26,35 @@ test.describe('Dynamic Playcount Threshold', () => {
    * The dynamic threshold formula is: min(30 seconds, 20% of track duration)
    * For a 10-second track (our test fixtures), the threshold is 2 seconds.
    *
-   * This test:
-   * 1. Launches the app and waits for the library to load
-   * 2. Gets the first visible track
-   * 3. Notes the initial play count
-   * 4. Double-clicks to play the track
-   * 5. Waits for more than 20% of the track duration (>2 seconds for 10-second tracks)
-   * 6. Pauses the track
-   * 7. Verifies the play count has incremented by 1
+   * The increment is driven by playback position ticks, not by the pause, so
+   * the test polls the rendered cell until it lands rather than sleeping past
+   * an estimated threshold.
    */
   test('should increment play count after listening to more than 20% of track', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load with fixture data
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Get the first visible track
     const trackRow = page.locator('[data-track-id]').first();
-    await expect(trackRow).toBeVisible({ timeout: 5000 });
+    await expect(trackRow).toBeVisible();
 
-    // Get the track ID for later verification
-    const trackId = await trackRow.getAttribute('data-track-id');
-    expect(trackId).toBeTruthy();
+    const columnIndex = await playsColumnIndex(page);
+    expect(columnIndex).toBeGreaterThan(-1);
 
-    // Find the Plays column index by looking at the header row
-    const headers = page.locator('thead th');
-    const headerCount = await headers.count();
-    let playsColumnIndex = -1;
-
-    for (let i = 0; i < headerCount; i += 1) {
-      const headerText = await headers.nth(i).textContent();
-      if (headerText?.includes('Plays')) {
-        playsColumnIndex = i;
-        break;
-      }
-    }
-
-    expect(playsColumnIndex).toBeGreaterThan(-1);
-
-    // Get the initial play count value from the cell
-    const playCountCell = trackRow.locator('td').nth(playsColumnIndex);
-    const initialPlayCountText = await playCountCell.textContent();
-    const initialPlayCount =
-      initialPlayCountText?.trim() === '-'
-        ? 0
-        : parseInt(initialPlayCountText?.trim() || '0', 10);
+    const playCountCell = trackRow.locator('td').nth(columnIndex);
+    const initialPlayCount = await readPlayCount(playCountCell);
 
     // Double-click the track to start playing
-    await trackRow.dblclick();
+    await TestHelpers.startPlayback(page, trackRow);
 
-    // Wait for the track to start playing
-    await page.waitForTimeout(1000);
-
-    // Verify play icon changed to pause icon (song is playing)
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
-
-    // Wait for more than 20% of the track duration
-    // Track duration is 10 seconds, so 20% = 2 seconds
-    // We wait 4 seconds to be safe (accounting for any startup delays)
-    await page.waitForTimeout(4000);
+    // The threshold for a 10s fixture track is 2s of listening. Poll the cell
+    // until the increment lands instead of sleeping for a padded 4 seconds.
+    await expect
+      .poll(() => readPlayCount(playCountCell), { timeout: 30000 })
+      .toBe(initialPlayCount + 1);
 
     // Click the play/pause button to pause
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
-
-    // Verify pause icon changed to play icon (song is paused)
-    const playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
-
-    // Wait a moment for the UI to update with the new play count
-    await page.waitForTimeout(2000);
-
-    // Get the updated play count value
-    const updatedPlayCountText = await playCountCell.textContent();
-    const updatedPlayCount =
-      updatedPlayCountText?.trim() === '-'
-        ? 0
-        : parseInt(updatedPlayCountText?.trim() || '0', 10);
-
-    // Verify the play count has incremented by 1
-    expect(updatedPlayCount).toBe(initialPlayCount + 1);
+    await TestHelpers.waitForPaused(page);
 
     await TestHelpers.closeApp(app);
   });
@@ -98,84 +62,55 @@ test.describe('Dynamic Playcount Threshold', () => {
   /**
    * Test that the play count does NOT increment if we pause before the threshold.
    *
-   * This test:
-   * 1. Launches the app
-   * 2. Gets the first visible track
-   * 3. Notes the initial play count
-   * 4. Double-clicks to play the track
-   * 5. Pauses BEFORE 20% of the track duration (< 2 seconds for 10-second tracks)
-   * 6. Verifies the play count has NOT changed
+   * The threshold is 2 seconds for a 10-second fixture track, and the counting
+   * happens on playback position ticks — so once playback is paused below the
+   * threshold, no further increment can be queued.
    */
   test('should NOT increment play count if paused before 20% threshold', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load with fixture data
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Get the first visible track
     const trackRow = page.locator('[data-track-id]').first();
-    await expect(trackRow).toBeVisible({ timeout: 5000 });
+    await expect(trackRow).toBeVisible();
 
-    // Get the track ID for later verification
     const trackId = await trackRow.getAttribute('data-track-id');
     expect(trackId).toBeTruthy();
 
-    // Find the Plays column index by looking at the header row
-    const headers = page.locator('thead th');
-    const headerCount = await headers.count();
-    let playsColumnIndex = -1;
+    const columnIndex = await playsColumnIndex(page);
+    expect(columnIndex).toBeGreaterThan(-1);
 
-    for (let i = 0; i < headerCount; i += 1) {
-      const headerText = await headers.nth(i).textContent();
-      if (headerText?.includes('Plays')) {
-        playsColumnIndex = i;
-        break;
-      }
-    }
-
-    expect(playsColumnIndex).toBeGreaterThan(-1);
-
-    // Get the initial play count value from the cell
-    const playCountCell = trackRow.locator('td').nth(playsColumnIndex);
-    const initialPlayCountText = await playCountCell.textContent();
-    const initialPlayCount =
-      initialPlayCountText?.trim() === '-'
-        ? 0
-        : parseInt(initialPlayCountText?.trim() || '0', 10);
+    const playCountCell = trackRow.locator('td').nth(columnIndex);
+    const initialPlayCount = await readPlayCount(playCountCell);
 
     // Double-click the track to start playing
     await trackRow.dblclick();
 
-    // Wait just a brief moment for playback to start
-    await page.waitForTimeout(200);
-
     // Verify play icon changed to pause icon (song is playing)
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.waitForPlaying(page);
 
-    // IMMEDIATELY pause - don't wait any longer
-    // The threshold is 2 seconds, so we need to pause well before that
-    // Total time from dblclick to here should be < 1 second
+    // IMMEDIATELY pause — the threshold is 2 seconds, so everything from the
+    // dblclick to here must stay well inside that window. Retrying assertions
+    // (rather than sleeps) are what keep this path fast enough to be valid.
     await page.locator('button:has(svg[data-testid="PauseIcon"])').click();
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForPaused(page);
 
-    // Verify pause icon changed to play icon (song is paused)
-    const playIcon = page.locator('button svg[data-testid="PlayArrowIcon"]');
-    await expect(playIcon).toBeVisible({ timeout: 5000 });
+    // Sanity-check that we really did pause before the threshold.
+    const elapsed = await page
+      .locator('[data-testid="player-elapsed-time"]')
+      .textContent();
+    expect(elapsed?.trim()).toMatch(/^0:0[01]$/);
 
-    // Wait a moment for any potential UI updates
-    await page.waitForTimeout(2000);
+    // Read the persisted count straight from the database. The IPC round-trip
+    // is ordered behind any write the tracker could already have issued, so a
+    // matching value here means no increment happened — no settle sleep needed.
+    const persistedPlayCount = await page.evaluate(async (id) => {
+      const tracks = await (window as any).electron.tracks.getAll();
+      return tracks.find((t: { id: string }) => t.id === id)?.playCount ?? 0;
+    }, trackId);
+    expect(persistedPlayCount).toBe(initialPlayCount);
 
-    // Get the play count value - it should still be the same
-    const updatedPlayCountText = await playCountCell.textContent();
-    const updatedPlayCount =
-      updatedPlayCountText?.trim() === '-'
-        ? 0
-        : parseInt(updatedPlayCountText?.trim() || '0', 10);
-
-    // Verify the play count has NOT changed
-    expect(updatedPlayCount).toBe(initialPlayCount);
+    // And the rendered cell agrees.
+    expect(await readPlayCount(playCountCell)).toBe(initialPlayCount);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/playing-row-alignment.spec.ts
+++ b/e2e/playing-row-alignment.spec.ts
@@ -12,9 +12,6 @@ test.describe('Playing Row Column Alignment', () => {
   test('playing row cells should align with header columns', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // Find the Title column index from the header row
     const headers = page.locator('thead th');
     const headerCount = await headers.count();
@@ -45,18 +42,13 @@ test.describe('Playing Row Column Alignment', () => {
     expect(artistBeforePlay?.trim()).toBeTruthy();
 
     // Double-click to start playback
-    await firstRow.dblclick();
-    await page.waitForTimeout(1000);
-
-    // Verify the track is playing
-    const pauseIcon = page.locator('button svg[data-testid="PauseIcon"]');
-    await expect(pauseIcon).toBeVisible({ timeout: 5000 });
+    await TestHelpers.startPlayback(page, firstRow);
 
     // Locate the playing row (has vt-row-playing or vt-row-playing-selected class)
     const playingRow = page.locator(
       'tr.vt-row-playing, tr.vt-row-playing-selected',
     );
-    await expect(playingRow).toBeVisible({ timeout: 5000 });
+    await expect(playingRow).toBeVisible();
 
     // Read the playing row's cells at the same column indices
     const titleDuringPlay = await playingRow

--- a/e2e/playlists.spec.ts
+++ b/e2e/playlists.spec.ts
@@ -28,12 +28,7 @@ test.describe('Playlist Management', () => {
     });
 
     // Verify the playlist appears in the sidebar
-    // The playlist should be visible in the sidebar after creation
-    await page.waitForTimeout(1000); // Give time for the playlist to be created
-
-    // Check if the playlist exists by looking for its data-playlist-id attribute
-    const playlistElement = await page.locator('text=My Test Playlist').first();
-    await playlistElement.waitFor({ state: 'visible', timeout: 5000 });
+    await expect(page.locator('text=My Test Playlist').first()).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });
@@ -43,74 +38,55 @@ test.describe('Playlist Management', () => {
 
     // Navigate to library view
     await page.click('[data-testid="nav-library"]');
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTracks(page);
 
     // Right-click on a track that's NOT already in "Test Playlist"
     // Test Playlist has test-large-001, test-large-002, test-large-003
     // So we'll add test-large-004 (Electronic Pulse - Your Dream of Love)
     // First, search for the track since virtualization may hide it
-    const searchToggle = page.locator('[aria-label="Show/Hide search"]');
-    if (await searchToggle.isVisible()) {
-      await searchToggle.click();
-      await page.waitForTimeout(500);
-    }
-
-    // Search for the specific track - try multiple selectors
-    let searchInput = page.locator('input[type="search"]').first();
-    if (!(await searchInput.isVisible())) {
-      searchInput = page.locator('input[placeholder*="Search"]').first();
-    }
-    if (!(await searchInput.isVisible())) {
-      searchInput = page.locator('.MuiInputBase-input').first();
-    }
+    await page.locator('[aria-label="Show/Hide search"]').click();
+    const searchInput = page.locator('[data-testid="search-input"]');
+    await expect(searchInput).toBeVisible();
 
     await searchInput.fill('Electronic Pulse');
-    await page.waitForTimeout(1000);
 
     // Now the track should be visible
-    const trackRow = await page.locator('[data-track-id="test-large-004"]');
-    await trackRow.waitFor({ state: 'visible', timeout: 5000 });
+    const trackRow = page.locator('[data-track-id="test-large-004"]');
+    await expect(trackRow).toBeVisible();
     await trackRow.click({ button: 'right' });
 
     // Click "Add to Playlist" in the context menu
     await page.click('[data-testid="add-to-playlist-menu-item"]');
 
-    // Wait for the playlist selection dialog to appear
-    await page.waitForTimeout(500);
-
     // Select the "Test Playlist" playlist (from fixture data)
     // The fixture data has playlist-1 which is "Test Playlist"
-    await page.click('[data-testid="playlist-option-playlist-1"]');
-
-    // Wait for the operation to complete
-    await page.waitForTimeout(1500);
+    const playlistOption = page.locator(
+      '[data-testid="playlist-option-playlist-1"]',
+    );
+    await expect(playlistOption).toBeVisible();
+    await playlistOption.click();
+    await expect(playlistOption).toBeHidden();
 
     // Clear the search before navigating to playlist
-    const searchInputToClear = page.locator('input[type="search"]').first();
-    if (await searchInputToClear.isVisible()) {
-      await searchInputToClear.clear();
-      await page.waitForTimeout(500);
-    }
+    await searchInput.clear();
+    await TestHelpers.waitForTracks(page);
 
     // Re-open sidebar (it auto-closes after navigation)
     const sidebarToggle = page.locator('[data-testid="sidebar-toggle"]');
     if (await sidebarToggle.isVisible()) {
       await sidebarToggle.click();
-      await page.waitForTimeout(500);
     }
 
     // Now navigate to the playlist view to verify the track was added
     // Click on "Test Playlist" in the sidebar
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(500);
 
-    // Verify that test-large-004 is now in the playlist
-    const addedTrack = await page.locator('[data-track-id="test-large-004"]');
-    await addedTrack.waitFor({ state: 'visible', timeout: 5000 });
-
-    // Also count the tracks to verify we have 4 now (started with 3)
-    const trackRows = await page.locator('[data-track-id]').count();
-    expect(trackRows).toBe(4);
+    // Verify that test-large-004 is now in the playlist, and that the playlist
+    // grew from 3 tracks to 4.
+    await expect(
+      page.locator('[data-track-id="test-large-004"]'),
+    ).toBeVisible();
+    await TestHelpers.waitForTrackCount(page, 4);
 
     await TestHelpers.closeApp(app);
   });
@@ -120,11 +96,9 @@ test.describe('Playlist Management', () => {
 
     // Navigate to the "Test Playlist" which has 3 tracks (test-large-001, test-large-002, test-large-003)
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(500);
 
     // Verify we start with 3 tracks
-    let trackRows = await page.locator('[data-track-id]').count();
-    expect(trackRows).toBe(3);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // Right-click on test-large-001 to open context menu
     const trackRow = await page.locator('[data-track-id="test-large-001"]');
@@ -136,16 +110,9 @@ test.describe('Playlist Management', () => {
     // Wait for the ConfirmationDialog to appear and click "Remove"
     await page.getByRole('button', { name: 'Remove' }).click();
 
-    // Wait for the operation to complete
-    await page.waitForTimeout(1500);
-
-    // Verify that test-large-001 is no longer in the playlist
-    const removedTrack = await page.locator('[data-track-id="test-large-001"]');
-    await removedTrack.waitFor({ state: 'hidden', timeout: 5000 });
-
-    // Also count the tracks to verify we have 2 now (started with 3)
-    trackRows = await page.locator('[data-track-id]').count();
-    expect(trackRows).toBe(2);
+    // Verify that test-large-001 is no longer in the playlist, leaving 2
+    await expect(page.locator('[data-track-id="test-large-001"]')).toBeHidden();
+    await TestHelpers.waitForTrackCount(page, 2);
 
     await TestHelpers.closeApp(app);
   });
@@ -181,15 +148,11 @@ test.describe('Playlist Management', () => {
       timeout: 5000,
     });
 
-    // Wait for the UI to update
-    await page.waitForTimeout(1000);
-
     // Verify the playlist name was updated in the sidebar
     // Look for the playlist by its data-playlist-id and check it contains the new name
-    const renamedPlaylist = await page.locator(
-      '[data-playlist-id="playlist-1"]:has-text("Renamed Test Playlist")',
+    await expect(page.locator('[data-playlist-id="playlist-1"]')).toContainText(
+      'Renamed Test Playlist',
     );
-    await renamedPlaylist.waitFor({ state: 'visible', timeout: 5000 });
 
     await TestHelpers.closeApp(app);
   });
@@ -207,18 +170,10 @@ test.describe('Playlist Management', () => {
     // Click "Delete Playlist" in the context menu
     await page.click('[data-testid="delete-playlist-menu-item"]');
 
-    // Wait for the playlist to be removed from the UI
-    await page.waitForTimeout(1500);
-
     // Verify the playlist no longer exists in the sidebar
-    await playlistItem.waitFor({ state: 'hidden', timeout: 5000 });
-
-    // Also verify by checking that there's no element with that data-playlist-id
-    const deletedPlaylist = await page.locator(
-      '[data-playlist-id="playlist-2"]',
+    await expect(page.locator('[data-playlist-id="playlist-2"]')).toHaveCount(
+      0,
     );
-    const count = await deletedPlaylist.count();
-    expect(count).toBe(0);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/scroll-to-song.spec.ts
+++ b/e2e/scroll-to-song.spec.ts
@@ -1,50 +1,53 @@
-/* eslint-disable no-console */
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/** Sort the library by Title descending and wait for the header to report it. */
+async function sortByTitleDescending(page: Page) {
+  const titleHeader = page.locator('th').filter({ hasText: 'Title' }).first();
+  await titleHeader.click();
+  await expect(titleHeader).toHaveAttribute('aria-sort', 'ascending');
+  await titleHeader.click();
+  await expect(titleHeader).toHaveAttribute('aria-sort', 'descending');
+}
+
+/** Id of the topmost rendered row — changes whenever the virtualizer re-ranges. */
+async function firstRenderedTrackId(page: Page) {
+  return page.locator('[data-track-id]').first().getAttribute('data-track-id');
+}
 
 test.describe('Scroll to Song', () => {
   test('should scroll to correct song after navigating away and back', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to load and tracks to appear
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
-
     // 1. Change sort order to Title descending
-    // Click Title header once for ascending, then again for descending
-    const titleHeader = page.locator('th').filter({ hasText: 'Title' }).first();
-    await titleHeader.click();
-    await page.waitForTimeout(500);
-    await titleHeader.click();
-    await page.waitForTimeout(1000);
+    await sortByTitleDescending(page);
 
     // 2. Scroll down to find a track about 20 rows into the library (not at the top)
     const tableContainer = page.locator('[data-testid="vt-container"]').first();
+    const topRowBeforeScroll = await firstRenderedTrackId(page);
     await tableContainer.evaluate((c) => {
       c.scrollTop = 800; // Scroll down ~20 rows
     });
-    await page.waitForTimeout(500);
+    // The virtualizer re-renders a new row range on the next frame; waiting for
+    // the top row to change is the signal that it has.
+    await expect
+      .poll(() => firstRenderedTrackId(page))
+      .not.toBe(topRowBeforeScroll);
 
     // Get a track from the middle of the visible area and play it
     const allVisibleTracks = page.locator('[data-track-id]');
     const trackCount = await allVisibleTracks.count();
     const middleTrack = allVisibleTracks.nth(Math.floor(trackCount / 2));
     const targetTrackId = await middleTrack.getAttribute('data-track-id');
-    console.log('Playing track:', targetTrackId);
 
-    // Double-click to play the track
-    await middleTrack.dblclick();
-    await page.waitForTimeout(1500);
-
-    // Get the song title for later clicking in the player
+    // Get the song title before playing, then double-click to play the track
     const trackTitle = await middleTrack.locator('td').first().textContent();
-    console.log('Track title:', trackTitle);
+    await TestHelpers.startPlayback(page, middleTrack);
 
     // 3. Scroll far away to the end so target track is not visible
     await tableContainer.evaluate((c) => {
       c.scrollTop = c.scrollHeight;
     });
-    await page.waitForTimeout(500);
 
     // Verify track is NOT visible after scrolling
     await expect(
@@ -53,35 +56,27 @@ test.describe('Scroll to Song', () => {
 
     // 4. Navigate to playlist view
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // 5. Click on the track title in Player to scroll back to library
     // Find the song title displayed in the player (use the actual track title we captured)
     const songTitleInPlayer = page
       .getByText(trackTitle!.trim(), { exact: true })
       .last();
-    await expect(songTitleInPlayer).toBeVisible({ timeout: 5000 });
+    await expect(songTitleInPlayer).toBeVisible();
     await songTitleInPlayer.click();
 
-    // Wait for the view to change and scroll to happen
-    // The scroll function now polls until the table is ready (up to 2000ms)
-    await page.waitForTimeout(2500);
-
-    // 6. Verify the correct track is now visible (the bug causes wrong scroll position)
-    // This should pass on FIRST click - not require a second click
+    // 6. Verify the correct track is now visible (the bug causes wrong scroll
+    // position). This should pass on FIRST click - not require a second click.
     await expect(
       page.locator(`[data-track-id="${targetTrackId}"]`),
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });
 
   test('should maintain sort order after navigating away and back to library', async () => {
     const { app, page } = await TestHelpers.launchApp();
-
-    // Wait for app to load
-    await page.waitForTimeout(3000);
-    await page.waitForSelector('[data-track-id]', { timeout: 10000 });
 
     // Helper to get first few track IDs
     const getFirstTrackIds = async () => {
@@ -95,47 +90,26 @@ test.describe('Scroll to Song', () => {
     };
 
     // 1. Change sort order to Title descending
-    // Click Title header once for ascending, then again for descending
-    const titleHeader2 = page
-      .locator('th')
-      .filter({ hasText: 'Title' })
-      .first();
-    await titleHeader2.click();
-    await page.waitForTimeout(500);
-    await titleHeader2.click();
-    await page.waitForTimeout(1000);
+    await sortByTitleDescending(page);
 
     // Record the track order after sorting
     const trackOrderAfterSort = await getFirstTrackIds();
-    console.log(
-      'Track order after sorting by Title desc:',
-      trackOrderAfterSort,
-    );
 
     // 2. Navigate to playlist view
     await page.click('[data-playlist-id="playlist-1"]');
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // 3. Re-open sidebar (it auto-closes after clicking a nav item)
     const sidebarToggle = page.locator('[data-testid="sidebar-toggle"]');
     if (await sidebarToggle.isVisible()) {
       await sidebarToggle.click();
-      await page.waitForTimeout(500);
     }
 
     // Navigate back to library view
     await page.click('[data-testid="nav-library"]');
-    await page.waitForTimeout(1000);
 
     // 4. Verify the sort order is maintained
-    const trackOrderAfterReturn = await getFirstTrackIds();
-    console.log(
-      'Track order after returning to library:',
-      trackOrderAfterReturn,
-    );
-
-    // The order should be the same
-    expect(trackOrderAfterReturn).toEqual(trackOrderAfterSort);
+    await expect.poll(getFirstTrackIds).toEqual(trackOrderAfterSort);
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/search-persistence.spec.ts
+++ b/e2e/search-persistence.spec.ts
@@ -1,41 +1,40 @@
-/* eslint-disable no-await-in-loop */
 import { test, expect } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+const SEARCH_TOGGLE = '[aria-label="Show/Hide search"]';
+const SEARCH_INPUT = '[data-testid="search-input"]';
 
 test.describe('Per-View Search Persistence', () => {
   test('library search persists across view navigation', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
     // Open search in Library
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
+    await page.locator(SEARCH_TOGGLE).click();
 
     // Type a search term
-    const searchInput = page.locator('[data-testid="search-input"]');
+    const searchInput = page.locator(SEARCH_INPUT);
     await searchInput.fill('Aurora');
-    await page.waitForTimeout(500);
 
-    // Verify rows are filtered (Aurora Synth tracks should appear)
+    // The search input debounces, so wait for the filter to actually land:
+    // every rendered row must match the term.
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Aurora' }),
+    ).toHaveCount(0);
     const filteredRows = await page.locator('[data-track-id]').count();
     expect(filteredRows).toBeGreaterThan(0);
-    expect(filteredRows).toBeLessThan(200); // Should be fewer than total
 
-    // Navigate to a playlist
+    // Navigate to a playlist and back
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
-
-    // Navigate back to library
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
     await page.locator('[data-testid="nav-library"]').click();
-    await page.waitForTimeout(500);
 
     // Assert search bar is visible with "Aurora"
-    const restoredInput = page.locator('[data-testid="search-input"]');
+    const restoredInput = page.locator(SEARCH_INPUT);
     await expect(restoredInput).toBeVisible();
     await expect(restoredInput).toHaveValue('Aurora');
 
     // Assert rows are still filtered
-    const restoredRows = await page.locator('[data-track-id]').count();
-    expect(restoredRows).toBe(filteredRows);
+    await TestHelpers.waitForTrackCount(page, filteredRows);
 
     await TestHelpers.closeApp(app);
   });
@@ -46,46 +45,38 @@ test.describe('Per-View Search Persistence', () => {
     // Navigate to Test Playlist (playlist-1)
     // Tracks: "Dream of Love", "A Dream of Love", "My Dream of Love"
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTrackCount(page, 3);
 
-    // Open search and type "Dream"
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
-    const searchInput1 = page.locator('[data-testid="search-input"]');
-    await searchInput1.fill('Dream');
-    await page.waitForTimeout(500);
+    // Open search and type "My Dream" — a term that narrows the playlist to a
+    // single row, so the filtered count is a real signal that the input's
+    // 150ms debounce has fired and the term is committed to the view's state.
+    await page.locator(SEARCH_TOGGLE).click();
+    const searchInput1 = page.locator(SEARCH_INPUT);
+    await searchInput1.fill('My Dream');
+    await TestHelpers.waitForTrackCount(page, 1);
 
     // Switch to Jazz Favorites (playlist-2)
     // Tracks: "A Dream of Love", "Night of Love", "A Day of Love"
     await page.getByText('Jazz Favorites', { exact: true }).click();
-    await page.waitForTimeout(500);
 
     // Search should be hidden (Jazz Favorites had no search)
-    let jazzSearchInput = page.locator('[data-testid="search-input"]');
-    await expect(jazzSearchInput).not.toBeVisible();
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
 
     // Open search and type "Night"
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
-    jazzSearchInput = page.locator('[data-testid="search-input"]');
+    await page.locator(SEARCH_TOGGLE).click();
+    const jazzSearchInput = page.locator(SEARCH_INPUT);
     await jazzSearchInput.fill('Night');
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTrackCount(page, 1);
 
-    // Switch back to Test Playlist
+    // Switch back to Test Playlist — "My Dream" is restored
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
-
-    // Assert "Dream" is restored
-    const restoredInput1 = page.locator('[data-testid="search-input"]');
+    const restoredInput1 = page.locator(SEARCH_INPUT);
     await expect(restoredInput1).toBeVisible();
-    await expect(restoredInput1).toHaveValue('Dream');
+    await expect(restoredInput1).toHaveValue('My Dream');
 
-    // Switch back to Jazz Favorites
+    // Switch back to Jazz Favorites — "Night" is restored
     await page.getByText('Jazz Favorites', { exact: true }).click();
-    await page.waitForTimeout(500);
-
-    // Assert "Night" is restored
-    const restoredInput2 = page.locator('[data-testid="search-input"]');
+    const restoredInput2 = page.locator(SEARCH_INPUT);
     await expect(restoredInput2).toBeVisible();
     await expect(restoredInput2).toHaveValue('Night');
 
@@ -96,38 +87,36 @@ test.describe('Per-View Search Persistence', () => {
     const { app, page } = await TestHelpers.launchApp();
 
     // Set search in Library to "Aurora"
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
-    const librarySearch = page.locator('[data-testid="search-input"]');
+    await page.locator(SEARCH_TOGGLE).click();
+    const librarySearch = page.locator(SEARCH_INPUT);
     await librarySearch.fill('Aurora');
-    await page.waitForTimeout(500);
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Aurora' }),
+    ).toHaveCount(0);
 
     // Navigate to Test Playlist
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
 
     // Open search and type "Dream"
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
-    const playlistSearch = page.locator('[data-testid="search-input"]');
+    await page.locator(SEARCH_TOGGLE).click();
+    const playlistSearch = page.locator(SEARCH_INPUT);
     await playlistSearch.fill('Dream');
-    await page.waitForTimeout(500);
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Dream' }),
+    ).toHaveCount(0);
 
     // Close search in playlist (toggle off)
-    await page.locator('[aria-label="Show/Hide search"]').click();
-    await page.waitForTimeout(300);
+    await page.locator(SEARCH_TOGGLE).click();
 
     // Verify search input is hidden
-    await expect(
-      page.locator('[data-testid="search-input"]'),
-    ).not.toBeVisible();
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
 
     // Navigate back to Library
     await page.locator('[data-testid="nav-library"]').click();
-    await page.waitForTimeout(500);
 
     // Assert "Aurora" is still active in Library
-    const restoredLibrarySearch = page.locator('[data-testid="search-input"]');
+    const restoredLibrarySearch = page.locator(SEARCH_INPUT);
     await expect(restoredLibrarySearch).toBeVisible();
     await expect(restoredLibrarySearch).toHaveValue('Aurora');
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -57,8 +57,7 @@ test.describe('Settings', () => {
 
     // Flip OFF and verify it persists in settings IPC.
     await toggle.click();
-    await page.waitForTimeout(300);
-    expect(await toggle.isChecked()).toBe(false);
+    await expect(toggle).not.toBeChecked();
 
     const persistedAfterOff = await page.evaluate(() =>
       (window as any).electron.settings
@@ -69,8 +68,7 @@ test.describe('Settings', () => {
 
     // Flip back ON.
     await toggle.click();
-    await page.waitForTimeout(300);
-    expect(await toggle.isChecked()).toBe(true);
+    await expect(toggle).toBeChecked();
 
     const persistedAfterOn = await page.evaluate(() =>
       (window as any).electron.settings
@@ -99,11 +97,14 @@ test.describe('Settings', () => {
 
     // Click the theme toggle
     await themeToggle.click();
-    await page.waitForTimeout(500);
 
     // Verify the theme has changed
+    if (initialThemeIsDark) {
+      await expect(themeToggle).not.toBeChecked();
+    } else {
+      await expect(themeToggle).toBeChecked();
+    }
     const newThemeIsDark = await themeToggle.isChecked();
-    expect(newThemeIsDark).not.toBe(initialThemeIsDark);
 
     // Verify the theme persisted in the store
     const themeInStore = await page.evaluate(() => {

--- a/e2e/sidebar-auto-close.spec.ts
+++ b/e2e/sidebar-auto-close.spec.ts
@@ -5,20 +5,15 @@ test.describe('Sidebar Persistence', () => {
   test('should keep sidebar open when clicking navigation items', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
-    // Helper function to check if sidebar is visible
-    const isSidebarOpen = async () => {
-      return page.locator('[data-testid="nav-library"]').isVisible();
-    };
+    // The library nav row only exists while the sidebar is open, so its
+    // visibility is the sidebar's open/closed state.
+    const sidebar = page.locator('[data-testid="nav-library"]');
 
     // 1. Verify sidebar is initially open
-    expect(await isSidebarOpen()).toBe(true);
+    await expect(sidebar).toBeVisible();
 
     // 2. Click on a playlist - sidebar should stay open
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
 
     // Verify we're in playlist view. The in-header `h2` title is intentionally
     // hidden while the sidebar is open (the selected sidebar row already names
@@ -30,28 +25,24 @@ test.describe('Sidebar Persistence', () => {
     await expect(selectedPlaylistRow).toHaveClass(/Mui-selected/);
 
     // Verify sidebar is still open
-    expect(await isSidebarOpen()).toBe(true);
+    await expect(sidebar).toBeVisible();
 
     // 3. Click "All" (Library) - sidebar should stay open
-    await page.locator('[data-testid="nav-library"]').click();
-    await page.waitForTimeout(500);
+    await sidebar.click();
 
     // Verify we're in library view (tracks visible)
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBeGreaterThan(0);
+    await expect(page.locator('[data-track-id]').first()).toBeVisible();
 
     // Verify sidebar is still open
-    expect(await isSidebarOpen()).toBe(true);
+    await expect(sidebar).toBeVisible();
 
     // 4. Explicit toggle closes sidebar
     await page.locator('[data-testid="sidebar-toggle-close"]').click();
-    await page.waitForTimeout(500);
-    expect(await isSidebarOpen()).toBe(false);
+    await expect(sidebar).toBeHidden();
 
     // 5. Toggle reopens sidebar
     await page.locator('[data-testid="sidebar-toggle"]').click();
-    await page.waitForTimeout(500);
-    expect(await isSidebarOpen()).toBe(true);
+    await expect(sidebar).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/sort-artist-by-album-artist.spec.ts
+++ b/e2e/sort-artist-by-album-artist.spec.ts
@@ -72,11 +72,14 @@ test.describe('Artist column — sort by album artist (toggle on)', () => {
       timeout: 5000,
     });
     await page.fill('[data-testid="search-input"]', 'Hip Hop Legends');
-    await page.waitForTimeout(500);
+    // Every rendered row matching the term means the debounced filter landed.
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Hip Hop Legends' }),
+    ).toHaveCount(0);
 
     const artistHeader = page.locator('th:has-text("Artist")').first();
     await artistHeader.click();
-    await page.waitForTimeout(500);
+    await expect(artistHeader).toHaveAttribute('aria-sort', 'ascending');
 
     const sortInfo = await getActiveSort(page);
     expect(sortInfo).not.toBeNull();
@@ -128,11 +131,14 @@ test.describe('Artist column — sort by raw artist (toggle off)', () => {
       timeout: 5000,
     });
     await page.fill('[data-testid="search-input"]', 'Hip Hop Legends');
-    await page.waitForTimeout(500);
+    // Every rendered row matching the term means the debounced filter landed.
+    await expect(
+      page.locator('[data-track-id]').filter({ hasNotText: 'Hip Hop Legends' }),
+    ).toHaveCount(0);
 
     const artistHeader = page.locator('th:has-text("Artist")').first();
     await artistHeader.click();
-    await page.waitForTimeout(500);
+    await expect(artistHeader).toHaveAttribute('aria-sort', 'ascending');
 
     let sortInfo = await getActiveSort(page);
     expect(sortInfo).not.toBeNull();
@@ -145,7 +151,7 @@ test.describe('Artist column — sort by raw artist (toggle off)', () => {
     // → useUpdateSettings mutation → settings:update IPC → DB write → query
     // cache update → column-defs + sorting-reference re-mint → table re-sort.
     await page.click('[data-testid="nav-settings"]');
-    await page.waitForTimeout(500);
+    await page.waitForSelector('[data-testid="settings-view"]');
 
     const toggle = page.locator(
       '[data-testid="sort-artist-by-album-artist-toggle"]',
@@ -153,8 +159,7 @@ test.describe('Artist column — sort by raw artist (toggle off)', () => {
     await expect(toggle).toBeVisible();
     expect(await toggle.isChecked()).toBe(true);
     await toggle.click();
-    await page.waitForTimeout(300);
-    expect(await toggle.isChecked()).toBe(false);
+    await expect(toggle).not.toBeChecked();
 
     // Confirm the value made it through IPC, not just the local switch state.
     const persistedAfterOff = await page.evaluate(() =>
@@ -170,8 +175,21 @@ test.describe('Artist column — sort by raw artist (toggle off)', () => {
     // intercepts pointer events for everything underneath. Press Escape to
     // dismiss it; sorting state is preserved (we never touched it).
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(500);
     await page.waitForSelector('.vt-table', { timeout: 10000 });
+
+    // The comparator swap propagates through the settings query; poll the
+    // rendered order until the raw-artist grouping lands rather than sleeping.
+    await expect
+      .poll(async () => {
+        const ids = await getRenderedTrackIds(page);
+        const at = (id: string) => ids.indexOf(id);
+        if (ALL_PLAIN_HHL.some((id) => at(id) < 0)) return false;
+        if (ALL_FEAT.some((id) => at(id) < 0)) return false;
+        return (
+          Math.max(...ALL_PLAIN_HHL.map(at)) < Math.min(...ALL_FEAT.map(at))
+        );
+      })
+      .toBe(true);
 
     // Header still says ascending Artist — sorting state never changed,
     // only the comparator behind it. If the table failed to re-sort, the

--- a/e2e/sorting-persistence.spec.ts
+++ b/e2e/sorting-persistence.spec.ts
@@ -93,6 +93,27 @@ async function getActiveSortColumn(
   });
 }
 
+/**
+ * Assert which column currently owns the sort indicator, retrying until the
+ * table commits. Every view transition in these tests moves the indicator to a
+ * different column, so polling on it doubles as the "the new view rendered"
+ * signal — no fixed delays needed.
+ */
+async function expectActiveSort(
+  page: Awaited<ReturnType<ElectronApplication['firstWindow']>>,
+  column: string,
+  direction?: 'ascending' | 'descending',
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const info = await getActiveSortColumn(page);
+      return info ? `${info.column}|${info.direction}` : 'none';
+    })
+    .toMatch(
+      new RegExp(`${column}.*\\|${direction ?? '(ascending|descending)'}`),
+    );
+}
+
 test.describe('Sorting Persistence', () => {
   test('in-session sorting persists across playlist navigation', async () => {
     const { app, page } = await TestHelpers.launchApp();
@@ -103,79 +124,57 @@ test.describe('Sorting Persistence', () => {
     // Click "Album" column header to sort library by album
     const albumHeader = page.locator('th:has-text("Album")').first();
     await albumHeader.click();
-    await page.waitForTimeout(500);
 
     // Verify sort indicator is on Album column
-    let sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Album');
+    await expectActiveSort(page, 'Album');
 
     // Navigate to "Test Playlist" in sidebar
     const testPlaylist = page.locator('text=Test Playlist').first();
     await testPlaylist.click();
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // Click "Title" column header in playlist view
     const titleHeader = page.locator('th:has-text("Title")').first();
     await titleHeader.click();
-    await page.waitForTimeout(500);
 
     // Verify sort indicator is on Title column
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Title');
+    await expectActiveSort(page, 'Title');
 
     // Navigate back to library ("All" in sidebar)
     const allNav = page.locator('[data-testid="nav-library"]');
     await allNav.click();
-    await page.waitForTimeout(1000);
 
     // Assert: Album column still has sort indicator
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Album');
+    await expectActiveSort(page, 'Album');
 
     // Navigate back to "Test Playlist"
     await testPlaylist.click();
-    await page.waitForTimeout(1000);
 
     // Assert: Title column still has sort indicator
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Title');
+    await expectActiveSort(page, 'Title');
 
     // Navigate to "Jazz Favorites"
     const jazzPlaylist = page.locator('text=Jazz Favorites').first();
     await jazzPlaylist.click();
-    await page.waitForTimeout(1000);
 
     // Click "Genre" column header
     const genreHeader = page.locator('th:has-text("Genre")').first();
     await genreHeader.click();
-    await page.waitForTimeout(500);
 
     // Verify sort indicator is on Genre column
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Genre');
+    await expectActiveSort(page, 'Genre');
 
     // Navigate back to "Test Playlist"
     await testPlaylist.click();
-    await page.waitForTimeout(1000);
 
     // Assert: Title column still has sort indicator (not Genre)
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Title');
+    await expectActiveSort(page, 'Title');
 
     // Navigate back to "Jazz Favorites"
     await jazzPlaylist.click();
-    await page.waitForTimeout(1000);
 
     // Assert: Genre column still has sort indicator
-    sortInfo = await getActiveSortColumn(page);
-    expect(sortInfo).not.toBeNull();
-    expect(sortInfo!.column).toContain('Genre');
+    await expectActiveSort(page, 'Genre');
 
     await TestHelpers.closeApp(app);
   });
@@ -224,27 +223,20 @@ test.describe('Sorting Persistence', () => {
 
     const page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(3000);
 
     // Wait for the library table to render
-    await page.waitForSelector('.vt-table', { timeout: 10000 });
+    await page.waitForSelector('.vt-table', { timeout: 20000 });
 
     // Assert: Album column has descending sort indicator
-    const librarySortInfo = await getActiveSortColumn(page);
-    expect(librarySortInfo).not.toBeNull();
-    expect(librarySortInfo!.column).toContain('Album');
-    expect(librarySortInfo!.direction).toBe('descending');
+    await expectActiveSort(page, 'Album', 'descending');
 
     // Navigate to "Test Playlist"
     const testPlaylist = page.locator('text=Test Playlist').first();
     await testPlaylist.click();
-    await page.waitForTimeout(1000);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // Assert: Title column has ascending sort indicator
-    const playlistSortInfo = await getActiveSortColumn(page);
-    expect(playlistSortInfo).not.toBeNull();
-    expect(playlistSortInfo!.column).toContain('Title');
-    expect(playlistSortInfo!.direction).toBe('ascending');
+    await expectActiveSort(page, 'Title', 'ascending');
 
     await TestHelpers.closeApp(app);
   });

--- a/e2e/stale-track-cleanup.spec.ts
+++ b/e2e/stale-track-cleanup.spec.ts
@@ -73,7 +73,10 @@ test.describe('Stale Track Cleanup on Rescan', () => {
 
     page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(2000);
+    // Empty-library CTA is the readiness signal for a brand new database.
+    await page.waitForSelector('text=Your library is empty', {
+      timeout: 20000,
+    });
   });
 
   test.afterAll(async () => {

--- a/e2e/track-context-menu.spec.ts
+++ b/e2e/track-context-menu.spec.ts
@@ -5,22 +5,13 @@ test.describe('Track Context Menu', () => {
   test('should display context menu with all options when right-clicking a track in library view', async () => {
     const { app, page } = await TestHelpers.launchApp();
 
-    // Wait for app to fully load
-    await page.waitForTimeout(3000);
-
     // Ensure we're in library view
     await page.click('[data-testid="nav-library"]');
-    await page.waitForTimeout(500);
-
-    // Wait for tracks to be visible
-    await page.waitForSelector('[data-track-id]', { timeout: 5000 });
+    await TestHelpers.waitForTracks(page);
 
     // Right-click on the first track to open the context menu
     const firstTrack = page.locator('[data-track-id]').first();
     await firstTrack.click({ button: 'right' });
-
-    // Wait for the context menu to appear
-    await page.waitForTimeout(500);
 
     // Verify the context menu is visible (MUI Menu uses role="menu")
     const contextMenu = page.locator('[role="menu"]');

--- a/e2e/ui-visual-verification.spec.ts
+++ b/e2e/ui-visual-verification.spec.ts
@@ -1,23 +1,53 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, ElectronApplication, Page } from '@playwright/test';
 import { TestHelpers } from './helpers/test-helpers';
+
+/**
+ * Resize the Electron window and wait until the renderer has actually laid out
+ * at the new size. Comparing `window.innerWidth` against the main process's
+ * content size is exact and survives clamping to the window's min size, so
+ * there is nothing to sleep for before screenshotting.
+ */
+async function resizeWindow(
+  app: ElectronApplication,
+  page: Page,
+  width: number,
+  height: number,
+) {
+  await app.evaluate(
+    ({ BrowserWindow }, size) => {
+      BrowserWindow.getAllWindows()[0].setSize(size.width, size.height);
+    },
+    { width, height },
+  );
+
+  await expect
+    .poll(async () => {
+      const [contentWidth, contentHeight] = await app.evaluate(
+        ({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows()[0].getContentSize(),
+      );
+      const inner = await page.evaluate(() => [
+        window.innerWidth,
+        window.innerHeight,
+      ]);
+      return inner[0] === contentWidth && inner[1] === contentHeight;
+    })
+    .toBe(true);
+}
+
+const SEARCH_TOGGLE = '[aria-label="Show/Hide search"]';
+const SEARCH_INPUT = '[data-testid="search-input"]';
 
 test.describe('UI Visual Verification', () => {
   test('full size (1280x800) - library with sidebar open', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
     // Set window to full size
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 800);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 1280, 800);
 
     // Verify sidebar is open and library is visible
-    expect(await page.locator('[data-testid="nav-library"]').isVisible()).toBe(
-      true,
-    );
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBeGreaterThan(0);
+    await expect(page.locator('[data-testid="nav-library"]')).toBeVisible();
+    await expect(page.locator('[data-track-id]').first()).toBeVisible();
 
     await TestHelpers.takeScreenshot(page, 'ui-full-1280x800-library');
 
@@ -26,23 +56,16 @@ test.describe('UI Visual Verification', () => {
 
   test('medium size (900x600) - sidebar open, toolbar check', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(900, 600);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 900, 600);
 
     // Sidebar should be open
-    expect(await page.locator('[data-testid="nav-library"]').isVisible()).toBe(
-      true,
-    );
+    await expect(page.locator('[data-testid="nav-library"]')).toBeVisible();
 
     // Toolbar should be visible and not overflowing
     const toolbar = page.locator('.MuiToolbar-root, [class*="TopToolbar"]');
     if ((await toolbar.count()) > 0) {
-      const firstToolbar = toolbar.first();
-      await expect(firstToolbar).toBeVisible();
+      await expect(toolbar.first()).toBeVisible();
     }
 
     await TestHelpers.takeScreenshot(page, 'ui-medium-900x600-library');
@@ -52,50 +75,38 @@ test.describe('UI Visual Verification', () => {
 
   test('minimum size (640x400) - sidebar open and closed', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(640, 400);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 640, 400);
 
     // Screenshot with sidebar open at minimum size
     await TestHelpers.takeScreenshot(page, 'ui-min-640x400-sidebar-open');
 
     // Close sidebar
     await page.locator('[data-testid="sidebar-toggle-close"]').click();
-    await page.waitForTimeout(500);
+    await expect(page.locator('[data-testid="nav-library"]')).toBeHidden();
 
     // Screenshot with sidebar closed at minimum size
     await TestHelpers.takeScreenshot(page, 'ui-min-640x400-sidebar-closed');
 
     // Verify tracks are still visible
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBeGreaterThan(0);
+    await expect(page.locator('[data-track-id]').first()).toBeVisible();
 
     await TestHelpers.closeApp(app);
   });
 
   test('settings slide-over panel', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 800);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 1280, 800);
 
     // Open settings via the gear button
     await page.locator('[data-testid="nav-settings"]').click();
-    await page.waitForTimeout(500);
 
     // Verify settings panel is visible
-    const settingsView = page.locator('[data-testid="settings-view"]');
-    await expect(settingsView).toBeVisible();
+    await expect(page.locator('[data-testid="settings-view"]')).toBeVisible();
 
     // Verify Settings heading
-    const settingsHeader = page.getByRole('heading', { name: 'Settings' });
-    await expect(settingsHeader).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
 
     await TestHelpers.takeScreenshot(page, 'ui-settings-slideover');
 
@@ -104,42 +115,32 @@ test.describe('UI Visual Verification', () => {
 
   test('search bar toggle - open, type, and close', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 800);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 1280, 800);
 
     // Screenshot before opening search
     await TestHelpers.takeScreenshot(page, 'ui-search-1-before-open');
 
     // Click the search toggle button
-    const searchToggle = page.locator('[aria-label="Show/Hide search"]');
-    await expect(searchToggle).toBeVisible({ timeout: 5000 });
+    const searchToggle = page.locator(SEARCH_TOGGLE);
+    await expect(searchToggle).toBeVisible();
     await searchToggle.click();
-    await page.waitForTimeout(500);
+    await expect(page.locator(SEARCH_INPUT)).toBeVisible();
 
     // Screenshot with search bar open (empty)
     await TestHelpers.takeScreenshot(page, 'ui-search-2-open-empty');
 
     // Type into the search field
-    const searchInput = page
-      .locator(
-        'input[type="search"], input[placeholder*="Filter"], input[placeholder*="Search"]',
-      )
-      .first();
-    if (await searchInput.isVisible()) {
-      await searchInput.fill('Test');
-      await page.waitForTimeout(500);
-    }
+    const searchInput = page.locator(SEARCH_INPUT);
+    await searchInput.fill('Test');
+    await expect(searchInput).toHaveValue('Test');
 
     // Screenshot with search bar open and text typed
     await TestHelpers.takeScreenshot(page, 'ui-search-3-open-with-text');
 
     // Close search by clicking the toggle button again
     await searchToggle.click();
-    await page.waitForTimeout(500);
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
 
     // Screenshot after closing search - check for doubling/whitespace
     await TestHelpers.takeScreenshot(page, 'ui-search-4-after-close');
@@ -149,31 +150,24 @@ test.describe('UI Visual Verification', () => {
 
   test('search bar at minimum size (640x400)', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(640, 400);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 640, 400);
 
     // Screenshot before opening search at small size
     await TestHelpers.takeScreenshot(page, 'ui-search-min-1-before');
 
     // Click the search toggle button
-    const searchToggle = page.locator('[aria-label="Show/Hide search"]');
-    if (await searchToggle.isVisible()) {
-      await searchToggle.click();
-      await page.waitForTimeout(500);
-    }
+    const searchToggle = page.locator(SEARCH_TOGGLE);
+    await expect(searchToggle).toBeVisible();
+    await searchToggle.click();
+    await expect(page.locator(SEARCH_INPUT)).toBeVisible();
 
     // Screenshot with search bar open at small size
     await TestHelpers.takeScreenshot(page, 'ui-search-min-2-open');
 
     // Close search
-    if (await searchToggle.isVisible()) {
-      await searchToggle.click();
-      await page.waitForTimeout(500);
-    }
+    await searchToggle.click();
+    await expect(page.locator(SEARCH_INPUT)).toBeHidden();
 
     // Screenshot after closing search at small size
     await TestHelpers.takeScreenshot(page, 'ui-search-min-3-after-close');
@@ -183,16 +177,13 @@ test.describe('UI Visual Verification', () => {
 
   test('compact layout - row density verification', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 800);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 1280, 800);
 
     // Verify that rows are visible (Apple Music-matched 22px rows)
-    const trackCount = await page.locator('[data-track-id]').count();
-    expect(trackCount).toBeGreaterThanOrEqual(20);
+    await expect
+      .poll(() => page.locator('[data-track-id]').count())
+      .toBeGreaterThanOrEqual(20);
 
     await TestHelpers.takeScreenshot(page, 'ui-compact-row-density');
 
@@ -201,21 +192,14 @@ test.describe('UI Visual Verification', () => {
 
   test('compact layout - sidebar density verification', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
-    await app.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 800);
-    });
-    await page.waitForTimeout(500);
+    await resizeWindow(app, page, 1280, 800);
 
     // Verify sidebar is visible
-    expect(await page.locator('[data-testid="nav-library"]').isVisible()).toBe(
-      true,
-    );
+    await expect(page.locator('[data-testid="nav-library"]')).toBeVisible();
 
     // Verify playlist items are present in sidebar
-    const playlistCount = await page.locator('[data-playlist-id]').count();
-    expect(playlistCount).toBeGreaterThan(0);
+    await expect(page.locator('[data-playlist-id]').first()).toBeVisible();
 
     await TestHelpers.takeScreenshot(page, 'ui-compact-sidebar-density');
 
@@ -224,21 +208,17 @@ test.describe('UI Visual Verification', () => {
 
   test('playlist view with unified toolbar', async () => {
     const { app, page } = await TestHelpers.launchApp();
-    await page.waitForTimeout(3000);
 
     // Click on a playlist
     await page.getByText('Test Playlist', { exact: true }).click();
-    await page.waitForTimeout(500);
+    await TestHelpers.waitForTrackCount(page, 3);
 
     // Verify sidebar stayed open (Phase 1)
-    expect(await page.locator('[data-testid="nav-library"]').isVisible()).toBe(
-      true,
-    );
+    await expect(page.locator('[data-testid="nav-library"]')).toBeVisible();
 
     // Title is hidden when sidebar is open (matches SidebarToggle pattern).
     // Close sidebar so the playlist name becomes visible for this assertion.
     await page.locator('[data-testid="sidebar-toggle-close"]').click();
-    await page.waitForTimeout(500);
 
     const playlistHeading = page.locator('h2');
     await expect(playlistHeading).toContainText('Test Playlist');


### PR DESCRIPTION
Closes #144.

## The problem

The e2e suite spent **594.6 seconds across 397 `page.waitForTimeout()` calls** waiting for state it could have observed directly. Every test paid a 3s sleep after launch, and several paid 12–30s sleeps waiting for playback, scans or window resizes to settle. Those sleeps are simultaneously too slow (they always pay full price) and too flaky (a loaded CI runner can exceed them).

## The fix

Each sleep was replaced with a wait on the signal the app itself emits.

**Launch** — `TestHelpers.launchApp` now waits for the first `[data-track-id]` row, which lands in ~0.9s instead of a flat 3s. The brand-new-user and migration launchers wait for the empty-state CTA and the migration dialog respectively.

**Shared helpers** for the patterns that repeated across dozens of tests: `waitForTracks`, `waitForTrackCount`, `startPlayback`, `waitForPlaying` / `waitForPaused`, `waitForNowPlaying` / `waitForNowPlayingChange`, `waitForElapsedAtLeast`.

**Playback** — transitions assert on the `vt-row-playing` row class, the transport icon and the now-playing title. State flips in under 100ms, so `dblclick` + `waitForTimeout(1000)` was paying 10× what it needed.

**Long waits that looked semantic** now poll the real completion signal:
- auto-advance → Gapless-5's own queue state via the `__hihat_e2e_getPlayerState` hook
- library rescan → the `library:scanComplete` notification (this one had a 30s fallback sleep; the test now runs in 2.2s)
- play-count threshold → the rendered play-count cell
- repeat-track → the elapsed clock wrapping back to 0:00

**Layout** — window resizes wait until `window.innerWidth` matches the main process's content size (robust to min-size clamping); virtualizer scroll bursts step on `requestAnimationFrame` and resolve when the burst is done.

**Search** — debounced filters wait for the filtered row set to land rather than guessing at the 150ms debounce.

## Assertions that were passing vacuously

Several tests asserted `expect(await page.content()).toContain(trackTitle)` after a skip — but the track table renders that title regardless of what's playing, so the assertion could not fail. Those now assert against the scoped `now-playing-title` element or the playing row's class. One of them (`playback-autoplay`) turned out to be checking a hardcoded title that was no longer the first row under the default sort.

## One sleep kept on purpose

`browser-type-ahead.spec.ts` outwaits the 600ms type-ahead buffer with 800ms. That delay *is* the feature under test, and it's now commented as such.

## Results

| | before | after |
|---|---|---|
| `waitForTimeout` calls | 397 | 1 (intentional) |
| hardcoded sleep time | 594.6s | 0.8s |
| **CI `Run E2E tests` step** (macOS runner) | **21m 29s** | **7m 01s** |
| full suite, local | did not finish inside a 10 min window | 4.2 min |

The CI baseline is the `Run E2E tests` step from the four most recent green PR Check runs on the old suite: 21m29s, 20m49s, 20m21s, 21m00s. This branch's run: **7m 01s** — roughly 3× faster, ~14 minutes back on every PR.

134 passed, 1 skipped (`debug.spec.ts`, already `test.skip`). No test consumed a retry, despite CI running with `retries: 2` — the waits are gated on real state, so there is nothing left to race. `npm run lint`, `npm run typecheck` and the 191 unit tests are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
